### PR TITLE
Patch 1.11.1

### DIFF
--- a/Frameworks/MetalPetal/Kernels/MTIMultilayerCompositeKernel.m
+++ b/Frameworks/MetalPetal/Kernels/MTIMultilayerCompositeKernel.m
@@ -124,7 +124,11 @@ __attribute__((objc_subclassing_restricted))
     renderPipelineDescriptor.depthAttachmentPixelFormat = MTLPixelFormatInvalid;
     renderPipelineDescriptor.stencilAttachmentPixelFormat = MTLPixelFormatInvalid;
     
-    renderPipelineDescriptor.rasterSampleCount = rasterSampleCount;
+    if (@available(iOS 11.0, macOS 10.13, *)) {
+        renderPipelineDescriptor.rasterSampleCount = rasterSampleCount;
+    } else {
+        renderPipelineDescriptor.sampleCount = rasterSampleCount;
+    }
 
     return [context renderPipelineWithDescriptor:renderPipelineDescriptor error:inOutError];
 }
@@ -200,7 +204,11 @@ __attribute__((objc_subclassing_restricted))
             renderPipelineDescriptor.depthAttachmentPixelFormat = MTLPixelFormatInvalid;
             renderPipelineDescriptor.stencilAttachmentPixelFormat = MTLPixelFormatInvalid;
             
-            renderPipelineDescriptor.rasterSampleCount = rasterSampleCount;
+            if (@available(iOS 11.0, macOS 10.13, *)) {
+                renderPipelineDescriptor.rasterSampleCount = rasterSampleCount;
+            } else {
+                renderPipelineDescriptor.sampleCount = rasterSampleCount;
+            }
             
             MTIRenderPipeline *pipeline = [context renderPipelineWithDescriptor:renderPipelineDescriptor error:&error];
             if (error) {

--- a/Frameworks/MetalPetal/Kernels/MTIRenderPipelineKernel.m
+++ b/Frameworks/MetalPetal/Kernels/MTIRenderPipelineKernel.m
@@ -172,7 +172,12 @@ NSUInteger const MTIRenderPipelineMaximumColorAttachmentCount = 8;
     }
     renderPipelineDescriptor.depthAttachmentPixelFormat = configuration.depthAttachmentPixelFormat;
     renderPipelineDescriptor.stencilAttachmentPixelFormat = configuration.stencilAttachmentPixelFormat;
-    renderPipelineDescriptor.rasterSampleCount = configuration.rasterSampleCount;
+    
+    if (@available(iOS 11.0, macOS 10.13, *)) {
+        renderPipelineDescriptor.rasterSampleCount = configuration.rasterSampleCount;
+    } else {
+        renderPipelineDescriptor.sampleCount = configuration.rasterSampleCount;
+    }
     
     return [context renderPipelineWithDescriptor:renderPipelineDescriptor error:inOutError];
 }


### PR DESCRIPTION
- Fix `renderPipelineDescriptor.rasterSampleCount` on iOS 10 (Fix #177)
- Fix a texture loader issue on old iOS devices.