### PR TITLE
Multisample anti-aliasing

### DIFF
--- a/Frameworks/MetalPetal/Filters/MTIMultilayerCompositingFilter.h
+++ b/Frameworks/MetalPetal/Filters/MTIMultilayerCompositingFilter.h
@@ -18,6 +18,8 @@ __attribute__((objc_subclassing_restricted))
 
 @property (nonatomic, copy) NSArray<MTILayer *> *layers;
 
+@property (nonatomic) NSUInteger rasterSampleCount;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Frameworks/MetalPetal/Filters/MTIMultilayerCompositingFilter.m
+++ b/Frameworks/MetalPetal/Filters/MTIMultilayerCompositingFilter.m
@@ -22,6 +22,13 @@
     return kernel;
 }
 
+- (instancetype)init {
+    if (self = [super init]) {
+        _rasterSampleCount = 1;
+    }
+    return self;
+}
+
 - (MTIImage *)outputImage {
     if (!_inputBackgroundImage) {
         return nil;
@@ -31,6 +38,7 @@
     }
     return [self.class.kernel applyToBackgroundImage:_inputBackgroundImage
                                               layers:_layers
+                                   rasterSampleCount:_rasterSampleCount
                              outputTextureDimensions:MTITextureDimensionsMake2DFromCGSize(_inputBackgroundImage.size)
                                    outputPixelFormat:_outputPixelFormat];
 }

--- a/Frameworks/MetalPetal/Filters/MTITransformFilter.h
+++ b/Frameworks/MetalPetal/Filters/MTITransformFilter.h
@@ -43,6 +43,8 @@ __attribute__((objc_subclassing_restricted))
 
 @property (nonatomic, readonly) MTITransformFilterViewport defaultViewport;
 
