### PR TITLE
Update MTIAlphaType.m

### DIFF
--- a/Frameworks/MetalPetal/MTIAlphaType.m
+++ b/Frameworks/MetalPetal/MTIAlphaType.m
@@ -89,7 +89,7 @@ NSString * MTIAlphaTypeGetDescription(MTIAlphaType alphaType) {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         passthroughAlphaTypeHandlingRule = [[MTIAlphaTypeHandlingRule alloc] initWithAcceptableAlphaTypes:@[@(MTIAlphaTypeNonPremultiplied),@(MTIAlphaTypeAlphaIsOne),@(MTIAlphaTypePremultiplied)] outputAlphaTypeHandler:^MTIAlphaType(NSArray<NSNumber *> * _Nonnull inputAlphaTypes) {
-            NSAssert(inputAlphaTypes.count == 1, @"");
+            NSAssert([NSSet setWithArray:inputAlphaTypes].count == 1, @"");
             return [inputAlphaTypes.firstObject integerValue];
         }];
     });


### PR DESCRIPTION
I was trying to append a watermark on the photo. So I was passing to fragment shader 2 unpremultiplicated images and this assertion fired.
We should be checking if there is in general only one alpha type. So if both are the same type it should be ok.