+@property (nonatomic) NSUInteger rasterSampleCount;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Frameworks/MetalPetal/Filters/MTITransformFilter.m
+++ b/Frameworks/MetalPetal/Filters/MTITransformFilter.m
@@ -41,6 +41,7 @@ static simd_float4x4 transformMatrix(CGSize imageSize, CGRect viewport, float fi
 
 - (instancetype)init {
     if (self = [super init]) {
+        _rasterSampleCount = 1;
         _transform = CATransform3DIdentity;
         _fieldOfView = 0.0;
     }
@@ -127,6 +128,7 @@ static simd_float4x4 transformMatrix(CGSize imageSize, CGRect viewport, float fi
     MTIRenderPassOutputDescriptor *outputDescriptor = [[MTIRenderPassOutputDescriptor alloc] initWithDimensions:MTITextureDimensionsMake2DFromCGSize(viewport.size) pixelFormat:self.outputPixelFormat loadAction:MTLLoadActionClear];
     MTIRenderCommand *command = [[MTIRenderCommand alloc] initWithKernel:MTIRenderPipelineKernel.passthroughRenderPipelineKernel geometry:geomerty images:@[self.inputImage] parameters:@{}];
     return [MTIRenderCommand imagesByPerformingRenderCommands:@[command]
+                                            rasterSampleCount:_rasterSampleCount
                                             outputDescriptors:@[outputDescriptor]].firstObject;
 }
 

--- a/Frameworks/MetalPetal/Filters/MultilayerCompositingFilter.swift
+++ b/Frameworks/MetalPetal/Filters/MultilayerCompositingFilter.swift
@@ -125,6 +125,15 @@ public class MultilayerCompositingFilter: MTIFilter {
         }
     }
     
+    public var rasterSampleCount: Int {
+        set {
+            internalFilter.rasterSampleCount = UInt(newValue)
+        }
+        get {
+            return Int(internalFilter.rasterSampleCount)
+        }
+    }
+    
     private var internalFilter = MTIMultilayerCompositingFilter()
     
     public init() {

--- a/Frameworks/MetalPetal/Kernels/MTIMultilayerCompositeKernel.h
+++ b/Frameworks/MetalPetal/Kernels/MTIMultilayerCompositeKernel.h
@@ -18,6 +18,7 @@ __attribute__((objc_subclassing_restricted))
 
 - (MTIImage *)applyToBackgroundImage:(MTIImage *)image
                               layers:(NSArray<MTILayer *> *)layers
+                   rasterSampleCount:(NSUInteger)rasterSampleCount
              outputTextureDimensions:(MTITextureDimensions)outputTextureDimensions
                    outputPixelFormat:(MTLPixelFormat)outputPixelFormat;
 

--- a/Frameworks/MetalPetal/Kernels/MTIMultilayerCompositeKernel.m
+++ b/Frameworks/MetalPetal/Kernels/MTIMultilayerCompositeKernel.m
@@ -516,7 +516,6 @@ __attribute__((objc_subclassing_restricted))
         tempTextureDescriptor.textureType = MTLTextureType2DMultisample;
         tempTextureDescriptor.usage = MTLTextureUsageRenderTarget;
         tempTextureDescriptor.sampleCount = _rasterSampleCount;
-        NSError *error = nil;
         MTIImagePromiseRenderTarget *msaaTarget = [renderingContext.context newRenderTargetWithResuableTextureDescriptor:[tempTextureDescriptor newMTITextureDescriptor] error:&error];
         if (error) {
             if (inOutError) {

--- a/Frameworks/MetalPetal/Kernels/MTIRenderPipelineKernel.h
+++ b/Frameworks/MetalPetal/Kernels/MTIRenderPipelineKernel.h
@@ -28,6 +28,8 @@ __attribute__((objc_subclassing_restricted))
 
 @property (nonatomic, readonly) MTLPixelFormat stencilAttachmentPixelFormat;
 
+@property (nonatomic, readonly) NSUInteger rasterSampleCount;
+
 - (instancetype)init NS_UNAVAILABLE;
 
 + (instancetype)new NS_UNAVAILABLE;
@@ -36,7 +38,7 @@ __attribute__((objc_subclassing_restricted))
 
 - (instancetype)initWithColorAttachmentPixelFormat:(MTLPixelFormat)colorAttachmentPixelFormat;
 
-- (instancetype)initWithColorAttachmentPixelFormats:(MTLPixelFormat[_Nonnull])colorAttachmentPixelFormats count:(NSUInteger)count depthAttachmentPixelFormat:(MTLPixelFormat)depthAttachmentPixelFormat stencilAttachmentPixelFormat:(MTLPixelFormat)stencilAttachmentPixelFormat NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithColorAttachmentPixelFormats:(MTLPixelFormat[_Nonnull])colorAttachmentPixelFormats count:(NSUInteger)count depthAttachmentPixelFormat:(MTLPixelFormat)depthAttachmentPixelFormat stencilAttachmentPixelFormat:(MTLPixelFormat)stencilAttachmentPixelFormat rasterSampleCount:(NSUInteger)rasterSampleCount NS_DESIGNATED_INITIALIZER;
 
 @end
 
@@ -90,6 +92,11 @@ __attribute__((objc_subclassing_restricted))
 @interface MTIRenderCommand (ImageCreation)
 
 + (NSArray<MTIImage *> *)imagesByPerformingRenderCommands:(NSArray<MTIRenderCommand *> *)renderCommands
+                                        outputDescriptors:(NSArray<MTIRenderPassOutputDescriptor *> *)outputDescriptors;
+
+
++ (NSArray<MTIImage *> *)imagesByPerformingRenderCommands:(NSArray<MTIRenderCommand *> *)renderCommands
+                                        rasterSampleCount:(NSUInteger)rasterSampleCount
                                         outputDescriptors:(NSArray<MTIRenderPassOutputDescriptor *> *)outputDescriptors;
 
 @end

--- a/Tests/MetalPetalTests/MetalPetalTests.swift
+++ b/Tests/MetalPetalTests/MetalPetalTests.swift
@@ -174,7 +174,9 @@ final class ImageLoadingTests: XCTestCase {
         PixelEnumerator.enumeratePixels(in: linearImage) { (pixel, coordinates) in
             if coordinates.x == 0 && coordinates.y == 0 {
                 let c = 128.0/255.0
-                let linearValue = UInt8((c <= 0.04045) ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4) * 255.0)
+                
+                // Should we use `round` here? https://developer.apple.com/documentation/metal/mtlrenderpipelinestate/3608177-texturewriteroundingmode
+                let linearValue = UInt8(round((c <= 0.04045) ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4) * 255.0))
                 XCTAssert(pixel.r == linearValue && pixel.g == linearValue && pixel.b == linearValue && pixel.a == 255)
             }
         }
@@ -756,6 +758,8 @@ final class RenderTests: XCTestCase {
                         p += 1.0/4.0
                     }
                 }
+                
+                //Should we use `round` here? https://developer.apple.com/documentation/metal/mtlrenderpipelinestate/3608177-texturewriteroundingmode
                 let value = UInt8(round(p * 255))
                 XCTAssert(pixel.r == value && pixel.g == value && pixel.b == value && pixel.a == 255)
             }
@@ -802,6 +806,8 @@ final class RenderTests: XCTestCase {
                         p += 1.0/4.0
                     }
                 }
+                
+                //Should we use `round` here? https://developer.apple.com/documentation/metal/mtlrenderpipelinestate/3608177-texturewriteroundingmode
                 let value = UInt8(round(p * 255))
                 XCTAssert(pixel.r == value && pixel.g == value && pixel.b == value && pixel.a == 255)
             }


### PR DESCRIPTION
This PR adds MSAA support for `MTIMultilayerCompositingFilter` and render passes issued with `MTIRenderCommand.images(byPerforming renderCommands:....)`

- [x] MSAA for `MTIMultilayerCompositingFilter`
- [x] MSAA for `MTIRenderCommand`
- [x] Add tests