### PR TITLE
Add mask support to MTILayer

### DIFF
--- a/Frameworks/MetalPetal/Filters/MultilayerCompositingFilter.swift
+++ b/Frameworks/MetalPetal/Filters/MultilayerCompositingFilter.swift
@@ -50,6 +50,8 @@ public class MultilayerCompositingFilter: MTIFilter {
         
         public var contentFlipOptions: MTILayer.FlipOptions = []
         
+        public var mask: MTIMask? = nil
+        
         public var compositingMask: MTIMask? = nil
         
         public var layoutUnit: MTILayer.LayoutUnit
@@ -81,6 +83,7 @@ public class MultilayerCompositingFilter: MTIFilter {
             hasher.combine(contentRegion.size.width)
             hasher.combine(contentRegion.size.height)
             hasher.combine(contentFlipOptions)
+            hasher.combine(mask)
             hasher.combine(compositingMask)
             hasher.combine(layoutUnit)
             hasher.combine(position.x)
@@ -119,11 +122,15 @@ public class MultilayerCompositingFilter: MTIFilter {
             self.mutating({ $0.contentFlipOptions = contentFlipOptions })
         }
         
-        public func compositingMask(_ mask: MTIMask?) -> Layer {
-            self.mutating({ $0.compositingMask = compositingMask })
+        public func mask(_ mask: MTIMask?) -> Layer {
+            self.mutating({ $0.mask = mask })
         }
         
-        public func frame(_ rect: CGRect, layoutUint: MTILayer.LayoutUnit) -> Layer {
+        public func compositingMask(_ mask: MTIMask?) -> Layer {
+            self.mutating({ $0.compositingMask = mask })
+        }
+        
+        public func frame(_ rect: CGRect, layoutUnit: MTILayer.LayoutUnit) -> Layer {
             self.mutating({
                 $0.size = rect.size
                 $0.position = CGPoint(x: rect.midX, y: rect.midY)
@@ -131,7 +138,7 @@ public class MultilayerCompositingFilter: MTIFilter {
             })
         }
         
-        public func frame(center: CGPoint, size: CGSize, layoutUint: MTILayer.LayoutUnit) -> Layer {
+        public func frame(center: CGPoint, size: CGSize, layoutUnit: MTILayer.LayoutUnit) -> Layer {
             self.mutating({
                 $0.size = size
                 $0.position = center
@@ -206,7 +213,7 @@ extension MultilayerCompositingFilter {
 
 extension MultilayerCompositingFilter.Layer {
     fileprivate func bridgeToObjectiveC() -> MTILayer {
-        return MTILayer(content: self.content, contentRegion: self.contentRegion, contentFlipOptions: self.contentFlipOptions, compositingMask: self.compositingMask, layoutUnit: self.layoutUnit, position: self.position, size: self.size, rotation: self.rotation, opacity: self.opacity, tintColor: self.tintColor, blendMode: self.blendMode)
+        return MTILayer(content: self.content, contentRegion: self.contentRegion, contentFlipOptions: self.contentFlipOptions, mask: self.mask, compositingMask: self.compositingMask, layoutUnit: self.layoutUnit, position: self.position, size: self.size, rotation: self.rotation, opacity: self.opacity, tintColor: self.tintColor, blendMode: self.blendMode)
     }
 }
 

--- a/Frameworks/MetalPetal/Kernels/MTIMultilayerCompositeKernel.m
+++ b/Frameworks/MetalPetal/Kernels/MTIMultilayerCompositeKernel.m
@@ -166,9 +166,6 @@ __attribute__((objc_subclassing_restricted))
 
 + (MTIRenderPipeline *)renderPipelineWithFragmentFunctionName:(NSString *)fragmentFunctionName colorAttachmentDescriptor:(MTLRenderPipelineColorAttachmentDescriptor *)colorAttachmentDescriptor rasterSampleCount:(NSUInteger)rasterSampleCount context:(MTIContext *)context error:(NSError * __autoreleasing *)inOutError {
     MTLRenderPipelineDescriptor *renderPipelineDescriptor = [[MTLRenderPipelineDescriptor alloc] init];
-    
-    BOOL useProgrammableBlending = context.defaultLibrarySupportsProgrammableBlending && context.isProgrammableBlendingSupported;
-
     NSError *error;
     id<MTLFunction> vertextFunction = [context functionWithDescriptor:[[MTIFunctionDescriptor alloc] initWithName:MTIFilterPassthroughVertexFunctionName] error:&error];
     if (error) {
@@ -190,9 +187,6 @@ __attribute__((objc_subclassing_restricted))
     renderPipelineDescriptor.fragmentFunction = fragmentFunction;
     
     renderPipelineDescriptor.colorAttachments[0] = colorAttachmentDescriptor;
-    if (useProgrammableBlending) {
-        renderPipelineDescriptor.colorAttachments[1] = colorAttachmentDescriptor;
-    }
     renderPipelineDescriptor.depthAttachmentPixelFormat = MTLPixelFormatInvalid;
     renderPipelineDescriptor.stencilAttachmentPixelFormat = MTLPixelFormatInvalid;
     
@@ -541,7 +535,7 @@ __attribute__((objc_subclassing_restricted))
         [commandEncoder setFragmentSamplerState:[renderingContext resolvedSamplerStateForImage:layer.content] atIndex:0];
         
         if (layer.compositingMask) {
-            NSParameterAssert(layer.mask.content.alphaType != MTIAlphaTypeUnknown);
+            NSParameterAssert(layer.compositingMask.content.alphaType != MTIAlphaTypeUnknown);
             [commandEncoder setFragmentTexture:[renderingContext resolvedTextureForImage:layer.compositingMask.content] atIndex:1];
             [commandEncoder setFragmentSamplerState:[renderingContext resolvedSamplerStateForImage:layer.compositingMask.content] atIndex:1];
         }

--- a/Frameworks/MetalPetal/MTIBlendFormulaSupport.mm
+++ b/Frameworks/MetalPetal/MTIBlendFormulaSupport.mm
@@ -48,13 +48,19 @@ typedef struct MTICLAHELUTGeneratorInputParameters MTICLAHELUTGeneratorInputPara
 
 struct MTIMultilayerCompositingLayerShadingParameters {
     float opacity;
-    bool contentHasPremultipliedAlpha;
-    bool hasCompositingMask;
+    int maskComponent;
     int compositingMaskComponent;
-    bool usesOneMinusMaskValue;
     vector_float4 tintColor;
 };
 typedef struct MTIMultilayerCompositingLayerShadingParameters MTIMultilayerCompositingLayerShadingParameters;
+
+struct MTIMultilayerCompositingLayerVertex {
+    vector_float4 position;
+    vector_float2 textureCoordinate;
+    vector_float2 positionInLayer;
+};
+typedef struct MTIMultilayerCompositingLayerVertex MTIMultilayerCompositingLayerVertex;
+
 
 #if __METAL_MACOS__ || __METAL_IOS__
 
@@ -66,6 +72,12 @@ namespace metalpetal {
         float4 position [[ position ]];
         float2 textureCoordinate;
     } VertexOut;
+
+    typedef struct {
+        float4 position [[ position ]];
+        float2 textureCoordinate;
+        float2 positionInLayer;
+    } MTIMultilayerCompositingLayerVertexOut;
     
     // GLSL mod func for metal
     template <typename T, typename _E = typename enable_if<is_floating_point<typename make_scalar<T>::type>::value>::type>
@@ -667,10 +679,43 @@ namespace metalpetal {
 
 #endif /* MTIShader_h */
 
+//
+//  MTIFunctionConstants.h
+//  Pods
+//
+//  Created by YuAo on 2021/3/29.
+//
+
+#ifndef MTIShaderFunctionConstants_h
+#define MTIShaderFunctionConstants_h
+
+#if __METAL_MACOS__ || __METAL_IOS__
+
+#include <metal_stdlib>
+
+namespace metalpetal {
+    constant bool blend_filter_backdrop_has_premultiplied_alpha [[function_constant(1024)]];
+    constant bool blend_filter_source_has_premultiplied_alpha [[function_constant(1025)]];
+    constant bool blend_filter_outputs_premultiplied_alpha [[function_constant(1026)]];
+    constant bool blend_filter_outputs_opaque_image [[function_constant(1027)]];
+    
+    constant bool multilayer_composite_content_premultiplied [[function_constant(1028)]];
+    constant bool multilayer_composite_has_mask [[function_constant(1029)]];
+    constant bool multilayer_composite_mask_inverted [[function_constant(1030)]];
+    constant bool multilayer_composite_has_compositing_mask [[function_constant(1031)]];
+    constant bool multilayer_composite_compositing_mask_inverted [[function_constant(1032)]];
+    constant bool multilayer_composite_has_tint_color [[function_constant(1033)]];
+}
+
+#endif
+
+#endif /* MTIShaderFunctionConstants_h */
+
 
 using namespace metalpetal;
 
 {MTIBlendFormula}
+
 
 fragment float4 customBlend(VertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
@@ -680,41 +725,65 @@ fragment float4 customBlend(VertexOut vertexIn [[ stage_in ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
     #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
-    float4 uCf = overlayTexture.sample(overlaySampler, modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height())));
-    #else
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
     #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
+    if (blend_filter_backdrop_has_premultiplied_alpha) {
+        uCb = unpremultiply(uCb);
+    }
+    if (blend_filter_source_has_premultiplied_alpha) {
+        uCf = unpremultiply(uCf);
+    }
     float4 blendedColor = blend(uCb, uCf);
-    return mix(uCb,blendedColor,intensity);
+    float4 output = mix(uCb,blendedColor,intensity);
+    if (blend_filter_outputs_premultiplied_alpha) {
+        return premultiply(output);
+    } else if (blend_filter_outputs_opaque_image) {
+        return float4(output.rgb, 1.0);
+    } else {
+        return output;
+    }
 }
+
+
 
 
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeCustomBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
     #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
-    float4 textureColor = colorTexture.sample(colorSampler, modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height())));
-    #else
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
     #endif
-    if (parameters.contentHasPremultipliedAlpha) {
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return blend(currentColor,textureColor);
@@ -723,9 +792,11 @@ fragment float4 multilayerCompositeCustomBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeCustomBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -734,26 +805,33 @@ fragment float4 multilayerCompositeCustomBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
     #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
-    float4 textureColor = colorTexture.sample(colorSampler, modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height())));
-    #else
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
     #endif
-    if (parameters.contentHasPremultipliedAlpha) {
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return blend(backgroundColor,textureColor);
 }
+
+
 
 )mtirawstring";
 

--- a/Frameworks/MetalPetal/MTIError.h
+++ b/Frameworks/MetalPetal/MTIError.h
@@ -51,9 +51,7 @@ typedef NS_ERROR_ENUM(MTIErrorDomain, MTIError) {
     //For operations do not support cross device or cross context rendering, we report these errors.
     MTIErrorCrossDeviceRendering = 5006,
     MTIErrorCrossContextRendering = 5007,
-    
-    MTIErrorFailedToFetchBlendRenderPipelineForMultilayerCompositing = 5008,
-    
+        
     //For features not available on iOS simulator.
     MTIErrorFeatureNotAvailableOnSimulator = 6001
 };

--- a/Frameworks/MetalPetal/MTILayer.h
+++ b/Frameworks/MetalPetal/MTILayer.h
@@ -39,6 +39,10 @@ __attribute__((objc_subclassing_restricted))
 
 @property (nonatomic, readonly) MTILayerFlipOptions contentFlipOptions;
 
+/// A mask that applies to the `content` of the layer. This mask is resized and aligned with the layer.
+@property (nonatomic, strong, readonly, nullable) MTIMask *mask;
+
+/// A mask that applies to the `content` of the layer. This mask is resized and aligned with the background.
 @property (nonatomic, strong, readonly, nullable) MTIMask *compositingMask;
 
 @property (nonatomic, readonly) MTILayerLayoutUnit layoutUnit;
@@ -99,9 +103,23 @@ __attribute__((objc_subclassing_restricted))
                         opacity:(float)opacity
                       blendMode:(MTIBlendMode)blendMode;
 
+
 - (instancetype)initWithContent:(MTIImage *)content
                   contentRegion:(CGRect)contentRegion
              contentFlipOptions:(MTILayerFlipOptions)contentFlipOptions
+                compositingMask:(nullable MTIMask *)compositingMask
+                     layoutUnit:(MTILayerLayoutUnit)layoutUnit
+                       position:(CGPoint)position
+                           size:(CGSize)size
+                       rotation:(float)rotation
+                        opacity:(float)opacity
+                      tintColor:(MTIColor)tintColor
+                      blendMode:(MTIBlendMode)blendMode;
+
+- (instancetype)initWithContent:(MTIImage *)content
+                  contentRegion:(CGRect)contentRegion
+             contentFlipOptions:(MTILayerFlipOptions)contentFlipOptions
+                           mask:(nullable MTIMask *)mask
                 compositingMask:(nullable MTIMask *)compositingMask
                      layoutUnit:(MTILayerLayoutUnit)layoutUnit
                        position:(CGPoint)position

--- a/Frameworks/MetalPetal/MTILayer.m
+++ b/Frameworks/MetalPetal/MTILayer.m
@@ -64,10 +64,26 @@
 }
 
 - (instancetype)initWithContent:(MTIImage *)content contentRegion:(CGRect)contentRegion contentFlipOptions:(MTILayerFlipOptions)contentFlipOptions compositingMask:(MTIMask *)compositingMask layoutUnit:(MTILayerLayoutUnit)layoutUnit position:(CGPoint)position size:(CGSize)size rotation:(float)rotation opacity:(float)opacity tintColor:(MTIColor)tintColor blendMode:(MTIBlendMode)blendMode {
+    return [self initWithContent:content
+                   contentRegion:contentRegion
+              contentFlipOptions:contentFlipOptions
+                            mask:nil
+                 compositingMask:compositingMask
+                      layoutUnit:layoutUnit
+                        position:position
+                            size:size
+                        rotation:rotation
+                         opacity:opacity
+                       tintColor:tintColor
+                       blendMode:blendMode];
+}
+
+- (instancetype)initWithContent:(MTIImage *)content contentRegion:(CGRect)contentRegion contentFlipOptions:(MTILayerFlipOptions)contentFlipOptions mask:(MTIMask *)mask compositingMask:(MTIMask *)compositingMask layoutUnit:(MTILayerLayoutUnit)layoutUnit position:(CGPoint)position size:(CGSize)size rotation:(float)rotation opacity:(float)opacity tintColor:(MTIColor)tintColor blendMode:(MTIBlendMode)blendMode {
     if (self = [super init]) {
         _content = content;
         _contentRegion = contentRegion;
         _contentFlipOptions = contentFlipOptions;
+        _mask = mask;
         _compositingMask = compositingMask;
         _layoutUnit = layoutUnit;
         _position = position;

--- a/Frameworks/MetalPetal/MetalPetal.h
+++ b/Frameworks/MetalPetal/MetalPetal.h
@@ -85,6 +85,7 @@
 #import "MTIVertex.h"
 #import "MTIWeakToStrongObjectsMapTable.h"
 #import "MTISCNSceneRenderer.h"
+#import "MTIShaderFunctionConstants.h"
 #import "MTIShaderLib.h"
 #import "MTISKSceneRenderer.h"
 #import "MTIImageView.h"

--- a/Frameworks/MetalPetal/Shaders/BlendingShaders.metal
+++ b/Frameworks/MetalPetal/Shaders/BlendingShaders.metal
@@ -4,16 +4,12 @@
 
 #include <metal_stdlib>
 #include "MTIShaderLib.h"
+#include "MTIShaderFunctionConstants.h"
 
 using namespace metal;
 using namespace metalpetal;
 
 namespace metalpetal {
-    
-constant bool blend_filter_backdrop_has_premultiplied_alpha [[function_constant(0)]];
-constant bool blend_filter_source_has_premultiplied_alpha [[function_constant(1)]];
-constant bool blend_filter_outputs_premultiplied_alpha [[function_constant(2)]];
-constant bool blend_filter_outputs_opaque_image [[function_constant(3)]];
 
 fragment float4 normalBlend(VertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
@@ -22,8 +18,13 @@ fragment float4 normalBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -49,8 +50,13 @@ fragment float4 darkenBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -76,8 +82,13 @@ fragment float4 multiplyBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -103,8 +114,13 @@ fragment float4 colorBurnBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -130,8 +146,13 @@ fragment float4 linearBurnBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -157,8 +178,13 @@ fragment float4 darkerColorBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -184,8 +210,13 @@ fragment float4 lightenBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -211,8 +242,13 @@ fragment float4 screenBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -238,8 +274,13 @@ fragment float4 colorDodgeBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -265,8 +306,13 @@ fragment float4 addBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -292,8 +338,13 @@ fragment float4 lighterColorBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -319,8 +370,13 @@ fragment float4 overlayBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -346,8 +402,13 @@ fragment float4 softLightBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -373,8 +434,13 @@ fragment float4 hardLightBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -400,8 +466,13 @@ fragment float4 vividLightBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -427,8 +498,13 @@ fragment float4 linearLightBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -454,8 +530,13 @@ fragment float4 pinLightBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -481,8 +562,13 @@ fragment float4 hardMixBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -508,8 +594,13 @@ fragment float4 differenceBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -535,8 +626,13 @@ fragment float4 exclusionBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -562,8 +658,13 @@ fragment float4 subtractBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -589,8 +690,13 @@ fragment float4 divideBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -616,8 +722,13 @@ fragment float4 hueBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -643,8 +754,13 @@ fragment float4 saturationBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -670,8 +786,13 @@ fragment float4 colorBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -697,8 +818,13 @@ fragment float4 luminosityBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }

--- a/Frameworks/MetalPetal/Shaders/MTIShaderFunctionConstants.h
+++ b/Frameworks/MetalPetal/Shaders/MTIShaderFunctionConstants.h
@@ -20,10 +20,8 @@ namespace metalpetal {
     
     constant bool multilayer_composite_content_premultiplied [[function_constant(1028)]];
     constant bool multilayer_composite_has_mask [[function_constant(1029)]];
-    constant bool multilayer_composite_mask_inverted [[function_constant(1030)]];
-    constant bool multilayer_composite_has_compositing_mask [[function_constant(1031)]];
-    constant bool multilayer_composite_compositing_mask_inverted [[function_constant(1032)]];
-    constant bool multilayer_composite_has_tint_color [[function_constant(1033)]];
+    constant bool multilayer_composite_has_compositing_mask [[function_constant(1030)]];
+    constant bool multilayer_composite_has_tint_color [[function_constant(1031)]];
 }
 
 #endif

--- a/Frameworks/MetalPetal/Shaders/MTIShaderFunctionConstants.h
+++ b/Frameworks/MetalPetal/Shaders/MTIShaderFunctionConstants.h
@@ -1,0 +1,31 @@
+//
+//  MTIFunctionConstants.h
+//  Pods
+//
+//  Created by YuAo on 2021/3/29.
+//
+
+#ifndef MTIShaderFunctionConstants_h
+#define MTIShaderFunctionConstants_h
+
+#if __METAL_MACOS__ || __METAL_IOS__
+
+#include <metal_stdlib>
+
+namespace metalpetal {
+    constant bool blend_filter_backdrop_has_premultiplied_alpha [[function_constant(1024)]];
+    constant bool blend_filter_source_has_premultiplied_alpha [[function_constant(1025)]];
+    constant bool blend_filter_outputs_premultiplied_alpha [[function_constant(1026)]];
+    constant bool blend_filter_outputs_opaque_image [[function_constant(1027)]];
+    
+    constant bool multilayer_composite_content_premultiplied [[function_constant(1028)]];
+    constant bool multilayer_composite_has_mask [[function_constant(1029)]];
+    constant bool multilayer_composite_mask_inverted [[function_constant(1030)]];
+    constant bool multilayer_composite_has_compositing_mask [[function_constant(1031)]];
+    constant bool multilayer_composite_compositing_mask_inverted [[function_constant(1032)]];
+    constant bool multilayer_composite_has_tint_color [[function_constant(1033)]];
+}
+
+#endif
+
+#endif /* MTIShaderFunctionConstants_h */

--- a/Frameworks/MetalPetal/Shaders/MTIShaderLib.h
+++ b/Frameworks/MetalPetal/Shaders/MTIShaderLib.h
@@ -41,13 +41,19 @@ typedef struct MTICLAHELUTGeneratorInputParameters MTICLAHELUTGeneratorInputPara
 
 struct MTIMultilayerCompositingLayerShadingParameters {
     float opacity;
-    bool contentHasPremultipliedAlpha;
-    bool hasCompositingMask;
+    int maskComponent;
     int compositingMaskComponent;
-    bool usesOneMinusMaskValue;
     vector_float4 tintColor;
 };
 typedef struct MTIMultilayerCompositingLayerShadingParameters MTIMultilayerCompositingLayerShadingParameters;
+
+struct MTIMultilayerCompositingLayerVertex {
+    vector_float4 position;
+    vector_float2 textureCoordinate;
+    vector_float2 positionInLayer;
+};
+typedef struct MTIMultilayerCompositingLayerVertex MTIMultilayerCompositingLayerVertex;
+
 
 #if __METAL_MACOS__ || __METAL_IOS__
 
@@ -59,6 +65,12 @@ namespace metalpetal {
         float4 position [[ position ]];
         float2 textureCoordinate;
     } VertexOut;
+
+    typedef struct {
+        float4 position [[ position ]];
+        float2 textureCoordinate;
+        float2 positionInLayer;
+    } MTIMultilayerCompositingLayerVertexOut;
     
     // GLSL mod func for metal
     template <typename T, typename _E = typename enable_if<is_floating_point<typename make_scalar<T>::type>::value>::type>

--- a/Frameworks/MetalPetal/Shaders/MTIShaderLib.h
+++ b/Frameworks/MetalPetal/Shaders/MTIShaderLib.h
@@ -40,9 +40,18 @@ struct MTICLAHELUTGeneratorInputParameters {
 typedef struct MTICLAHELUTGeneratorInputParameters MTICLAHELUTGeneratorInputParameters;
 
 struct MTIMultilayerCompositingLayerShadingParameters {
+    vector_float2 canvasSize;
+    
     float opacity;
+    
     int maskComponent;
+    bool maskHasPremultipliedAlpha;
+    bool maskUsesOneMinusValue;
+    
     int compositingMaskComponent;
+    bool compositingMaskHasPremultipliedAlpha;
+    bool compositingMaskUsesOneMinusValue;
+    
     vector_float4 tintColor;
 };
 typedef struct MTIMultilayerCompositingLayerShadingParameters MTIMultilayerCompositingLayerShadingParameters;

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,228 +7,229 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0105312D47432D4D5410C5DA59FC3FDE /* MTIColorMatrix.m in Sources */ = {isa = PBXBuildFile; fileRef = C9341F7A1F3E62D93D34ACB037FCF283 /* MTIColorMatrix.m */; };
-		0291B60B349B40F78722194A6B73FE86 /* MTIBlendWithMaskFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A1D58E560C44C6DBDD985E536D6BFDE /* MTIBlendWithMaskFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		038FD9E89E2FE655773268C243331DEE /* MTIColorHalftoneFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 21AA4C22D9BE7F8481CB8F165BFFDE4B /* MTIColorHalftoneFilter.m */; };
-		0436131A376364D03BB732B43BCBABE9 /* MTIBlendFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = B1EE4F5B4A078E85AFA072199F881C17 /* MTIBlendFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		045F1F10D1209F8E784A41605C402BF6 /* Halftone.metal in Sources */ = {isa = PBXBuildFile; fileRef = 765CD1D513DCC53DF5E439FAB1C8475A /* Halftone.metal */; };
-		06FCC133F0969F15E99D1BA1046692C0 /* MTIPixelFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = E6CFF1002699AB1C75E6D7169AD10772 /* MTIPixelFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		071606C0D4365597BAA54E2A9E912559 /* MTIImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 60DE3B29A8D244B28096E314A9F38DB6 /* MTIImageView.m */; };
-		07963D34AEEBB8B45812DBDE6FB2952E /* MTICVMetalIOSurfaceBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = DF537F7A9A72644759B75F600A566DE1 /* MTICVMetalIOSurfaceBridge.m */; };
-		0847385D98FFCB314EBF9D21289C3748 /* MTIImageProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = CBD4ADD0029458CD8379EAE8E7358007 /* MTIImageProperties.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0866FAD5FFDB9083BAA37D668D9ECCC0 /* MTIImageOrientation.m in Sources */ = {isa = PBXBuildFile; fileRef = 74061F6AAECA5B7ABF7500FB689EA692 /* MTIImageOrientation.m */; };
-		09AF56B1D58EBDCF2606FD0F4869EDA8 /* MTIThreadSafeImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A73490F7FBC21A2D26096D7346BDE0F /* MTIThreadSafeImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0A467BF1C4544B195098E3BD4CA40E1F /* MTIRoundCornerFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = B40915E5D0F2D2231739A8850E333C2C /* MTIRoundCornerFilter.m */; };
-		0B71C713AE8B7D1893260DB0F7FD8D8A /* MTIGeometry.h in Headers */ = {isa = PBXBuildFile; fileRef = C84B38774E5EF7F53888666906AB5FAA /* MTIGeometry.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0C5C967871379DB2ECC2ABE523B9CF82 /* MTIBlendFormulaSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A3AA61E4DC06647448CA24CEF27AD9D /* MTIBlendFormulaSupport.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		0FED3A746460700CE8F5F4C78A2FA285 /* MTIPixellateFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 398C4EC9EF22FCE2ABAD722084008E21 /* MTIPixellateFilter.m */; };
-		100D11F88D01349DDEB245DCCCE5EB19 /* LensBlur.metal in Sources */ = {isa = PBXBuildFile; fileRef = 88614D896761050099A8A798078CAD80 /* LensBlur.metal */; };
-		112AA5571FCED3D9254B4954A2CA4E07 /* MTIVector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BBD017E0C9B38AD87CD2738749CDF1D /* MTIVector.swift */; };
-		1208C359D8D2C0801F7A2CC465F64277 /* MTISKSceneRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = D918C587147DAC53E119C134F088916E /* MTISKSceneRenderer.m */; };
-		139C76A5D80F87173754A94805609E1F /* MTIImageViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FEE9C959BFEECD7FA4614F6E385E0FC /* MTIImageViewProtocol.swift */; };
-		1577F648289E582A1DAE3AA1D17BCC7B /* MTIMPSHistogramFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 920019B9E8653C980E7384086452A571 /* MTIMPSHistogramFilter.m */; };
-		17A93991A6EE1A22BBE44B65BB45881E /* MTITexturePool.h in Headers */ = {isa = PBXBuildFile; fileRef = DF5FD054F0E76B597090379B7D703AFB /* MTITexturePool.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		193CC58DE156D7B7595BF3D2C0C50D35 /* MTIColorMatrix.h in Headers */ = {isa = PBXBuildFile; fileRef = 7480CDF9696845AAE86B3FE3A1282323 /* MTIColorMatrix.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1B0ADDB0EEE9E9E0E13B2BF0BFD68C6A /* MTIMPSConvolutionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = BAFE24041771958D747DC76A98F2F320 /* MTIMPSConvolutionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1BF53E63CB23B0C49FAB24D05BCC5D2B /* MTIBlendWithMaskFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = CB37301CCDE806AB3B461B46D4A0892D /* MTIBlendWithMaskFilter.m */; };
-		1C1848E17DF84B052C5C195131C1B93A /* MTIBulgeDistortionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = EE8480BF4E03B23C283F26BCED87275C /* MTIBulgeDistortionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1CCA76FB4025E134DE737FEBC70FFEDE /* MTIColorMatrix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 817E2B62184F77F2F437A2226E162A67 /* MTIColorMatrix.swift */; };
-		1CD52652DA3758546FCD269B02B0AD8F /* MTIUnaryImageRenderingFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = A1E9946A80A087C34E0392DC001BC1B3 /* MTIUnaryImageRenderingFilter.m */; };
-		1DF63F779E6CA8ED8A4E17DD7A908DFC /* MTIImage.m in Sources */ = {isa = PBXBuildFile; fileRef = E72464AB19C80A06A585AF6569B35054 /* MTIImage.m */; };
-		1EAD1FA325C68E0CF3B7680378EBCAF6 /* MTIComputePipelineKernel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0321876584FA0BB1552C24FE09DCB1DD /* MTIComputePipelineKernel.swift */; };
-		2271F1422462B09CBEF70197511D4199 /* MTITextureDimensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 182194D34BA8667C762FB8BB906B9789 /* MTITextureDimensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2281BA9E88B636ACD22CE77E467D39D5 /* MTIMPSKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 91B7AE11A52CF2257DDFD39FC4639BEE /* MTIMPSKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		23EDE4AF6B9C33A3DE2BB60BC3D2B8AA /* MTIAlphaPremultiplicationFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 017E8CEBEC7896E0BD86B0BFC883F38E /* MTIAlphaPremultiplicationFilter.m */; };
-		26499BB0E554A67DAE1B043C60856DC2 /* MultilayerCompositingFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED967B218BF3820C9841DDAD64AFCA4C /* MultilayerCompositingFilter.swift */; };
-		28209CC142ED73F648C5B2F3BAF25264 /* MTIGeometryUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A863AA532943C9EA9E79603515C3594 /* MTIGeometryUtilities.m */; };
+		01B0292CFBB20E4DA8E7526EEB55663C /* MTIImagePromise.m in Sources */ = {isa = PBXBuildFile; fileRef = BA8891D1A558E880C80BAC28DEABE906 /* MTIImagePromise.m */; };
+		02AB38B977BD4F6926B3E6A3A30873D7 /* MTITransformFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = DB66AFD5F859F2417471C27B890DB139 /* MTITransformFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0437F52BF224ECC822DC99B9166ED928 /* MTIHighPassSkinSmoothingFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = E09E4D72E0A0564E93051813AEDA135E /* MTIHighPassSkinSmoothingFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		043EAED079168285C46090966912A2B1 /* MTIPixellateFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 04AE91654A85602AE96DBA70381A36C7 /* MTIPixellateFilter.m */; };
+		04AB9AA1682FA0BB46E52E06018A8D35 /* MTIContext+Rendering.m in Sources */ = {isa = PBXBuildFile; fileRef = A721B1ACEAD3E9D9DA3E515AA4462584 /* MTIContext+Rendering.m */; };
+		05BA3B2EA4BDBF9A40FAB12E858407DF /* MTIBlendModes.m in Sources */ = {isa = PBXBuildFile; fileRef = BE7948D8AB11AF33255EC4BD5256AF7D /* MTIBlendModes.m */; };
+		070B522E85AE6BB7B781917608EE91FF /* MTIRoundCornerFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = A83710B5CCF3635F0608BCBB58917AB8 /* MTIRoundCornerFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		07FD3FA1708FA2B7668B72373369776F /* MTICoreImageRendering.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D6A57A0CBF92626D2F1CBBB6468E979 /* MTICoreImageRendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0891019BEA3BC04C2DA42909C7935038 /* MTIContext+Rendering.h in Headers */ = {isa = PBXBuildFile; fileRef = 9CAD2273320E618C229D82E3F500B4CF /* MTIContext+Rendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0C8F50D11A9424F39987AF30DD72C89F /* MTIImageRenderingContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = E26357780DD62E344BD10535B3506ED0 /* MTIImageRenderingContext.mm */; };
+		0CB9AB709592B926572735A1550A0AC1 /* MTIAlphaType.m in Sources */ = {isa = PBXBuildFile; fileRef = DE7351B22C7AB93628DC57B4D2CDA6F8 /* MTIAlphaType.m */; };
+		0DADDB4FFCE808128F571927C9A62B25 /* MTIBlendFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AC3C84676FDF5D19F81611C5243C360 /* MTIBlendFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0DF2E971C6112B73AE24AACA703EEBDA /* MTIMPSHistogramFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = E2C57730B41EDFAE73C8D8B27CBE6141 /* MTIMPSHistogramFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0F4B748DDC5ACD30674F2CC8E60669B8 /* MTIDrawableRendering.h in Headers */ = {isa = PBXBuildFile; fileRef = ACD44E37F73AFF532F6F2E4C26A29209 /* MTIDrawableRendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0FFE5F60EF84D12E17E9DD7126B27E8A /* BlendingShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 667966AD30020077DA795C3C18C52558 /* BlendingShaders.metal */; };
+		1195078819FB10C16368B109A10731CC /* MTIBlendFormulaSupport.mm in Sources */ = {isa = PBXBuildFile; fileRef = 05C66E6AFF20587B07B2E966A6A1D0A9 /* MTIBlendFormulaSupport.mm */; };
+		11D1402597087A9A101F870C8FAD7A22 /* MultilayerCompositingFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED967B218BF3820C9841DDAD64AFCA4C /* MultilayerCompositingFilter.swift */; };
+		12B37A1CD040171E802DF7CE67539C58 /* MTICVPixelBufferRendering.h in Headers */ = {isa = PBXBuildFile; fileRef = 43609648848E5F567A7FABD1218CAE1D /* MTICVPixelBufferRendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1301C9DBF5094511860B664156DF44A5 /* MetalPetal.h in Headers */ = {isa = PBXBuildFile; fileRef = 7849F3C8538B419AD017F5D050446D2A /* MetalPetal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		14C3B82888E210425F5A267FDC20C49E /* MTIDotScreenFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = F6108799C47A88E63AF47ACADF3A00FD /* MTIDotScreenFilter.m */; };
+		1514262303AA1FE0D10EB1CE9A7D6C9D /* MTISIMDArgumentEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6956F80885792D34F389794FF5515D9 /* MTISIMDArgumentEncoder.swift */; };
+		1590E372170CC4804F19A29488E30756 /* MTITextureDimensions.h in Headers */ = {isa = PBXBuildFile; fileRef = A98CA48DA90740DA3A5ED193A9D9C7E5 /* MTITextureDimensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		15CE2A47B7987F8D8D6466FF7C3F45B8 /* MTICVMetalTextureCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 0ED8D5077B159E8DDF17721711D92723 /* MTICVMetalTextureCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		182E75868786AAE7A6700E8B257832CC /* MTICVPixelBufferPool.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D8E3C7C6C0AD69A5BF8A49E54A63C04 /* MTICVPixelBufferPool.m */; };
+		1B441A819246EBB1A2B0497D09C93ACC /* MTIComputePipelineKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = 1840031625149F92C9D4B6F5263C6508 /* MTIComputePipelineKernel.m */; };
+		1BC25E13242789309B7C0512235C2808 /* MTIMPSGaussianBlurFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = E053B8E9CCD0F411B22A2AE5A31545AC /* MTIMPSGaussianBlurFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D00C3320F0ACCD6D8C8578558C8CC58 /* MTIRGBColorSpaceConversionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = C51E35307EB9E571F5ADD641ABC5C0CB /* MTIRGBColorSpaceConversionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1DB29419308FFB15A187B99FFF14DC88 /* MTITextureDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 7F0AD4AA5EAEF72BC66DB4A8F1FBBDC2 /* MTITextureDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1EDF7B1F6DAF886C33909D3F77A6E488 /* MTIWeakToStrongObjectsMapTable.m in Sources */ = {isa = PBXBuildFile; fileRef = 2392A2383A76EE8F4020EADDC119D1C4 /* MTIWeakToStrongObjectsMapTable.m */; };
+		1FD50FC568A7D704F63A2D7F208DE670 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73010CC983E3809BECEE5348DA1BB8C6 /* Foundation.framework */; };
+		21655750E446A8C233F3801AF67A43ED /* MTIBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EF4C6CCA87B0A7ED6B528B9EF00391F /* MTIBuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2244DE8DAD8A98A45C5E75CC92FFE53F /* MTIContext+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DEFE522353775645479595270728273 /* MTIContext+Internal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		23B5AF0B6D2C130E8EA92F5A0C385C67 /* MTIVector.m in Sources */ = {isa = PBXBuildFile; fileRef = F0AAC758A632963D76270F37E3A0FDF4 /* MTIVector.m */; };
+		2401AAFFB3FF049B4E4094CADDB82647 /* MTIUnaryImageRenderingFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = EF5CA4F1A19F24699089C00C27638B20 /* MTIUnaryImageRenderingFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		261A57C1FECBF26786733CC67624B826 /* MTICVMetalTextureCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B91F6134F13DAC7E31458970C968234 /* MTICVMetalTextureCache.m */; };
+		27486FACE2DAF4DB1D2C26E653A7E721 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E069528B6E4B104DF5E3FB5CA9DDE988 /* Filter.swift */; };
 		282C54C33FF0EBF163ADF2924B5200B2 /* Pods-MetalPetalDemo-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EE04A67933AF897CCE4BA65DF272949 /* Pods-MetalPetalDemo-dummy.m */; };
-		28E527B5682833783882D0F1A8C6A627 /* MTIRGBColorSpaceConversionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FBC5E880893DF658CE8C42AFDB3EFE1 /* MTIRGBColorSpaceConversionFilter.m */; };
-		2A08B5A62F7E3E55F6F506F331B8E21F /* MTICLAHEFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = C4FE10061A867C198269C2D587DCEF2C /* MTICLAHEFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2A9EAF6B9A03B7951ED066FDD6C47A07 /* MTILibrarySource.h in Headers */ = {isa = PBXBuildFile; fileRef = 334D1276AB7BB37A7966E6CEDDC506EC /* MTILibrarySource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2B1F26B99A731F69D7F63B865A41DD28 /* MTIRenderPassOutputDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C62938684F93FE4ABD8F01C03618074 /* MTIRenderPassOutputDescriptor.m */; };
-		2B906F4A48DB77C83AC44D42815055E5 /* MTIMPSKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = 04021D79209A22A71378929D740E21BF /* MTIMPSKernel.m */; };
-		2BEFBD0E58ECAA494DC431D8D49CF6BC /* MTISKSceneRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = CFFF513AA45E92258F737206085A1FB6 /* MTISKSceneRenderer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2CE8CB191ECD9A671CA21045EFC99A6E /* MTICVMetalIOSurfaceBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 41E39614F2AEEB175FCC6F0F428747FF /* MTICVMetalIOSurfaceBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2E4A5F65BD7B37C163CDF56FF7C1DCC3 /* MTIContext.m in Sources */ = {isa = PBXBuildFile; fileRef = A6802FEA6C73888CAE5CF06B860A7BF4 /* MTIContext.m */; };
-		2F64E72855CCC6602B685C119DA4C65B /* MTILayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 825C53F63F41C797BC4981CCF22343F8 /* MTILayer.m */; };
-		309CD9B501982530D6DC7C8183F600A6 /* MTICVPixelBufferPool.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F2E6A40946FCA93AA656A0E66A0F0B4 /* MTICVPixelBufferPool.m */; };
-		3193779E163F1EA20F9D1266ED80DF60 /* MTILock.m in Sources */ = {isa = PBXBuildFile; fileRef = 92FC9F8B0D958B462B847FD6F41E1BCB /* MTILock.m */; };
-		31BED32266DAF392241F7142B6A77F8E /* MTIHasher.h in Headers */ = {isa = PBXBuildFile; fileRef = E9BA8DEA27E8473D0496E03599269227 /* MTIHasher.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		367FBC57F466D3A060D766BA9CBB85E7 /* MTICVPixelBufferPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C5688196AC43221CC7F06788E4F44CF /* MTICVPixelBufferPromise.m */; };
-		36B6867FF1EE8092DAB08B0CC9B2560E /* MTIChromaKeyBlendFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 508ECCFFAEDBC424B2868384462985FB /* MTIChromaKeyBlendFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3814930C8647C6C48413536AE0F47CB4 /* MTIUnaryImageRenderingFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = F1DAC9B5A3B49A9ADC814F3FC039DE86 /* MTIUnaryImageRenderingFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3B54D81404551E37898FC880A3297305 /* MTIBlendModes.m in Sources */ = {isa = PBXBuildFile; fileRef = A431037551AAF3CA52FCAF307E2BD93A /* MTIBlendModes.m */; };
-		3B8889065D5A963661B0D38F15C95AC0 /* MTIAlphaPremultiplicationFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 4BF1D573A3D2FB02D5394C021B7190BB /* MTIAlphaPremultiplicationFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3CD5924C09EFA78D305B63F6060286D1 /* MTIMultilayerCompositeKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 32FFE8A4A958E6BCE240E1054C901B14 /* MTIMultilayerCompositeKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3E091DB7E79BB9A2709CC1CAE8FB6CB6 /* MTIMPSBoxBlurFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = C7BDD6D47791C4508C03C47289A3382B /* MTIMPSBoxBlurFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3ECD3B45A3B78DC2CAB04ED06AF54087 /* MTITransformFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = B1C7EFF766AB01017BA6E7AD2872CDEE /* MTITransformFilter.m */; };
-		3FB2F8A597FA21AC7110C8732869DCED /* MTIColorHalftoneFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = DFA64C8D21F1C7851C9B0D475A9543A6 /* MTIColorHalftoneFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3FF6BA3D8EE17A3C9FF1CEEB3D746311 /* MTIDotScreenFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 616594FAC6B27A6075F875D7E23D0EAB /* MTIDotScreenFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3FF847DDC4AC4F9C93BCDC93CF7D3DD7 /* MTIMultilayerCompositeKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A91AB0A419FE0AB6226B47C35DC34C0 /* MTIMultilayerCompositeKernel.m */; };
-		42CC018DBCA118DEE260853EE457B252 /* MTIImageRenderingContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = FD5E74278D4181FCEF4726543190DE5F /* MTIImageRenderingContext.mm */; };
-		4554919085BA4D1BFF5AF7C141507B9D /* MTIFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = BFDFDF4F5452205A4C8366819FA0149D /* MTIFilter.m */; };
-		4577E2FFC95477907290D8CDA8F0C3F1 /* MTIKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 80E8535AF70B8B0BA370C1F8681B3EB4 /* MTIKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		47737AB5905FD5AB3F48A1811139ECC5 /* MTITextureLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = C40E942AC5FEDE1B917A3EC8DF038ED1 /* MTITextureLoader.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4AACC34D93C4CE9B53103F26F8B7AC2B /* MTISCNSceneRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 14A1932D300EB6B53DF05B58B0956FC4 /* MTISCNSceneRenderer.m */; };
-		4BFA3D04E836A89263814F7D987F865E /* MTIContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 10A1A9ED09C7E9FAF2F6D5E6ECF7707C /* MTIContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4DEFEE61AEF7F27C699DECDE98B03BFD /* MTIRenderCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = DEC0DCDB61AFEC013ADA8C8A0E060D6F /* MTIRenderCommand.m */; };
-		4E2B94FB6055903DEA83B0C0D1F47EFA /* MTIContext+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B9A5C5872D5A8F0334590A3855B0DBA /* MTIContext+Internal.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4EF34D6C8CCCB786C3858C8A6E180D9C /* MTIError.m in Sources */ = {isa = PBXBuildFile; fileRef = 54465B216A991179386A9001C8AD45D0 /* MTIError.m */; };
-		5291F00F0EFEA07D51EBEA0CA3F19F27 /* MTIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AE1C4BCC9E523CB4012128BBC15D1A /* MTIError.swift */; };
-		52EA30069060F561D11C9F7A1BC55B44 /* MTIMultilayerCompositingFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5364A9F1F54B3C07262B472D30679A90 /* MTIMultilayerCompositingFilter.m */; };
-		53E18C0A2B98A1F11683ED9ED747BFD1 /* MTICVMetalTextureBridging.h in Headers */ = {isa = PBXBuildFile; fileRef = C31694634F18EB151F94CDDCC4A1C1CA /* MTICVMetalTextureBridging.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		56B960BE76CE9589911E81AF41A473E5 /* MTICVMetalTextureCache.h in Headers */ = {isa = PBXBuildFile; fileRef = FC8A2DCE49C750BE184056A2DC8D6094 /* MTICVMetalTextureCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		578362F630F435434E28583D6836D37A /* MTISCNSceneRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B036B4C4978458BCDF4DE1444A564DE /* MTISCNSceneRenderer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		58481D0E9687F6EBA5ECB8D090825ABC /* MTICVPixelBufferPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 411EAD7B92F9A6F4ABF5B93C0FFFAB1E /* MTICVPixelBufferPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		58B1CEBB296382CE203118A781B1F2A3 /* MTIWeakToStrongObjectsMapTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 822B374D1B7AC61401EDF66E89E801D0 /* MTIWeakToStrongObjectsMapTable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		58C1E09F4DBF7CB5941E385ABF03072D /* MTIFunctionDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF239292141F3924BF4C6579225E2D0 /* MTIFunctionDescriptor.swift */; };
-		59A4DACF0FAA235FFCE50656C64C363A /* MTIVector+SIMD.m in Sources */ = {isa = PBXBuildFile; fileRef = 30D1E273724BFDF49C8ECBEFFF5A5BA0 /* MTIVector+SIMD.m */; };
-		5AA050E57F014F6061F00E140B8E81E9 /* MTICVPixelBufferPool.h in Headers */ = {isa = PBXBuildFile; fileRef = 8149A338AC9B24DCADC5C9DDD30E40CE /* MTICVPixelBufferPool.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5B4B801E603C521B608A6C3ED9C9EFF5 /* MTIMPSUnsharpMaskFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E98D625F283124D8E259BA7D2021672 /* MTIMPSUnsharpMaskFilter.m */; };
-		5CBBC0DF9117B9FE845999753D8E1113 /* MTIImagePromise.m in Sources */ = {isa = PBXBuildFile; fileRef = D1C68188E9EF03F3E41F6EDD633B44D0 /* MTIImagePromise.m */; };
-		5CE1EEC5A8EF0E10592F988F5647C3A0 /* MTIHighPassSkinSmoothingFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 84F5AC24AA37EEEF84D3E1CDE7B5E606 /* MTIHighPassSkinSmoothingFilter.m */; };
-		5CFE3B5507B31366B51BDBFCE19DB050 /* MTICoreImageRendering.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A897E1269E33424151E7A242885A423 /* MTICoreImageRendering.m */; };
-		5FF45284C25F64C4AF099BDC97214668 /* HighPassSkinSmoothing.metal in Sources */ = {isa = PBXBuildFile; fileRef = 79202407595B995A13EA91C0416CC03C /* HighPassSkinSmoothing.metal */; };
-		602690C1969246053A612D08883BE9A9 /* MTICLAHEFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BF80F72D70ACE02C8A43B666886282F /* MTICLAHEFilter.m */; };
-		602CD2485FAAC4E27AAF416B06E6B215 /* MTIDataBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD6624F73FC4ED9BC3A4DDD34DCB1D1 /* MTIDataBuffer.swift */; };
-		60E472B72D9583FBE5C918F96E9580CE /* MTIColorMatrixFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 50CFD0757D9AC50BADE1AE2FBB4C17DC /* MTIColorMatrixFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		614C5C5F01B1D2A103D2A117F343B6BE /* MTIComputePipelineKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = 6350A1CB8B7A21F46B78F7B2E98B0521 /* MTIComputePipelineKernel.m */; };
-		61FDEF8B49C152E2A9997FFA75BF2AFC /* MTIChromaKeyBlendFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = F772F315645B48157EA0D1CF9B5CF156 /* MTIChromaKeyBlendFilter.m */; };
-		62DE9195DD8207F91CE0BA79218EE32E /* MTIVibranceFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 15A01A17698EB0654EF17F29ABDECE2F /* MTIVibranceFilter.m */; };
-		63338396A68DAA5C9364084EE7D5CC38 /* MTITransform.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A348ABAE37C19B03E2184C2D92B1188 /* MTITransform.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		64F5A4DE7E114109DB6904614B995998 /* MTIMPSSobelFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = E184EC58E8EBBB081F2AA233F3FA1AE4 /* MTIMPSSobelFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		659815DB5BAC54C131F5A05DB1C8E9D8 /* MTIImage.h in Headers */ = {isa = PBXBuildFile; fileRef = E683F9E1DE6AF4709C7E566B27EE0BE9 /* MTIImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		65A16694FA59B822A022119D066FC1A4 /* BlendingShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = A6F8624B08A618DE7C915EC491E998AD /* BlendingShaders.metal */; };
-		6664CB9CC25DCB087733A0FD0FF0C1B6 /* MTIMultilayerCompositingFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 89AC1520E80D4FD3E9C005B8999395EF /* MTIMultilayerCompositingFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		67B76A9208B7D80816E9D5E122A99F90 /* MTIShaderLib.h in Headers */ = {isa = PBXBuildFile; fileRef = 82198882F891F495127AF2EE5EF1DC85 /* MTIShaderLib.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		67EA6A90555BA1804EFFAB192C08A6C0 /* MTIColorLookupFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 620CB9D86964842C0E9F224DFD8EEAF4 /* MTIColorLookupFilter.m */; };
-		698CFEF202E062B62E46A374EFAAE70D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73010CC983E3809BECEE5348DA1BB8C6 /* Foundation.framework */; };
-		6A1E79FE3E981E89E1290AF3F5FE72B4 /* MetalPetal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C14D184B546F25F00AC1B3358AEFECD /* MetalPetal.swift */; };
-		6B0BA713000606421DE1A90E0ED71E05 /* MTIBlendFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = F9A17AAE698190BA322F3EF9B5A65A31 /* MTIBlendFilter.m */; };
-		6D0D4740D720E42A12CA2AAB82B894C6 /* VideoProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605086DE5E2520BECAEBB726AA053DF1 /* VideoProcessing.swift */; };
-		6D1FC603B5CFA7C322A8D4FEAFF68BB6 /* MTIRGBToneCurveFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = B7DE8BC55DB2B3E345E4092D21340132 /* MTIRGBToneCurveFilter.m */; };
-		6D507EFE1398D39E45267923DEAE5BA5 /* MTIHexagonalBokehBlurFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 12B4F6EDF4B1472AE0BC53723B03D9D4 /* MTIHexagonalBokehBlurFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6FBD9329D284285998BF912BA53267E4 /* MTIAlphaType.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D34335ADC9ED66E82E9CF8DFB63F3F3 /* MTIAlphaType.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		722A90779B92D3532C196FE180890492 /* MTITextureDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EECD0ADFA2ABB7E0DD686573C413F5B /* MTITextureDescriptor.m */; };
-		7368A31BE5ADC2306764868C8B7CE1ED /* MultilayerCompositeShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = CFF3B11C4EA905C987073D3924975F67 /* MultilayerCompositeShaders.metal */; };
-		763E4AA206511022977FB0537CFBB438 /* MTIWeakToStrongObjectsMapTable.m in Sources */ = {isa = PBXBuildFile; fileRef = 17B89A6774A590C405D8CB8F871AC395 /* MTIWeakToStrongObjectsMapTable.m */; };
-		77C364842DE3CB8636FCC812ACDDE16D /* MTIMask.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BD88D7605EC9D4FE51AFEB36C5CE2F3 /* MTIMask.m */; };
-		7916E1F8ACF7FF7F013243CEE023652F /* MTIImagePromiseDebug.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A8BF44F331C40A4A5A9A855182A2161 /* MTIImagePromiseDebug.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7B4533FE309C6399CB00C6E76B12C7EE /* MTITextureLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 692136E53CACE8CAAE2910F5A7DFCEAE /* MTITextureLoader.m */; };
-		7F171EA26739DDBD1D19EBBFA6FCC86A /* MTIAlphaType.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DC3F8207CFAAC737A1DFF48239199B0 /* MTIAlphaType.m */; };
-		813E8F7FCEFC5C7B39C05C5B1E3B3BDF /* MTIPixelFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839828DBAF7622F615BED791E9F0DE2C /* MTIPixelFormat.swift */; };
-		81C60763EAEA660DA5CAB95B6AAAD45F /* MetalPetal.h in Headers */ = {isa = PBXBuildFile; fileRef = 29B708591E96EFA4BC1BC999DA114D3D /* MetalPetal.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81E8F4687A9DBF1BC83BA1B1593A697D /* MTICVPixelBufferRendering.m in Sources */ = {isa = PBXBuildFile; fileRef = 2704D4D68ECBEF5F74393C96D657EC44 /* MTICVPixelBufferRendering.m */; };
-		81F3C18DD466A0CDC316C98FA1578346 /* MTIPixellateFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E55274F6B0BF74DC5390057766E0FC6 /* MTIPixellateFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		847718B0872A47A78A30D085129BBBE3 /* MTIComputePipelineKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = A940799E64A89F80E8498F3420D15260 /* MTIComputePipelineKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		854538A1F8FEAA1DAE78A6A867854729 /* MTIRGBColorSpaceConversionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 87D8F15A54A9F2FC9ACC0BD652B5A248 /* MTIRGBColorSpaceConversionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		88DCE191EB261E62A63A1914C687B40C /* MTIDotScreenFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = A08CCF290B4005CC0BC5DC52BF770D4B /* MTIDotScreenFilter.m */; };
-		89F52DF0939DBD7856AA3ECB31D5419A /* MTILayer.h in Headers */ = {isa = PBXBuildFile; fileRef = D1DE18D9F58B6EF781D4EFC6CAC8A446 /* MTILayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A90C7A224ACE5D851AFBE8C2C529E8B /* MTIBlendFormulaSupport.mm in Sources */ = {isa = PBXBuildFile; fileRef = 682900B3D786C9F4B3A58B3C142F054E /* MTIBlendFormulaSupport.mm */; };
-		8B332E0891E65061608854C9F32CC1D8 /* MTIImage+Promise.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F38149B2B9EF53FB1AB1BFEB4D642C2 /* MTIImage+Promise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8B63396338F1A00AA4BCBADD28ABD746 /* MTIMPSUnsharpMaskFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FAED1CF584C5CA4009EA1E105DA699C /* MTIMPSUnsharpMaskFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CB5D2BA69A57C31B5C0855426023C37 /* MTIMPSDefinitionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = A4E3C9EC289989036013422F5B6AF4C8 /* MTIMPSDefinitionFilter.m */; };
-		8EDE4CA628A0B0EBB2EEFF7FAA4E403E /* MTIImage+Filters.m in Sources */ = {isa = PBXBuildFile; fileRef = 7143ADF1023D9F602ED861D42D6E9A6F /* MTIImage+Filters.m */; };
-		8F4A80D075BF9E64F68D5DF681FBAE3B /* MTIImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 7FA9A3F636E1BC52D86EE736D0F908E5 /* MTIImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		90549BC29D286476F5F2818DC6DB8DE8 /* MTIMask.h in Headers */ = {isa = PBXBuildFile; fileRef = 60E2ED62310B9ADBA4C447F7851C2722 /* MTIMask.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		90E4AD3CA04E6784257D5D91FCD9CCDD /* MTIHexagonalBokehBlurFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = B600A87CA39082EA4BAE8025F471B8DE /* MTIHexagonalBokehBlurFilter.m */; };
-		91D23D5A217BDDC92ACA43C5B69C50FE /* MTIContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ECAB595CC0D66B62BA815F7EDE21F89 /* MTIContext.swift */; };
-		91FE083B6AEBA71CA7B6A877AF6C39CB /* MTIImageRenderingContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 691D273F8D681266E9B10752D0CD0454 /* MTIImageRenderingContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		92D21E3B21E9AD4EB7EF53F9E2CBF20F /* MTIPrint.h in Headers */ = {isa = PBXBuildFile; fileRef = 3256B897FDD8338AC18560B1DA10C0A0 /* MTIPrint.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		92F692DA0008C7D4931BE296BE274F29 /* MetalPetal-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B2F078B6BC4782A2563EF651AF36398C /* MetalPetal-dummy.m */; };
-		96D6D12C4F2D58AD9686884CC6422EFB /* MTISamplerDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DFB3E6CA7B5FBF44D0AEB9C5E46FDA1 /* MTISamplerDescriptor.m */; };
-		979CFE57D491D0DEDB0399A0905C6E88 /* MTITextureDimensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DB0AD25B9D6A79975853E926F3DA0CB /* MTITextureDimensions.m */; };
-		980B4EF41BD668AD3AC852DDC71784EA /* MTIDefer.m in Sources */ = {isa = PBXBuildFile; fileRef = 56FAA0A2415D05D5CBDB5EF54E9734BF /* MTIDefer.m */; };
-		98FF338195A9E10F67315F3FD08A4E09 /* MTIPixelFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 94B7EB9DE2F53BD26A69F2745A6923D3 /* MTIPixelFormat.m */; };
-		9C15AC7551063E6C82794B896F952D67 /* MTICVPixelBufferRendering.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E2FDC2CF0ADB745A7F21E2913358013 /* MTICVPixelBufferRendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9D97B17B02669A4A92836CFA1285ADFE /* MTIImageProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = D5512E421942EBB49268D69EE940CE00 /* MTIImageProperties.m */; };
-		9F19628D133A33DC019B5501E770DAAC /* MTIMemoryWarningObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DF1BFDED9A39703FEF7CEF979229440 /* MTIMemoryWarningObserver.m */; };
-		A01AA3ACA31BE323939E5E7FCCF75AF0 /* MTIBulgeDistortionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E0D90CC84894318DB55CE51578E507B /* MTIBulgeDistortionFilter.m */; };
-		A0A7F8341145156F25B92DFA9DD1A257 /* MTIRenderPipelineKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F75F8E55D72FC0AAE6AF558354893E6 /* MTIRenderPipelineKernel.m */; };
-		A16E0804CFC138E44431791E7CA62A60 /* MTICoreImageRendering.h in Headers */ = {isa = PBXBuildFile; fileRef = FE75488F101C48B296323A7CB423CABF /* MTICoreImageRendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A6E22306EB078C61228CAC0EBE7B06C3 /* MTITexturePool.mm in Sources */ = {isa = PBXBuildFile; fileRef = B761B42FA4E54934723152A21E74A3D5 /* MTITexturePool.mm */; };
-		A9E9A9BECD2263073F0CF24110A29F8D /* MTITransform.m in Sources */ = {isa = PBXBuildFile; fileRef = DE020F57431B0DF4121CAAE397734F8A /* MTITransform.m */; };
-		AABADDB9FD7574FE7C445A3184DBB96F /* MTIFunctionArgumentsEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 583BA45980FE3F5172DD0DFB878C5D5A /* MTIFunctionArgumentsEncoder.m */; };
-		ABF576E508561959F4AC6D4FFEC5FF2B /* MTIRenderTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E32DDB1FE676E809383369ABB3347EE /* MTIRenderTask.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AEC2849FCBCC0DFD6D37294BABBB817A /* MTIMPSDefinitionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C6D98518A9FB123DDAC92F1CE0B2875 /* MTIMPSDefinitionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B0EB960DF50AA16CCACBAF7BBB84EB4F /* MTIColorLookupFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 081D0B68C18113024A52925BA2D7F723 /* MTIColorLookupFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B145A7C429A6418ABCC48F8916204DFF /* MTIFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = CC302A734DCF5CF01F83752AB33FE076 /* MTIFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B23191C52632400F19838D6A48B314B5 /* MTIMPSHistogramFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 624F416CF5A852072F6AAEDEEBFF2186 /* MTIMPSHistogramFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B3633352D397E4DBA11D0172B98C63E1 /* MTIGeometryUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = F09AB7E786103C9423194FA6801C22C5 /* MTIGeometryUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B365C1698EB528BCD56960FF38D965C7 /* MTIBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = D60AADA47F1834E755A0C41B6042CCAF /* MTIBuffer.m */; };
-		B4DA6DD1772F5E027572B2A6048466F1 /* MTIMPSBoxBlurFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F31F4C77536F54DB56F54B731F465D1 /* MTIMPSBoxBlurFilter.m */; };
-		B4DF702C956429AF622A9B6BC788428F /* MTIMPSSobelFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 55B87BE9699FB1674C3758931D904F7C /* MTIMPSSobelFilter.m */; };
-		B4F502CF6FDDF287F81DA45EC8755346 /* MTITextureDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A0EED9736CC728C77562D4836D644AE /* MTITextureDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B5DE863A6D62B084AA65D5C5B72B8894 /* MTIComputePipeline.h in Headers */ = {isa = PBXBuildFile; fileRef = 90D4397D716DA7D688ED77CE9CCB5369 /* MTIComputePipeline.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B6812D76B047AE8BF474CF4B89BC329A /* MTIRenderGraphOptimization.h in Headers */ = {isa = PBXBuildFile; fileRef = F83BE4B1777D61472E81650FB4856E60 /* MTIRenderGraphOptimization.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B7578CA065AD54AF4C8A2587AB20EDC2 /* MTICoreImageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1781EE46FE30A1C38E19F36EF1B44B5 /* MTICoreImageExtension.swift */; };
-		BC2032E67317948AC59739E19D132C75 /* MTIGeometry.m in Sources */ = {isa = PBXBuildFile; fileRef = 86DA02E3BE110C898754DC50D588A626 /* MTIGeometry.m */; };
+		286ECF052F713246636415E974800705 /* MTILibrarySource.m in Sources */ = {isa = PBXBuildFile; fileRef = 26646DD1E036FB52BDF6AFA612989DC3 /* MTILibrarySource.m */; };
+		29775F614A788778240C885E0948E68F /* MTIFunctionDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF239292141F3924BF4C6579225E2D0 /* MTIFunctionDescriptor.swift */; };
+		2A1512E39043BFBE6DC8743195E60B6B /* MTILock.h in Headers */ = {isa = PBXBuildFile; fileRef = 9EA016D063952EE35D8B939A79CDC459 /* MTILock.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2A6DEC503E1C6F7EB88DCFC05EC51DAE /* MTIImage+Promise.h in Headers */ = {isa = PBXBuildFile; fileRef = 72BA29B2881466D8F2D01877989CCB9B /* MTIImage+Promise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2B7EE0E88E32551F69E317D9CA25504F /* MetalPetal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C14D184B546F25F00AC1B3358AEFECD /* MetalPetal.swift */; };
+		2C6F5A1EBE532C530235E82BD61F99FD /* MTISamplerDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 653B817921D29F09E0CF496BA38303EF /* MTISamplerDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2C941CAD70A17ABF95467BD24EEA442E /* MTIFunctionDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = B864E44D9A93D5B877CC1FCF099CD527 /* MTIFunctionDescriptor.m */; };
+		2CC3DB5832B311741181C0EF4985AA16 /* MetalPetal-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B2F078B6BC4782A2563EF651AF36398C /* MetalPetal-dummy.m */; };
+		2CFEEC732104CBFDA0593BBD448094DE /* MTIContext.m in Sources */ = {isa = PBXBuildFile; fileRef = BE357AC542883DB4D087D84CC1DDA02E /* MTIContext.m */; };
+		2E22414DFE177F5CDC0E8E3DB09053A2 /* MTIMPSSobelFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 45AA2651BDA08AF62E8A2F4FE9752F5D /* MTIMPSSobelFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2F4CD11750CA53A903990D23FCBF867E /* MTIDataBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD6624F73FC4ED9BC3A4DDD34DCB1D1 /* MTIDataBuffer.swift */; };
+		2FD7A360C133FADAC995A4C2EEE576C2 /* MTIColorHalftoneFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 749C7EA36E5F8012D001DF2695696D0E /* MTIColorHalftoneFilter.m */; };
+		30B0B358A59AA93E2FB24EA0ADA6DABD /* MTIFunctionDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = DF9A879D13E400B915610E773F2F9106 /* MTIFunctionDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3147587BFF33D7EFCA364614BEDA84A4 /* MTIRGBToneCurveFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 613ECCEE272C2A30923E1E7C634B2545 /* MTIRGBToneCurveFilter.m */; };
+		32E90C32A6017CCAD177969332C09945 /* MTIRenderCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 6023C5FC0CA683525D59511FA9B15748 /* MTIRenderCommand.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3351308B052718EF27D84AC4293F33C6 /* Shaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 4B8A56911E6F355A867C448317A24ED8 /* Shaders.metal */; };
+		33EAD62A6528C8912FE3DCA0034056AA /* LensBlur.metal in Sources */ = {isa = PBXBuildFile; fileRef = 0BC009493F548ADCBC1ADE0611B51F95 /* LensBlur.metal */; };
+		356D4CB414E43B057D401A7EAEF9CC75 /* MTIMultilayerCompositingFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = D62FB9CAE1D00D594FF8AA44C1E69465 /* MTIMultilayerCompositingFilter.m */; };
+		35880AA0EC413C004E648AB998D57FC4 /* MTIBulgeDistortionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D339E430650471E788ABF006A21758D /* MTIBulgeDistortionFilter.m */; };
+		3650A36F3749E8D20634918C75F5AAD7 /* MTIRenderGraphOptimization.m in Sources */ = {isa = PBXBuildFile; fileRef = E181A25A6EC0192F4F1DDE8663024BC1 /* MTIRenderGraphOptimization.m */; };
+		38304241A4279B3BF6FDBAA9FA7A9BC0 /* MTIBlendFormulaSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 679A37895EC9F27F8BC5396FC3FEF6BF /* MTIBlendFormulaSupport.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		38B0F34CE93918304B679D698A86672B /* MTICLAHEFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = B59C493FE6FDD5D2B8333AD90A088C17 /* MTICLAHEFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3B9638D435E1DBF1915FC284865B5DC2 /* MTIShaderLib.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C69C797E40401744545441EFEB071D9 /* MTIShaderLib.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3DC8FBEF5DE64BA457CDDBDDC581D9FB /* MTIVertex.h in Headers */ = {isa = PBXBuildFile; fileRef = F2C65459BB7F43240B20E55F19FAF375 /* MTIVertex.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3F787F380BB07C84021ADE48AF1950C0 /* MTITexturePool.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D92E4F5CBED7A5A7D81D9C311029B47 /* MTITexturePool.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3FA3CA0CC3A4FA05A9B9172CBE68E7C6 /* MTIImageProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 160151F161CB13F459B062CED8802237 /* MTIImageProperties.m */; };
+		40CBB048EBF37783A3A8EBCA4974E98C /* MTIPixellateFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6811B094931CE1FEAE894C427B4DE5C7 /* MTIPixellateFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		42B46B986EC9B7511DFED617ACA23784 /* MTIBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C678968CF2E2CC996CC4F70CEED2B6 /* MTIBuffer.m */; };
+		4334F8E7E24EFFD037917DD7BBFEBB4D /* MTIDrawableRendering.m in Sources */ = {isa = PBXBuildFile; fileRef = 99388288BE9BD3B425D97C4AA053BDD7 /* MTIDrawableRendering.m */; };
+		4404ABE4EFE9F2F077A3BC45BD07362F /* MTIMPSUnsharpMaskFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = E6FD6F97D9EFA6B45B9940556F254FED /* MTIMPSUnsharpMaskFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		457AEC8EAD560BC8F124B2EEE5650FCD /* MTIMPSConvolutionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = D10BE2C75A6C593F298042CD00913640 /* MTIMPSConvolutionFilter.m */; };
+		45D86D3A643BB843FBCFAD2AFF01E2A2 /* MTITexturePool.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7FEC3E6303CC592CDFCFD2C903670437 /* MTITexturePool.mm */; };
+		462C237076B2E456AF66A22C9A72414C /* MTIPrint.h in Headers */ = {isa = PBXBuildFile; fileRef = E3FA2955EA8BA3CB3A227F45B4AF157F /* MTIPrint.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4926C84B82919E8FC4B4FC4A98046CD4 /* MTIRenderPassOutputDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 95E031DFFD3F4A30E6F4B6CB0E414B72 /* MTIRenderPassOutputDescriptor.m */; };
+		4A8DB3904C90FB01AE4D66C31626C03E /* MTIDefer.h in Headers */ = {isa = PBXBuildFile; fileRef = 61EFE1B44FF83757530F511DEB7D8BC0 /* MTIDefer.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4AAC1B99A00EF3FE82DD8DAD444D025B /* MTIUnaryImageRenderingFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 13A415962D5F0D1661591580D24DE5F9 /* MTIUnaryImageRenderingFilter.m */; };
+		4AAF13642BB083C79E825B61DED4E487 /* MTIFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0974FB05EEA4A9D10D0B128598790F70 /* MTIFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4AFAAADC14836395017466AB897B4CE1 /* MTIContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ECAB595CC0D66B62BA815F7EDE21F89 /* MTIContext.swift */; };
+		4BBC01776F321209183754F0B300F90B /* MTIMultilayerCompositingFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF0F576E50377C64B8C9F79A55963D4 /* MTIMultilayerCompositingFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4ED711B32823B4B28CE6FF9F4A0C8594 /* MTIMPSBoxBlurFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 916B7A8A1D2A74910A90EAC3A80FECE0 /* MTIMPSBoxBlurFilter.m */; };
+		4EE0790DBBDD36C2184FF94A44010962 /* HighPassSkinSmoothing.metal in Sources */ = {isa = PBXBuildFile; fileRef = 5A94EB3B45C2C5B6C13888F920C4D3ED /* HighPassSkinSmoothing.metal */; };
+		4FAD1120603975C64806288539918084 /* MTIAlphaType.h in Headers */ = {isa = PBXBuildFile; fileRef = C6479525A04A41BA443EE169937ACE75 /* MTIAlphaType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4FDFC8EF5EE0563B9EC8AF23DBEB061A /* MTISKSceneRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 920B9E425DFC7C31D98C55CC861A0F73 /* MTISKSceneRenderer.m */; };
+		50AD818C1A6AF76EC88510DD93E71861 /* MTIChromaKeyBlendFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = EA242206C2A041F41FFF9ABEA6EC9E83 /* MTIChromaKeyBlendFilter.m */; };
+		51DA10A075A8332636D9AC8BE1BA840E /* MTICVMetalIOSurfaceBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 634D3C18B59D7AA2B67EDEA17C00E7EA /* MTICVMetalIOSurfaceBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		538BDDE2ACCDA6F1DE82A86577422309 /* MTIImagePromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 55EFE23113DA1F16D2F4AF25D0FEB371 /* MTIImagePromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		569F2B407C030F71466316A1685399AB /* MTIImagePromiseDebug.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A376CED1F2B72D755F0725F4F267A93 /* MTIImagePromiseDebug.m */; };
+		58C5B8CCBBF2EBCA5349CB11C5E8B009 /* MTIVector.h in Headers */ = {isa = PBXBuildFile; fileRef = 36A21F2F754582A8D6EABA982DB005D3 /* MTIVector.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		59E4CDF4F530997CCB05787F8CAFAC13 /* MTILibrarySource.h in Headers */ = {isa = PBXBuildFile; fileRef = 72E1C5AA10525212DBBD50DC8FCD79A5 /* MTILibrarySource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5DC692C529BA714014BAEFB51FFA61ED /* MTICVPixelBufferPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F3835D9C09A2F3027A6ADD33EB0AE24 /* MTICVPixelBufferPromise.m */; };
+		60AA568123305DAAB16D55D63BFA14AF /* MTITransformFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 481119FA39449CC292F9E2FA10EF270E /* MTITransformFilter.m */; };
+		60E649524955B67DA54ED0F13A115468 /* MTIMPSBoxBlurFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 72091B0D243215EAC1AC78211BC1D1B5 /* MTIMPSBoxBlurFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		626190EA7A33D05CDD96B9E2FCD4FB37 /* MTICVPixelBufferPool.h in Headers */ = {isa = PBXBuildFile; fileRef = FE331423244833C1C311ED905A3894E1 /* MTICVPixelBufferPool.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		64290F8F8BC85CCBE13C2B4DD6BECB13 /* MTIMemoryWarningObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 03211368F7652876292FE0561439A47B /* MTIMemoryWarningObserver.m */; };
+		6449F0681567C028ABF2DE8758E1DFF3 /* MTICVPixelBufferPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = ACC3B9BA82EAA846CB3E21DFC42B65BC /* MTICVPixelBufferPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		650F3BECA2FDDB4C09BB9D1803255761 /* MTIKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 52B9D0F2C4A0C54888681D4BFC252079 /* MTIKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		652CC49CF8EA8ED016D3C8640C0DCCB7 /* MTIMask.h in Headers */ = {isa = PBXBuildFile; fileRef = 2AD0C95DE4CC49839465DDBE56B4CB27 /* MTIMask.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		65375EBB76517260B072F274EB469FC5 /* MTIThreadSafeImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E2341333D2619A04032BC32C2D225A0 /* MTIThreadSafeImageView.m */; };
+		670D500ECA12E6C6EE32529B792231CA /* MTIMPSGaussianBlurFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 91C7F17C15A73D10297190DF6CBC4825 /* MTIMPSGaussianBlurFilter.m */; };
+		691D77915207B03BD19F7D2C39C7FBDC /* MTISCNSceneRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C47F8067AA6C4C6BF3396C40AE9C233 /* MTISCNSceneRenderer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6A341E8BEAE279B399034D12A5F7A877 /* MTILock.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C4A0F1CA12FECB5365A8153685A66FB /* MTILock.m */; };
+		6AF14D006FC25963B5BC36E8408E7CC2 /* MTIRenderGraphOptimization.h in Headers */ = {isa = PBXBuildFile; fileRef = CA86E9784DC4C48C67C3DCC6FB024DCB /* MTIRenderGraphOptimization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DD8432302789E2226F4697B9E63DADC /* MTIImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 57BB3E1A59896225D1F028327734D60F /* MTIImageView.m */; };
+		6FCB27E858A816715BBF9F7E58B176FD /* MTIHasher.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C78A301CC30E1A77B3474864AE36D7A /* MTIHasher.m */; };
+		7281C81A9614CE8D6A9D969CF17F15A3 /* MTIColorMatrixFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5469D751D199F91FBF290D13B15EED78 /* MTIColorMatrixFilter.m */; };
+		72E7AE45D47F7623060BF4E4C6B2DDDD /* MTIColorMatrixFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CB5FEAD683A0979A40A4A5AF0C5C62E /* MTIColorMatrixFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7353E439E187FE737191FC56A94CC2C1 /* MTICropFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 29CF2B191746FE13A8E3A7C5A7F859D8 /* MTICropFilter.m */; };
+		73B207C3DC66DBE0A9C7B460305E7BAA /* MTISamplerDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = F129A8C0AEAD9A4A17CDD39989E2FF52 /* MTISamplerDescriptor.m */; };
+		76D148FACCBDB25A61CBFD414491939E /* MTIError.m in Sources */ = {isa = PBXBuildFile; fileRef = EEEEA1D2382D37319085A3C7E019A115 /* MTIError.m */; };
+		77DB477EC2E0D66B668B15D2035A5DF2 /* MTITextureDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 1765F24DA26B8F34E3FE119C1FD84487 /* MTITextureDescriptor.m */; };
+		7808BEB6CCC017FF604AD43F44840260 /* MTIVertex.m in Sources */ = {isa = PBXBuildFile; fileRef = 022EFC32DB63E480A2840CD46BC4C4F0 /* MTIVertex.m */; };
+		78501A658F1B27E23D4E5E5122274AEE /* MTIColorLookupFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D7E129DCBA4E7779C331C7F17C30EA5 /* MTIColorLookupFilter.m */; };
+		7E316047F3BF026ED84DEC994F599B90 /* MTITextureLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 75A8528944308AB6F22335710D46D955 /* MTITextureLoader.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7EA6C6A72AABED612880D199F16D56E1 /* MTIImageOrientation.m in Sources */ = {isa = PBXBuildFile; fileRef = 7FE5E3474304EBC74E4D050B97716F4F /* MTIImageOrientation.m */; };
+		7F62CFF867A2E540C904DD55CA6E3419 /* MTIImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 398B73A915C2D59188AA9D5D4FB70E0D /* MTIImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7F88239EA123E3DB2562E8B02A7CD544 /* MTIRGBColorSpaceConversionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B0E1E9318A1609CA3E5DA382AC9B832 /* MTIRGBColorSpaceConversionFilter.m */; };
+		81640022F2679B7DE7AB4828673A7EC5 /* MTIVertex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100B284BC49A631F68D0E68CC834E220 /* MTIVertex.swift */; };
+		82A83E087EF4FBBBF82FE29B3AC34802 /* MTIImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = B1043298318B39A854A07DADB624A814 /* MTIImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		82FA0178EC14043F58D279B7B29CAA09 /* MTIComputePipeline.m in Sources */ = {isa = PBXBuildFile; fileRef = F2856969EB19D2C5D930FF3F776944EE /* MTIComputePipeline.m */; };
+		832A44208293731E10EAF7006E321625 /* MTIHexagonalBokehBlurFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 05A3AB28CC8F9CB607C20FF9BF7B72B7 /* MTIHexagonalBokehBlurFilter.m */; };
+		838C612F726AFA34DDA79C7B3555BD1C /* MTIComputePipelineKernel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0321876584FA0BB1552C24FE09DCB1DD /* MTIComputePipelineKernel.swift */; };
+		84512654E46E733D130919BEB4B9AB32 /* MTIChromaKeyBlendFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 25F2A7EE45AA430E6C49A5504107E6B8 /* MTIChromaKeyBlendFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		84BDCAD89AAE5FB5C49AEBB136FF90C8 /* MTICVMetalTextureBridging.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FE8837A7BB63E3F7156A222C5073B03 /* MTICVMetalTextureBridging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		853F56FA7F9D8A31365D702338C1E89B /* MTIFunctionArgumentsEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F1584D72463FD5A4B2317C6B619EE44 /* MTIFunctionArgumentsEncoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		854721C2A67D5CA74C66F2A5159CBCD4 /* MTIVector+SIMD.h in Headers */ = {isa = PBXBuildFile; fileRef = CE669A1E167194251732A995A577ADE4 /* MTIVector+SIMD.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8737DB627F284DDC40CDA8307B4C5D13 /* MTIImagePromiseDebug.h in Headers */ = {isa = PBXBuildFile; fileRef = 25BD9BA7AE2F69C2CCBA1A2B35F105E1 /* MTIImagePromiseDebug.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		87B713C4F3F5626D140463998A371503 /* MTIGeometry.h in Headers */ = {isa = PBXBuildFile; fileRef = E920DDB803B2B025ECF52E333E3C019D /* MTIGeometry.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		88BE36D2E0EE170397A8A9066946D530 /* MTIImageViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FEE9C959BFEECD7FA4614F6E385E0FC /* MTIImageViewProtocol.swift */; };
+		8B662F2DD2A352ACD74A5099FBA8B914 /* MTIRenderPipeline.m in Sources */ = {isa = PBXBuildFile; fileRef = 34079501D0E96E94E89259340717F0A3 /* MTIRenderPipeline.m */; };
+		8BCBD14A8B11443FAC910B05541079BF /* MTIMPSDefinitionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 160B83A6C820B95BD6210C47EC70DA1A /* MTIMPSDefinitionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8ED3216B604019AD6C90A8B00DDDD722 /* MTIBulgeDistortionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B26C9F98C517A01E012AE6D18C62AFB /* MTIBulgeDistortionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8EF1BD54CE206B851F39845D6875EC25 /* MTITextureLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = D114BA13F24EF82E279FF3669CBD77AE /* MTITextureLoader.m */; };
+		90E46628B756C1881FCC6C8591180F7F /* MTISCNSceneRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = A6F34B48D4ABB15DEEBE2FD171A20847 /* MTISCNSceneRenderer.m */; };
+		929EF105D30DBA9FC2AFD8ACE8E5625B /* MTICropRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D49B2552395A22B949533199A9EE699 /* MTICropRegion.swift */; };
+		934F9DFA5E1DB1F3C45930B49C52115B /* MTIColorMatrix.m in Sources */ = {isa = PBXBuildFile; fileRef = 05A4935EB223201339B14A22D2FE7845 /* MTIColorMatrix.m */; };
+		93575BBE79C9204C6947F3A8A773CD28 /* MTIAlphaPremultiplicationFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 79655AC00AED64FE8A16577D885ECAC7 /* MTIAlphaPremultiplicationFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9654E8FB3309E09ED60BF8A36ABCFE77 /* CLAHE.metal in Sources */ = {isa = PBXBuildFile; fileRef = D3C7B6E32479024359634B347A91E0D4 /* CLAHE.metal */; };
+		967095322D748161E0C306ACDBA7776F /* MTIVibranceFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = B30F1E69C911CB2468E77FA1A76A14E8 /* MTIVibranceFilter.m */; };
+		9733E3BEBEF875D093F21A935D3DCEC0 /* MTIImage+Filters.h in Headers */ = {isa = PBXBuildFile; fileRef = 192A23E62DCDA7FA27C5C2EA04252460 /* MTIImage+Filters.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9C3C665FD93CB440DDB3DDB180D666B8 /* MTITransform.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E80B756B982A36B3D292D6C93A900B9 /* MTITransform.m */; };
+		9CED7054D9E64E20CC3C8922B358429E /* MTIMultilayerCompositeKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = A2A5AE3DE15150AF151C33405438F5D7 /* MTIMultilayerCompositeKernel.m */; };
+		9D48D2740D1F480B7EA37293C92DDDF9 /* ColorConversionShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 02579605A28E576467C92615450AC894 /* ColorConversionShaders.metal */; };
+		A09798D3E0485B1BDF2D1159AD1F0D6A /* MTIMPSDefinitionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DB26C42ECC81541575FED2660982F3B /* MTIMPSDefinitionFilter.m */; };
+		A630EA528AC31959CBAF4DF5A61877D8 /* MTIHexagonalBokehBlurFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = F83F1920910E673263CFB9E45D61E24B /* MTIHexagonalBokehBlurFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A6FBCA0414DDE5118FAF896BF2B4A6B0 /* MTIImage+Filters.m in Sources */ = {isa = PBXBuildFile; fileRef = FCA76D8C59404EABF5C3DF143DD12B02 /* MTIImage+Filters.m */; };
+		A74F5882279DE00122527B0992F129C8 /* MTIMask.m in Sources */ = {isa = PBXBuildFile; fileRef = 42CA419BDB2F8F6E46CF3B582812299B /* MTIMask.m */; };
+		A8B0C1B8F7C3C81DF925719DCE96F361 /* MTIRenderTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E41DBB1BD4BE7CDA82345FE6D53A524 /* MTIRenderTask.m */; };
+		A918483DB7EBA3179758B3A6A803A546 /* MTIBlendModes.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F369250749CEA3FD05B2E2E6D8BEA0C /* MTIBlendModes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A930D521094735675ED6EF7D81E2380C /* Halftone.metal in Sources */ = {isa = PBXBuildFile; fileRef = 536313D4BBEFB5BD20C7CAFA097AB693 /* Halftone.metal */; };
+		AB825C96313F2D64A04A2C7AA0AC200F /* MTIFunctionArgumentsEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D780E63B6B0F03C292D25BC4BF52CAD /* MTIFunctionArgumentsEncoder.m */; };
+		ABDE47DAF578307E3ABB789DF1E2986E /* MultilayerCompositeShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 270481E63FC9B9128C135FD1450ED4B8 /* MultilayerCompositeShaders.metal */; };
+		AC6F7FAFFC3A4C80A764EC46862794A1 /* MTIPixelFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839828DBAF7622F615BED791E9F0DE2C /* MTIPixelFormat.swift */; };
+		ACA4B7AF569A08682EFBBED475979CE8 /* MTIWeakToStrongObjectsMapTable.h in Headers */ = {isa = PBXBuildFile; fileRef = A324DCB96C0FFFE3FA21C097A7126AC3 /* MTIWeakToStrongObjectsMapTable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ACCBCC1A2B6F357C7E4F85644D6B7070 /* MTICropFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F95686506292531717C3231DFA16277 /* MTICropFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AD29301E4621DEAF20925A0BB0565DFE /* MTIShaderFunctionConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = B2EAA5288D9AB128D1D2C4232528F283 /* MTIShaderFunctionConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AF06E2759550E9C8867FCD94498C8AF7 /* MTIVibranceFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F9593BD03FF7F10C70BCF33A3B18A1A /* MTIVibranceFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AFABF7D47D8D0ACCB071B49DD423755C /* MTIHighPassSkinSmoothingFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = ECD39D4C09DA6FBAF0A4054864838409 /* MTIHighPassSkinSmoothingFilter.m */; };
+		AFD42861CD6D786BA57E61BF2A066684 /* MTICLAHEFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0315CB67BA8D16F62E325BE549C850AA /* MTICLAHEFilter.m */; };
+		B2A28F5EA5CBAB25C1261464CDEC917B /* MTICVPixelBufferRendering.m in Sources */ = {isa = PBXBuildFile; fileRef = CFED737389BF486E8363CCF28E2DA40D /* MTICVPixelBufferRendering.m */; };
+		B2C5CB07F7BFB833212D538F1FF730D8 /* MTICoreImageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1781EE46FE30A1C38E19F36EF1B44B5 /* MTICoreImageExtension.swift */; };
+		B335759158334C4637AB2D1BA3A56478 /* MTIMPSConvolutionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 64DF907002280C8330B8478F6D16DCA9 /* MTIMPSConvolutionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B41C90DD0AEF1E8EE37108D49DF11BF9 /* MTIGeometryUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 70373E960472CA0797C7F4DD8668BD94 /* MTIGeometryUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B70642002F13A46D5A9244232C1419C4 /* MTIDefer.m in Sources */ = {isa = PBXBuildFile; fileRef = 6222FCFB35B35E00038476E09741B9EA /* MTIDefer.m */; };
+		B7907F4A69045D59E6282080B0DDD110 /* MTIColorMatrix.h in Headers */ = {isa = PBXBuildFile; fileRef = D0C2E2A565343BD3C34EF9EE7761C03A /* MTIColorMatrix.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B93B80DF5C1FF46F8FD4A3D664B3981A /* MTIMPSHistogramFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 586EF6F15845B15A7B646405D9F07074 /* MTIMPSHistogramFilter.m */; };
+		BA47FDB89DB71E47D75D822B0E253168 /* MTIHasher.h in Headers */ = {isa = PBXBuildFile; fileRef = B4265EEB236C009CB0DFDF4D954F33AB /* MTIHasher.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC53E42E1163DAFEA0CAAA38B9BFBEC0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73010CC983E3809BECEE5348DA1BB8C6 /* Foundation.framework */; };
-		BD3B960CF36DA9491571FCAB1F618282 /* MTIRGBToneCurveFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = C4E271B5D630FF9B70789A757064FF56 /* MTIRGBToneCurveFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BD4365D2341CCDD17B84FB44D3998D3B /* MTIVertex.h in Headers */ = {isa = PBXBuildFile; fileRef = 83777152C6ACEC39F21DF11858ADA6A7 /* MTIVertex.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BEB05302997E0BA4883B8156B5B91C05 /* MTIRenderTask.m in Sources */ = {isa = PBXBuildFile; fileRef = B201151C616B126936CFBF624AB97D7B /* MTIRenderTask.m */; };
-		BEBBA61043CDDE9F83A36D52EFF5A564 /* MTIMPSConvolutionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 364B67452ABEBD63BF0E129E642B487D /* MTIMPSConvolutionFilter.m */; };
-		C01909C946A6A9EC4AAB3093E21FB1B0 /* MTICVMetalTextureCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A349F92F03DC2A923845D2C00AF9486 /* MTICVMetalTextureCache.m */; };
-		C1DA89613002FF0643B231EB6DA61645 /* CLAHE.metal in Sources */ = {isa = PBXBuildFile; fileRef = CC960FB45A6A1F47881BFA02883F1C96 /* CLAHE.metal */; };
-		C1E1AEE4A6A6DD6B7CF3B2E85B3AD864 /* MTICropRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D49B2552395A22B949533199A9EE699 /* MTICropRegion.swift */; };
-		C20DBBFC6F45A1F91C23F029CA662443 /* ColorConversionShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = E186B4EF06532CD3702854030AC50048 /* ColorConversionShaders.metal */; };
-		C2177E897495535695C1430896A67E9E /* MTILock.h in Headers */ = {isa = PBXBuildFile; fileRef = 376981EFA3B717CCE86297270C7B2E58 /* MTILock.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BC5741B8DBB7F5E0B8E6D6F4A2D2CC01 /* MTIComputePipeline.h in Headers */ = {isa = PBXBuildFile; fileRef = 13126AEAEF3D8AE022EB95AA6D2FB2D6 /* MTIComputePipeline.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF81EFDB7AF66684121370E86B74FDFB /* MTIVector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BBD017E0C9B38AD87CD2738749CDF1D /* MTIVector.swift */; };
+		C211BB06A425BB8383D31E4D814630D9 /* MTIError.h in Headers */ = {isa = PBXBuildFile; fileRef = 89A372D6E21F515D9907A8A5523C3F8A /* MTIError.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C24395B390A955134E2F8C004C5A0A41 /* Pods-MetalPetalDemo-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F38A5141FF45F6DFB2B3925DB311442 /* Pods-MetalPetalDemo-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C2AD77EE173722AC9DB7851B9CE04E7B /* MTIImageRenderingContext+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 935FDC03670DF769B93631BF0ECFB04A /* MTIImageRenderingContext+Internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		C4744A26A3E6B7B8C12EE354ED48217E /* MTIAlphaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214952C0D3C410E24A6CC3A99D7FEA0C /* MTIAlphaType.swift */; };
-		C5D4B1B3333C955AC974F0774EB1C9AD /* MTIColorMatrixFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = C9989AE6C184FA9CD9DD586953E3433A /* MTIColorMatrixFilter.m */; };
-		C79057578A3E86F27F9044AFCC648590 /* MTIContext+Rendering.h in Headers */ = {isa = PBXBuildFile; fileRef = FDE03ED95EE77C567C4AEF8E5A1513A0 /* MTIContext+Rendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CD299378AB0A539C4A4C520098135F0D /* MTITransformFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = F045DF47046828B214B57A01EE2CE1CB /* MTITransformFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CD4F1934A4EB9DB3B823D9B127199A2D /* MTIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B979E33E65E208114577BE0065A178 /* MTIColor.swift */; };
-		CDFCDC8332315D1D9F6BC9977A10D6C4 /* MTIVertex.m in Sources */ = {isa = PBXBuildFile; fileRef = B76A35A22A307B122ADDC35870B575B8 /* MTIVertex.m */; };
-		CEBB00741F9CD3504749FAB13236576D /* MTIComputePipeline.m in Sources */ = {isa = PBXBuildFile; fileRef = 771793A2A60E4341F83C7FC36DDB4216 /* MTIComputePipeline.m */; };
-		D0F3177DBBC407530ED561EA6DCE6B84 /* MTIFunctionArgumentsEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = E6D6D3137D202883FCD337168C3410C2 /* MTIFunctionArgumentsEncoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D184DAC9399E6F387FA56CE68CE87150 /* MTIFunctionDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 22F41B70EACCBF98657AD2CC6A9D6892 /* MTIFunctionDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D3DCB4A0D4F533D71EC28DB3D60A7E69 /* MTIRenderPipelineKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = C1C5EDF47FF82766EF253886656FA74A /* MTIRenderPipelineKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D4A011F0ACEB46DF34C8AB2211B71AC0 /* MTIRenderPipeline.m in Sources */ = {isa = PBXBuildFile; fileRef = BC5E0F4AB88F9140148CF4FCB36FA836 /* MTIRenderPipeline.m */; };
-		D533A7F7730E969E0689DD048E71BF8E /* MTIRenderCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = A8F7E869E863C72F0010F9451DD1B502 /* MTIRenderCommand.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D5A9469F11BAB1C79B648C7B8616EFF9 /* MTISIMDArgumentEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6956F80885792D34F389794FF5515D9 /* MTISIMDArgumentEncoder.swift */; };
-		D600241BB3EE423421DF158148F5644F /* MTISamplerDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = ABF631EB1B40A6CB8DFBA45BD271EACE /* MTISamplerDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D68BF9BD7CAA3A8743D81C3035EC5E1D /* MTIDefer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C40AB7CDF7B77E1AB437A2CD2801C78 /* MTIDefer.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		D71ECF9577BF14E2E5F93E82FF207FC4 /* MTIImagePromiseDebug.m in Sources */ = {isa = PBXBuildFile; fileRef = CC8245F807EEDFD9F98FCEF1B351D3C7 /* MTIImagePromiseDebug.m */; };
-		D9937743F7B68F6A1CA74E1B13B6B1C8 /* MTIVector.m in Sources */ = {isa = PBXBuildFile; fileRef = A5796517B48A5D5532483528B2CAC31B /* MTIVector.m */; };
-		DADF1F6AAB71DD46EB1370E588836705 /* MTIHighPassSkinSmoothingFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 70CF84F0A31BE3EDBE794B17389DBEE9 /* MTIHighPassSkinSmoothingFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DB30A62752A717127A6A7A3DDA1573F8 /* MTIImage+Filters.h in Headers */ = {isa = PBXBuildFile; fileRef = 090B8FDB5B7BA5A225CCC8D51A5CDB62 /* MTIImage+Filters.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DD13274A660A947EFAAF57191277A57D /* MTIVector.h in Headers */ = {isa = PBXBuildFile; fileRef = BF690F8C9F79671A66CE8E9BE6A6D5E0 /* MTIVector.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DEA8060DCCF5188CE7CEFE83B9C970FF /* MTIMemoryWarningObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 827513924F896DCB764FE701AEFCA9C5 /* MTIMemoryWarningObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E0BE0D74D78F65D2779D25F55D184D49 /* MTIMPSGaussianBlurFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7963DF11BA0077E8E375441D92A514C5 /* MTIMPSGaussianBlurFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E1230FC444EF9C7E2C47209CC8456FAE /* MTIFunctionDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 79598357110B01300FE1C1C13EC4782D /* MTIFunctionDescriptor.m */; };
-		E13963DF90A2CE9B6B2680B0DA9499E1 /* MTIVector+SIMD.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F9DF86342B4EC11138454DF936D55D4 /* MTIVector+SIMD.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E21B17495886AF401B9DB5F70E136790 /* MTIContext+Rendering.m in Sources */ = {isa = PBXBuildFile; fileRef = 76CEB5758B60E3B42FB780A8BBEE75B4 /* MTIContext+Rendering.m */; };
-		E32C84C2BE854A6675E0BD7826082A5D /* MTILibrarySource.m in Sources */ = {isa = PBXBuildFile; fileRef = 0447D7BAE13A371E68D47BA41528269A /* MTILibrarySource.m */; };
-		E3582B390C5E78F7476812590EF75B09 /* MTIBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = C148193F3B729CEFD8B8A282D4E0B37B /* MTIBuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E50D612F58EA3C0EF605415286320718 /* MTIImageOrientation.h in Headers */ = {isa = PBXBuildFile; fileRef = 78C43373C8E7DC3522A292CB68C4BE9E /* MTIImageOrientation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E5A0B355772EF3CD18B898143B51C4B8 /* MTIError.h in Headers */ = {isa = PBXBuildFile; fileRef = A817A8F3ED1400371D5A3C53DB9C48CD /* MTIError.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E67A3749F4E272E0665C1585008B404B /* MTIRenderPassOutputDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = D2696BB30F7D660904F5CBC010AD3415 /* MTIRenderPassOutputDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E6C97D71D7F7B233A111A11641F4067C /* MTIThreadSafeImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C70E88E5545B63745C2B2D3AB03EE68 /* MTIThreadSafeImageView.m */; };
-		E73983A93F093C178853AA21BD3F8E46 /* MTIHasher.m in Sources */ = {isa = PBXBuildFile; fileRef = 46BA53C30D5C5BD0640A42DDFEC91E33 /* MTIHasher.m */; };
-		E7F0A3F123FBC70104D5A03AFB1C4E34 /* MTIRenderPipeline.h in Headers */ = {isa = PBXBuildFile; fileRef = 17448C2E4F9235E3A1EBB2ABCF84A0EE /* MTIRenderPipeline.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EACB460EC51B3C4AC8B3919C92463022 /* Shaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = E78BAFBC08B2773B47E9449DA6A8D336 /* Shaders.metal */; };
-		EAF3A27D495F10A67F65BC5054F6D78B /* MTITextureDimensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1404B4E201A66CED54798A0A414FCF /* MTITextureDimensions.swift */; };
-		EC5E87C609337EC078A161E55FA3EA84 /* MTICropFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 093995D246B4AF578FA9A29F74011A90 /* MTICropFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EC625119930CAB8AEE083926C2DE9EDA /* MTIVertex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100B284BC49A631F68D0E68CC834E220 /* MTIVertex.swift */; };
-		EC8179F9C2BBC79FF821D645357E830B /* MTIRoundCornerFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = A78EE2CA9D1B0F614AF227FD4FA86A07 /* MTIRoundCornerFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EE819AB76B99F835CC72CBF723BD4898 /* MTIColor.h in Headers */ = {isa = PBXBuildFile; fileRef = 84CB0268F88EE6A80D8F07052EA7A69D /* MTIColor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EF5F00F5FC69AC206E3A7CA8892A71BD /* MTIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241E42C19758A9944F92C41B6E272F19 /* MTIImage.swift */; };
-		F2F0E55A232691FFCE4CE048ADCCF119 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E069528B6E4B104DF5E3FB5CA9DDE988 /* Filter.swift */; };
-		F4677B5BC0EA7448ACFBBD1A3C21810E /* MTIDrawableRendering.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DDF88D24AECEEB18B2D9B4288BF6C02 /* MTIDrawableRendering.m */; };
-		F48AB242701A1F71340F8980120758E8 /* MTIColor.m in Sources */ = {isa = PBXBuildFile; fileRef = C020930B4362CBF063F0EAAA6162FF45 /* MTIColor.m */; };
-		F70B755C991376176C2D19BFA2AEE6E3 /* MTIBlendModes.h in Headers */ = {isa = PBXBuildFile; fileRef = 9081AA72F478E687A6E8F3B5D7D2C695 /* MTIBlendModes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F713AFE06A4216E391948FA305F91F95 /* MTIRenderGraphOptimization.m in Sources */ = {isa = PBXBuildFile; fileRef = 78BE5AC27645F3E7CB1D1BD955CF9C7A /* MTIRenderGraphOptimization.m */; };
-		F714FE715FE0121490ADF2DB366DFE91 /* MTIVibranceFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = E11B72D9BE78E58E2A89D94CFDD502D4 /* MTIVibranceFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F77F23C585C3A4F70948CDEDFE458625 /* MTICropFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = B123F941C7582F65A46EB59FABF250A4 /* MTICropFilter.m */; };
-		F8B460900644C603859685E6611399B4 /* MTIImagePromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 462DED185217EBC002A82A9BC744ACD5 /* MTIImagePromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FBE3F0A99E9E049C11FF3E0A08EF823E /* MTIDrawableRendering.h in Headers */ = {isa = PBXBuildFile; fileRef = 42D226BA2B4C19500965081D4EA294A7 /* MTIDrawableRendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FE6A68DDFA8124A3CE10FD3CB626F083 /* MTIMPSGaussianBlurFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F4A6393034641F4798CBB3D2C79BF27 /* MTIMPSGaussianBlurFilter.m */; };
+		C2E1A134E22B3A5381B05989BDFE1CD2 /* MTIImage.m in Sources */ = {isa = PBXBuildFile; fileRef = B595DAD1C234B1F70C90D054860B0FB6 /* MTIImage.m */; };
+		C4EB6B41B274093BBF19F1F70CC9A7B3 /* MTIMPSSobelFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 14E519B47E9A4B0DCB1B499D58E2D170 /* MTIMPSSobelFilter.m */; };
+		C689E8509CC06A5B312398E0CC844C16 /* MTICVMetalIOSurfaceBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EE350F6CCD35817F08499268062BCEF /* MTICVMetalIOSurfaceBridge.m */; };
+		C81D2C1CFF6AABC745CE4564C246874A /* MTIContext.h in Headers */ = {isa = PBXBuildFile; fileRef = FB66385CD659C33619A6F89BC435A041 /* MTIContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C9D32FC9F8879096FF0750B1B0707675 /* MTIGeometry.m in Sources */ = {isa = PBXBuildFile; fileRef = 178E40ECCDB78DB0FD9B2D40AD655F24 /* MTIGeometry.m */; };
+		CA173D62E1D8921EB7AF1954C0FD96CB /* MTIBlendWithMaskFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = FE6915BEFC927DF11C1D78E302D60A1F /* MTIBlendWithMaskFilter.m */; };
+		CC1714E306B6AA0497B6C9580E513839 /* MTIRenderCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = F6E359C6A48CB2155DF5A0DDA9632E35 /* MTIRenderCommand.m */; };
+		CD2BAF74A16C5883C0BE0E602A94AC11 /* MTIDotScreenFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = CBD8D80E592D7A2183E4F190A68ADBAA /* MTIDotScreenFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CD483FF9971A021F978E934FF73DB01B /* MTIBlendWithMaskFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = E4EA106367C04661E8A3F5B965F7BE99 /* MTIBlendWithMaskFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CE91E07A48EEDD50924B3472D7CB198D /* MTIComputePipelineKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 134654EA038168008A67DE508D6D4B07 /* MTIComputePipelineKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CE96E1F4E916D861C67FF99713EEF12A /* MTIColor.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D8F08D4FD37615A67EDD83D4E2176B2 /* MTIColor.m */; };
+		D03F7058CBA660F29C9588C009991F4E /* MTIColorHalftoneFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 39CE823D2A843F63980FAC74D614FFB5 /* MTIColorHalftoneFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D0C8205D4F22F893A479320EDD6CB3C8 /* MTIRenderTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 58DB4177664FD7FE0CE6C226EBD618D1 /* MTIRenderTask.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D1D4CEF7F02C8F039E48D336D8BD0D10 /* MTIMPSUnsharpMaskFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = E37586BF578B4525A0B57C8582D0806F /* MTIMPSUnsharpMaskFilter.m */; };
+		D3C865485216B38CCCE626BF1C074066 /* MTIImageRenderingContext+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 89FEA9B7C91BC359581BACDC57D6F8B1 /* MTIImageRenderingContext+Internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D7AE8BC7F22EF0DCFA8707DCE962474B /* MTIColor.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AD143EFB1556A622006CAA5324049C6 /* MTIColor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D8303A335A94E9B3F5E37BE375281FF3 /* MTIFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A10021480415F41B3C4DC24B3A10E2B /* MTIFilter.m */; };
+		DABCB0BFD3F345376B8C8BF01C0FDEEC /* MTIColorMatrix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 817E2B62184F77F2F437A2226E162A67 /* MTIColorMatrix.swift */; };
+		DD3BA56237655971064D5FB14C793F6D /* MTIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AE1C4BCC9E523CB4012128BBC15D1A /* MTIError.swift */; };
+		DD4E435727CF5FDB8CAD56BAD37F7BF3 /* MTITextureDimensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1404B4E201A66CED54798A0A414FCF /* MTITextureDimensions.swift */; };
+		E5B263707D1AB01CCE420DEBB39AAF7F /* MTIImageRenderingContext.h in Headers */ = {isa = PBXBuildFile; fileRef = B7C61DED1E4EFA9CB46233160E9F2EBB /* MTIImageRenderingContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E631648C269B7D2C20C945069BCEE80B /* MTIMemoryWarningObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = F504AA4539923C2283DCECE5B242F5E5 /* MTIMemoryWarningObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E6956AF5301FDF57F2F3FB60F3925669 /* MTITextureDimensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 062C600B5E9D962937EBDC1A4B9323F4 /* MTITextureDimensions.m */; };
+		E87C1B5D104B7CC61B6468398450A7F2 /* MTISKSceneRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = A1BEE5582D885439E9BF198942052088 /* MTISKSceneRenderer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E882D2881B31F263E764744FD078EB5F /* MTIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B979E33E65E208114577BE0065A178 /* MTIColor.swift */; };
+		E923FD1B6306AF86DB699B5AA59C35A3 /* MTIRenderPassOutputDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = E38442D57A8DACAF91730D558EF79B1F /* MTIRenderPassOutputDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E96B05D8F42FF5777C54C49919696B86 /* MTICoreImageRendering.m in Sources */ = {isa = PBXBuildFile; fileRef = 2898A7973E4E644DA8B782690238C0DA /* MTICoreImageRendering.m */; };
+		EA019E9373A79CE5E591D55DA21ABC00 /* MTIRenderPipeline.h in Headers */ = {isa = PBXBuildFile; fileRef = BEED677BCAF818A7E241223566B45F4F /* MTIRenderPipeline.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EEB36FDC4BA0808B7E9EA472FBCAAB8A /* MTIImageOrientation.h in Headers */ = {isa = PBXBuildFile; fileRef = 68B5CCEC43F83625FC32B5302B7F9477 /* MTIImageOrientation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F0111708E4176F86CEED2BC9E5E9D2E8 /* MTIMPSKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = CE50B20A2C3620CCEFE6014D9DB6DA65 /* MTIMPSKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F0A09B39DDD4924417523867E1B765FF /* MTIAlphaPremultiplicationFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 148B6092CB5BC775E49FEE4A67E1B376 /* MTIAlphaPremultiplicationFilter.m */; };
+		F1D0F5FB6636690DC10F301C2F207084 /* MTITransform.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E3210E6A5683F8D448047A8D153D3D2 /* MTITransform.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F1F802B8294DA527936ABBC49D18F13D /* MTIMultilayerCompositeKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 8DD28B6BAE689B1C53CE1071A179D5D7 /* MTIMultilayerCompositeKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F2E1CACEF29FA5F190A52BBFFC43DA2C /* MTIPixelFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = A7B9C14E61E56A83D9368EF3A09C8C61 /* MTIPixelFormat.m */; };
+		F4CE9BBC2F98ED3854D061CC4143308E /* MTIRenderPipelineKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 1190F7C1CBDDC5F4E9758676F2AE014F /* MTIRenderPipelineKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4CF88845D7CEDCE963B54334E332DB8 /* MTIRoundCornerFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 175A887448859E15D78AA5E7AA8EE781 /* MTIRoundCornerFilter.m */; };
+		F4EDB4EAF66F1646A98187A3346A974D /* MTILayer.h in Headers */ = {isa = PBXBuildFile; fileRef = A48BB00E5FA51B17E49206D3648D8B16 /* MTILayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F518B9AA384F7677041283D63A233EC3 /* MTIRGBToneCurveFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B854D2B3F34C29959D5D41EC66080F7 /* MTIRGBToneCurveFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F613F627FA63215FB7959436725C4FF3 /* MTIVector+SIMD.m in Sources */ = {isa = PBXBuildFile; fileRef = AD17B52170742E4D3F0FDBEB6BEDDC11 /* MTIVector+SIMD.m */; };
+		F698E07D93F5A68D3E298C9BFC7A8011 /* MTIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241E42C19758A9944F92C41B6E272F19 /* MTIImage.swift */; };
+		F6AE96C842B5416B0866733FC1FCB992 /* MTIColorLookupFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = BCA1A737A5543861CFCF486A4BEAD173 /* MTIColorLookupFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F7BC844B982006EC3D90FAAFC969C062 /* MTILayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 57FB1E7FCF1B44DA4A5E7F23EB244A82 /* MTILayer.m */; };
+		F9C3C24765AFF0950E72ECC90A49FD08 /* MTIAlphaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214952C0D3C410E24A6CC3A99D7FEA0C /* MTIAlphaType.swift */; };
+		F9C7D14DA731F161D29ED3B983B18507 /* MTIMPSKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = C32FC755A52CE99E274D243DB60DDB3B /* MTIMPSKernel.m */; };
+		FACE822E597DE8650116E87A7F47E166 /* MTIBlendFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = CF241CDA8F6B441BB4953C664E14CBCB /* MTIBlendFilter.m */; };
+		FC9462BBCBF192C37A5C5E6467448E69 /* MTIPixelFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B3EF613A9DF583F91FD2B6CEC95D6F8 /* MTIPixelFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FCA274E613746ACE3E3DD6A137B95F0D /* MTIGeometryUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 27C22BD1826DBD424CB535FDE5EAB186 /* MTIGeometryUtilities.m */; };
+		FD82EFB5227C1C9108A330E35A231EA8 /* VideoProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605086DE5E2520BECAEBB726AA053DF1 /* VideoProcessing.swift */; };
+		FE7958DB1FE99AC16921E1D08089F1A1 /* MTIThreadSafeImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 208E775116CA33DAECD4A32A6B6CE97E /* MTIThreadSafeImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FEA3D776AEDB52F22D23306180309C1A /* MTIImageProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = 490807A8C291D7C2E0BD9F2E16A646E4 /* MTIImageProperties.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FF2E2A4EC20B11AB3E7C28D8CCE18186 /* MTIRenderPipelineKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = A4A858DAAD6A965BCF2E594658D583AB /* MTIRenderPipelineKernel.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		86EF2AC7576268F092FB297A9C34B68C /* PBXContainerItemProxy */ = {
+		D934680802A8F2D1D3D4FCEB7CB55CA6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
@@ -239,238 +240,239 @@
 
 /* Begin PBXFileReference section */
 		005DFD14213AA63B85AE55644C51BEA9 /* MetalPetal.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = MetalPetal.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		017E8CEBEC7896E0BD86B0BFC883F38E /* MTIAlphaPremultiplicationFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIAlphaPremultiplicationFilter.m; sourceTree = "<group>"; };
+		022EFC32DB63E480A2840CD46BC4C4F0 /* MTIVertex.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIVertex.m; sourceTree = "<group>"; };
+		02579605A28E576467C92615450AC894 /* ColorConversionShaders.metal */ = {isa = PBXFileReference; includeInIndex = 1; path = ColorConversionShaders.metal; sourceTree = "<group>"; };
 		02D45B7DB7796C8D178C499BA4880652 /* MetalPetal.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = MetalPetal.modulemap; sourceTree = "<group>"; };
+		0315CB67BA8D16F62E325BE549C850AA /* MTICLAHEFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTICLAHEFilter.m; sourceTree = "<group>"; };
+		03211368F7652876292FE0561439A47B /* MTIMemoryWarningObserver.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMemoryWarningObserver.m; sourceTree = "<group>"; };
 		0321876584FA0BB1552C24FE09DCB1DD /* MTIComputePipelineKernel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIComputePipelineKernel.swift; sourceTree = "<group>"; };
-		04021D79209A22A71378929D740E21BF /* MTIMPSKernel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMPSKernel.m; sourceTree = "<group>"; };
-		0447D7BAE13A371E68D47BA41528269A /* MTILibrarySource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTILibrarySource.m; sourceTree = "<group>"; };
-		081D0B68C18113024A52925BA2D7F723 /* MTIColorLookupFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIColorLookupFilter.h; sourceTree = "<group>"; };
-		090B8FDB5B7BA5A225CCC8D51A5CDB62 /* MTIImage+Filters.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MTIImage+Filters.h"; sourceTree = "<group>"; };
-		093995D246B4AF578FA9A29F74011A90 /* MTICropFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICropFilter.h; sourceTree = "<group>"; };
-		0A0EED9736CC728C77562D4836D644AE /* MTITextureDescriptor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTITextureDescriptor.h; sourceTree = "<group>"; };
+		04AE91654A85602AE96DBA70381A36C7 /* MTIPixellateFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIPixellateFilter.m; sourceTree = "<group>"; };
+		05A3AB28CC8F9CB607C20FF9BF7B72B7 /* MTIHexagonalBokehBlurFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIHexagonalBokehBlurFilter.m; sourceTree = "<group>"; };
+		05A4935EB223201339B14A22D2FE7845 /* MTIColorMatrix.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIColorMatrix.m; sourceTree = "<group>"; };
+		05C66E6AFF20587B07B2E966A6A1D0A9 /* MTIBlendFormulaSupport.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = MTIBlendFormulaSupport.mm; sourceTree = "<group>"; };
+		062C600B5E9D962937EBDC1A4B9323F4 /* MTITextureDimensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTITextureDimensions.m; sourceTree = "<group>"; };
+		0974FB05EEA4A9D10D0B128598790F70 /* MTIFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIFilter.h; sourceTree = "<group>"; };
 		0A57956B5FFBDC5A98D9EF3E79151D51 /* MetalPetal.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = MetalPetal.framework; path = MetalPetal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0AD143EFB1556A622006CAA5324049C6 /* MTIColor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIColor.h; sourceTree = "<group>"; };
+		0BC009493F548ADCBC1ADE0611B51F95 /* LensBlur.metal */ = {isa = PBXFileReference; includeInIndex = 1; path = LensBlur.metal; sourceTree = "<group>"; };
 		0C45A3B725AB07067F983E52F10A4B2E /* Pods_MetalPetalDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_MetalPetalDemo.framework; path = "Pods-MetalPetalDemo.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		0DFB3E6CA7B5FBF44D0AEB9C5E46FDA1 /* MTISamplerDescriptor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTISamplerDescriptor.m; sourceTree = "<group>"; };
-		0E98D625F283124D8E259BA7D2021672 /* MTIMPSUnsharpMaskFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMPSUnsharpMaskFilter.m; sourceTree = "<group>"; };
-		0F2E6A40946FCA93AA656A0E66A0F0B4 /* MTICVPixelBufferPool.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTICVPixelBufferPool.m; sourceTree = "<group>"; };
+		0D780E63B6B0F03C292D25BC4BF52CAD /* MTIFunctionArgumentsEncoder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIFunctionArgumentsEncoder.m; sourceTree = "<group>"; };
+		0ED8D5077B159E8DDF17721711D92723 /* MTICVMetalTextureCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICVMetalTextureCache.h; sourceTree = "<group>"; };
+		0EF4C6CCA87B0A7ED6B528B9EF00391F /* MTIBuffer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIBuffer.h; sourceTree = "<group>"; };
+		0F3835D9C09A2F3027A6ADD33EB0AE24 /* MTICVPixelBufferPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTICVPixelBufferPromise.m; sourceTree = "<group>"; };
 		100B284BC49A631F68D0E68CC834E220 /* MTIVertex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIVertex.swift; sourceTree = "<group>"; };
-		10A1A9ED09C7E9FAF2F6D5E6ECF7707C /* MTIContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIContext.h; sourceTree = "<group>"; };
-		12B4F6EDF4B1472AE0BC53723B03D9D4 /* MTIHexagonalBokehBlurFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIHexagonalBokehBlurFilter.h; sourceTree = "<group>"; };
-		14A1932D300EB6B53DF05B58B0956FC4 /* MTISCNSceneRenderer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTISCNSceneRenderer.m; sourceTree = "<group>"; };
-		15A01A17698EB0654EF17F29ABDECE2F /* MTIVibranceFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIVibranceFilter.m; sourceTree = "<group>"; };
-		17448C2E4F9235E3A1EBB2ABCF84A0EE /* MTIRenderPipeline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRenderPipeline.h; sourceTree = "<group>"; };
-		17B89A6774A590C405D8CB8F871AC395 /* MTIWeakToStrongObjectsMapTable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIWeakToStrongObjectsMapTable.m; sourceTree = "<group>"; };
-		182194D34BA8667C762FB8BB906B9789 /* MTITextureDimensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTITextureDimensions.h; sourceTree = "<group>"; };
-		1BD88D7605EC9D4FE51AFEB36C5CE2F3 /* MTIMask.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMask.m; sourceTree = "<group>"; };
+		1190F7C1CBDDC5F4E9758676F2AE014F /* MTIRenderPipelineKernel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRenderPipelineKernel.h; sourceTree = "<group>"; };
+		13126AEAEF3D8AE022EB95AA6D2FB2D6 /* MTIComputePipeline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIComputePipeline.h; sourceTree = "<group>"; };
+		134654EA038168008A67DE508D6D4B07 /* MTIComputePipelineKernel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIComputePipelineKernel.h; sourceTree = "<group>"; };
+		13A415962D5F0D1661591580D24DE5F9 /* MTIUnaryImageRenderingFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIUnaryImageRenderingFilter.m; sourceTree = "<group>"; };
+		148B6092CB5BC775E49FEE4A67E1B376 /* MTIAlphaPremultiplicationFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIAlphaPremultiplicationFilter.m; sourceTree = "<group>"; };
+		14E519B47E9A4B0DCB1B499D58E2D170 /* MTIMPSSobelFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMPSSobelFilter.m; sourceTree = "<group>"; };
+		160151F161CB13F459B062CED8802237 /* MTIImageProperties.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIImageProperties.m; sourceTree = "<group>"; };
+		160B83A6C820B95BD6210C47EC70DA1A /* MTIMPSDefinitionFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMPSDefinitionFilter.h; sourceTree = "<group>"; };
+		175A887448859E15D78AA5E7AA8EE781 /* MTIRoundCornerFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIRoundCornerFilter.m; sourceTree = "<group>"; };
+		1765F24DA26B8F34E3FE119C1FD84487 /* MTITextureDescriptor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTITextureDescriptor.m; sourceTree = "<group>"; };
+		178E40ECCDB78DB0FD9B2D40AD655F24 /* MTIGeometry.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIGeometry.m; sourceTree = "<group>"; };
+		1840031625149F92C9D4B6F5263C6508 /* MTIComputePipelineKernel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIComputePipelineKernel.m; sourceTree = "<group>"; };
+		192A23E62DCDA7FA27C5C2EA04252460 /* MTIImage+Filters.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MTIImage+Filters.h"; sourceTree = "<group>"; };
+		1A10021480415F41B3C4DC24B3A10E2B /* MTIFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIFilter.m; sourceTree = "<group>"; };
+		1C78A301CC30E1A77B3474864AE36D7A /* MTIHasher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIHasher.m; sourceTree = "<group>"; };
+		1D8F08D4FD37615A67EDD83D4E2176B2 /* MTIColor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIColor.m; sourceTree = "<group>"; };
+		1EE350F6CCD35817F08499268062BCEF /* MTICVMetalIOSurfaceBridge.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTICVMetalIOSurfaceBridge.m; sourceTree = "<group>"; };
 		1F38A5141FF45F6DFB2B3925DB311442 /* Pods-MetalPetalDemo-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-MetalPetalDemo-umbrella.h"; sourceTree = "<group>"; };
+		1F95686506292531717C3231DFA16277 /* MTICropFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICropFilter.h; sourceTree = "<group>"; };
 		1FF8E78B0E436FFF5C6755011D7AAF46 /* Pods-MetalPetalDemo-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-MetalPetalDemo-acknowledgements.markdown"; sourceTree = "<group>"; };
+		208E775116CA33DAECD4A32A6B6CE97E /* MTIThreadSafeImageView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIThreadSafeImageView.h; sourceTree = "<group>"; };
 		214952C0D3C410E24A6CC3A99D7FEA0C /* MTIAlphaType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIAlphaType.swift; sourceTree = "<group>"; };
-		21AA4C22D9BE7F8481CB8F165BFFDE4B /* MTIColorHalftoneFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIColorHalftoneFilter.m; sourceTree = "<group>"; };
-		22F41B70EACCBF98657AD2CC6A9D6892 /* MTIFunctionDescriptor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIFunctionDescriptor.h; sourceTree = "<group>"; };
+		2392A2383A76EE8F4020EADDC119D1C4 /* MTIWeakToStrongObjectsMapTable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIWeakToStrongObjectsMapTable.m; sourceTree = "<group>"; };
 		241E42C19758A9944F92C41B6E272F19 /* MTIImage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIImage.swift; sourceTree = "<group>"; };
 		248F40022EC56B24B925B2F1DDD178FA /* Pods-MetalPetalDemo.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-MetalPetalDemo.modulemap"; sourceTree = "<group>"; };
-		2704D4D68ECBEF5F74393C96D657EC44 /* MTICVPixelBufferRendering.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTICVPixelBufferRendering.m; sourceTree = "<group>"; };
-		29B708591E96EFA4BC1BC999DA114D3D /* MetalPetal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MetalPetal.h; sourceTree = "<group>"; };
-		2A897E1269E33424151E7A242885A423 /* MTICoreImageRendering.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTICoreImageRendering.m; sourceTree = "<group>"; };
-		2BF80F72D70ACE02C8A43B666886282F /* MTICLAHEFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTICLAHEFilter.m; sourceTree = "<group>"; };
-		2E0D90CC84894318DB55CE51578E507B /* MTIBulgeDistortionFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIBulgeDistortionFilter.m; sourceTree = "<group>"; };
+		25BD9BA7AE2F69C2CCBA1A2B35F105E1 /* MTIImagePromiseDebug.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIImagePromiseDebug.h; sourceTree = "<group>"; };
+		25F2A7EE45AA430E6C49A5504107E6B8 /* MTIChromaKeyBlendFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIChromaKeyBlendFilter.h; sourceTree = "<group>"; };
+		26646DD1E036FB52BDF6AFA612989DC3 /* MTILibrarySource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTILibrarySource.m; sourceTree = "<group>"; };
+		270481E63FC9B9128C135FD1450ED4B8 /* MultilayerCompositeShaders.metal */ = {isa = PBXFileReference; includeInIndex = 1; path = MultilayerCompositeShaders.metal; sourceTree = "<group>"; };
+		27C22BD1826DBD424CB535FDE5EAB186 /* MTIGeometryUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIGeometryUtilities.m; sourceTree = "<group>"; };
+		2898A7973E4E644DA8B782690238C0DA /* MTICoreImageRendering.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTICoreImageRendering.m; sourceTree = "<group>"; };
+		29CF2B191746FE13A8E3A7C5A7F859D8 /* MTICropFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTICropFilter.m; sourceTree = "<group>"; };
+		2AD0C95DE4CC49839465DDBE56B4CB27 /* MTIMask.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMask.h; sourceTree = "<group>"; };
+		2B0E1E9318A1609CA3E5DA382AC9B832 /* MTIRGBColorSpaceConversionFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIRGBColorSpaceConversionFilter.m; sourceTree = "<group>"; };
+		2C4A0F1CA12FECB5365A8153685A66FB /* MTILock.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTILock.m; sourceTree = "<group>"; };
 		2FEE9C959BFEECD7FA4614F6E385E0FC /* MTIImageViewProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIImageViewProtocol.swift; sourceTree = "<group>"; };
-		30D1E273724BFDF49C8ECBEFFF5A5BA0 /* MTIVector+SIMD.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "MTIVector+SIMD.m"; sourceTree = "<group>"; };
-		3256B897FDD8338AC18560B1DA10C0A0 /* MTIPrint.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIPrint.h; sourceTree = "<group>"; };
-		32FFE8A4A958E6BCE240E1054C901B14 /* MTIMultilayerCompositeKernel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMultilayerCompositeKernel.h; sourceTree = "<group>"; };
-		334D1276AB7BB37A7966E6CEDDC506EC /* MTILibrarySource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTILibrarySource.h; sourceTree = "<group>"; };
-		364B67452ABEBD63BF0E129E642B487D /* MTIMPSConvolutionFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMPSConvolutionFilter.m; sourceTree = "<group>"; };
-		376981EFA3B717CCE86297270C7B2E58 /* MTILock.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTILock.h; sourceTree = "<group>"; };
-		398C4EC9EF22FCE2ABAD722084008E21 /* MTIPixellateFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIPixellateFilter.m; sourceTree = "<group>"; };
-		3A349F92F03DC2A923845D2C00AF9486 /* MTICVMetalTextureCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTICVMetalTextureCache.m; sourceTree = "<group>"; };
-		3A73490F7FBC21A2D26096D7346BDE0F /* MTIThreadSafeImageView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIThreadSafeImageView.h; sourceTree = "<group>"; };
-		3A8BF44F331C40A4A5A9A855182A2161 /* MTIImagePromiseDebug.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIImagePromiseDebug.h; sourceTree = "<group>"; };
+		32C678968CF2E2CC996CC4F70CEED2B6 /* MTIBuffer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIBuffer.m; sourceTree = "<group>"; };
+		34079501D0E96E94E89259340717F0A3 /* MTIRenderPipeline.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIRenderPipeline.m; sourceTree = "<group>"; };
+		36A21F2F754582A8D6EABA982DB005D3 /* MTIVector.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIVector.h; sourceTree = "<group>"; };
+		398B73A915C2D59188AA9D5D4FB70E0D /* MTIImage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIImage.h; sourceTree = "<group>"; };
+		39CE823D2A843F63980FAC74D614FFB5 /* MTIColorHalftoneFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIColorHalftoneFilter.h; sourceTree = "<group>"; };
+		3B26C9F98C517A01E012AE6D18C62AFB /* MTIBulgeDistortionFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIBulgeDistortionFilter.h; sourceTree = "<group>"; };
 		3BBD017E0C9B38AD87CD2738749CDF1D /* MTIVector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIVector.swift; sourceTree = "<group>"; };
-		3D34335ADC9ED66E82E9CF8DFB63F3F3 /* MTIAlphaType.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIAlphaType.h; sourceTree = "<group>"; };
-		3DB0AD25B9D6A79975853E926F3DA0CB /* MTITextureDimensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTITextureDimensions.m; sourceTree = "<group>"; };
-		3F38149B2B9EF53FB1AB1BFEB4D642C2 /* MTIImage+Promise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MTIImage+Promise.h"; sourceTree = "<group>"; };
-		3FBC5E880893DF658CE8C42AFDB3EFE1 /* MTIRGBColorSpaceConversionFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIRGBColorSpaceConversionFilter.m; sourceTree = "<group>"; };
+		3D8E3C7C6C0AD69A5BF8A49E54A63C04 /* MTICVPixelBufferPool.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTICVPixelBufferPool.m; sourceTree = "<group>"; };
 		40202EEB29CDCAC5376B90DB56E4D832 /* MetalPetal.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = MetalPetal.release.xcconfig; sourceTree = "<group>"; };
-		411EAD7B92F9A6F4ABF5B93C0FFFAB1E /* MTICVPixelBufferPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICVPixelBufferPromise.h; sourceTree = "<group>"; };
-		41E39614F2AEEB175FCC6F0F428747FF /* MTICVMetalIOSurfaceBridge.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICVMetalIOSurfaceBridge.h; sourceTree = "<group>"; };
-		42D226BA2B4C19500965081D4EA294A7 /* MTIDrawableRendering.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIDrawableRendering.h; sourceTree = "<group>"; };
-		462DED185217EBC002A82A9BC744ACD5 /* MTIImagePromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIImagePromise.h; sourceTree = "<group>"; };
-		46BA53C30D5C5BD0640A42DDFEC91E33 /* MTIHasher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIHasher.m; sourceTree = "<group>"; };
+		42CA419BDB2F8F6E46CF3B582812299B /* MTIMask.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMask.m; sourceTree = "<group>"; };
+		43609648848E5F567A7FABD1218CAE1D /* MTICVPixelBufferRendering.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICVPixelBufferRendering.h; sourceTree = "<group>"; };
+		45AA2651BDA08AF62E8A2F4FE9752F5D /* MTIMPSSobelFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMPSSobelFilter.h; sourceTree = "<group>"; };
+		481119FA39449CC292F9E2FA10EF270E /* MTITransformFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTITransformFilter.m; sourceTree = "<group>"; };
+		490807A8C291D7C2E0BD9F2E16A646E4 /* MTIImageProperties.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIImageProperties.h; sourceTree = "<group>"; };
 		4AD6624F73FC4ED9BC3A4DDD34DCB1D1 /* MTIDataBuffer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIDataBuffer.swift; sourceTree = "<group>"; };
-		4B036B4C4978458BCDF4DE1444A564DE /* MTISCNSceneRenderer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTISCNSceneRenderer.h; sourceTree = "<group>"; };
-		4BF1D573A3D2FB02D5394C021B7190BB /* MTIAlphaPremultiplicationFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIAlphaPremultiplicationFilter.h; sourceTree = "<group>"; };
-		4C62938684F93FE4ABD8F01C03618074 /* MTIRenderPassOutputDescriptor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIRenderPassOutputDescriptor.m; sourceTree = "<group>"; };
-		4C6D98518A9FB123DDAC92F1CE0B2875 /* MTIMPSDefinitionFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMPSDefinitionFilter.h; sourceTree = "<group>"; };
-		4F9DF86342B4EC11138454DF936D55D4 /* MTIVector+SIMD.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MTIVector+SIMD.h"; sourceTree = "<group>"; };
-		508ECCFFAEDBC424B2868384462985FB /* MTIChromaKeyBlendFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIChromaKeyBlendFilter.h; sourceTree = "<group>"; };
-		50CFD0757D9AC50BADE1AE2FBB4C17DC /* MTIColorMatrixFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIColorMatrixFilter.h; sourceTree = "<group>"; };
-		5364A9F1F54B3C07262B472D30679A90 /* MTIMultilayerCompositingFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMultilayerCompositingFilter.m; sourceTree = "<group>"; };
-		54465B216A991179386A9001C8AD45D0 /* MTIError.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIError.m; sourceTree = "<group>"; };
-		55B87BE9699FB1674C3758931D904F7C /* MTIMPSSobelFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMPSSobelFilter.m; sourceTree = "<group>"; };
-		56FAA0A2415D05D5CBDB5EF54E9734BF /* MTIDefer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIDefer.m; sourceTree = "<group>"; };
-		583BA45980FE3F5172DD0DFB878C5D5A /* MTIFunctionArgumentsEncoder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIFunctionArgumentsEncoder.m; sourceTree = "<group>"; };
-		5C70E88E5545B63745C2B2D3AB03EE68 /* MTIThreadSafeImageView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIThreadSafeImageView.m; sourceTree = "<group>"; };
+		4B8A56911E6F355A867C448317A24ED8 /* Shaders.metal */ = {isa = PBXFileReference; includeInIndex = 1; path = Shaders.metal; sourceTree = "<group>"; };
+		4B91F6134F13DAC7E31458970C968234 /* MTICVMetalTextureCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTICVMetalTextureCache.m; sourceTree = "<group>"; };
+		4D6A57A0CBF92626D2F1CBBB6468E979 /* MTICoreImageRendering.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICoreImageRendering.h; sourceTree = "<group>"; };
+		4DB26C42ECC81541575FED2660982F3B /* MTIMPSDefinitionFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMPSDefinitionFilter.m; sourceTree = "<group>"; };
+		4DEFE522353775645479595270728273 /* MTIContext+Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MTIContext+Internal.h"; sourceTree = "<group>"; };
+		4E2341333D2619A04032BC32C2D225A0 /* MTIThreadSafeImageView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIThreadSafeImageView.m; sourceTree = "<group>"; };
+		4F1584D72463FD5A4B2317C6B619EE44 /* MTIFunctionArgumentsEncoder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIFunctionArgumentsEncoder.h; sourceTree = "<group>"; };
+		52B9D0F2C4A0C54888681D4BFC252079 /* MTIKernel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIKernel.h; sourceTree = "<group>"; };
+		536313D4BBEFB5BD20C7CAFA097AB693 /* Halftone.metal */ = {isa = PBXFileReference; includeInIndex = 1; path = Halftone.metal; sourceTree = "<group>"; };
+		5469D751D199F91FBF290D13B15EED78 /* MTIColorMatrixFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIColorMatrixFilter.m; sourceTree = "<group>"; };
+		55EFE23113DA1F16D2F4AF25D0FEB371 /* MTIImagePromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIImagePromise.h; sourceTree = "<group>"; };
+		57BB3E1A59896225D1F028327734D60F /* MTIImageView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIImageView.m; sourceTree = "<group>"; };
+		57FB1E7FCF1B44DA4A5E7F23EB244A82 /* MTILayer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTILayer.m; sourceTree = "<group>"; };
+		586EF6F15845B15A7B646405D9F07074 /* MTIMPSHistogramFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMPSHistogramFilter.m; sourceTree = "<group>"; };
+		58DB4177664FD7FE0CE6C226EBD618D1 /* MTIRenderTask.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRenderTask.h; sourceTree = "<group>"; };
+		5A376CED1F2B72D755F0725F4F267A93 /* MTIImagePromiseDebug.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIImagePromiseDebug.m; sourceTree = "<group>"; };
+		5A94EB3B45C2C5B6C13888F920C4D3ED /* HighPassSkinSmoothing.metal */ = {isa = PBXFileReference; includeInIndex = 1; path = HighPassSkinSmoothing.metal; sourceTree = "<group>"; };
+		5AC3C84676FDF5D19F81611C5243C360 /* MTIBlendFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIBlendFilter.h; sourceTree = "<group>"; };
 		5D754A56E11FAB79A75735BBB37A1D41 /* Pods-MetalPetalDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-MetalPetalDemo.release.xcconfig"; sourceTree = "<group>"; };
-		5DC3F8207CFAAC737A1DFF48239199B0 /* MTIAlphaType.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIAlphaType.m; sourceTree = "<group>"; };
-		5E32DDB1FE676E809383369ABB3347EE /* MTIRenderTask.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRenderTask.h; sourceTree = "<group>"; };
 		5ECAB595CC0D66B62BA815F7EDE21F89 /* MTIContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIContext.swift; sourceTree = "<group>"; };
-		5EECD0ADFA2ABB7E0DD686573C413F5B /* MTITextureDescriptor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTITextureDescriptor.m; sourceTree = "<group>"; };
+		5F9593BD03FF7F10C70BCF33A3B18A1A /* MTIVibranceFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIVibranceFilter.h; sourceTree = "<group>"; };
+		6023C5FC0CA683525D59511FA9B15748 /* MTIRenderCommand.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRenderCommand.h; sourceTree = "<group>"; };
 		605086DE5E2520BECAEBB726AA053DF1 /* VideoProcessing.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VideoProcessing.swift; sourceTree = "<group>"; };
-		60DE3B29A8D244B28096E314A9F38DB6 /* MTIImageView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIImageView.m; sourceTree = "<group>"; };
-		60E2ED62310B9ADBA4C447F7851C2722 /* MTIMask.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMask.h; sourceTree = "<group>"; };
-		616594FAC6B27A6075F875D7E23D0EAB /* MTIDotScreenFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIDotScreenFilter.h; sourceTree = "<group>"; };
-		620CB9D86964842C0E9F224DFD8EEAF4 /* MTIColorLookupFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIColorLookupFilter.m; sourceTree = "<group>"; };
-		624F416CF5A852072F6AAEDEEBFF2186 /* MTIMPSHistogramFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMPSHistogramFilter.h; sourceTree = "<group>"; };
+		613ECCEE272C2A30923E1E7C634B2545 /* MTIRGBToneCurveFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIRGBToneCurveFilter.m; sourceTree = "<group>"; };
+		61EFE1B44FF83757530F511DEB7D8BC0 /* MTIDefer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIDefer.h; sourceTree = "<group>"; };
+		6222FCFB35B35E00038476E09741B9EA /* MTIDefer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIDefer.m; sourceTree = "<group>"; };
 		62AE1C4BCC9E523CB4012128BBC15D1A /* MTIError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIError.swift; sourceTree = "<group>"; };
-		6350A1CB8B7A21F46B78F7B2E98B0521 /* MTIComputePipelineKernel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIComputePipelineKernel.m; sourceTree = "<group>"; };
-		682900B3D786C9F4B3A58B3C142F054E /* MTIBlendFormulaSupport.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = MTIBlendFormulaSupport.mm; sourceTree = "<group>"; };
-		691D273F8D681266E9B10752D0CD0454 /* MTIImageRenderingContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIImageRenderingContext.h; sourceTree = "<group>"; };
-		692136E53CACE8CAAE2910F5A7DFCEAE /* MTITextureLoader.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTITextureLoader.m; sourceTree = "<group>"; };
-		6A348ABAE37C19B03E2184C2D92B1188 /* MTITransform.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTITransform.h; sourceTree = "<group>"; };
-		6A3AA61E4DC06647448CA24CEF27AD9D /* MTIBlendFormulaSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIBlendFormulaSupport.h; sourceTree = "<group>"; };
+		634D3C18B59D7AA2B67EDEA17C00E7EA /* MTICVMetalIOSurfaceBridge.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICVMetalIOSurfaceBridge.h; sourceTree = "<group>"; };
+		64DF907002280C8330B8478F6D16DCA9 /* MTIMPSConvolutionFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMPSConvolutionFilter.h; sourceTree = "<group>"; };
+		653B817921D29F09E0CF496BA38303EF /* MTISamplerDescriptor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTISamplerDescriptor.h; sourceTree = "<group>"; };
+		667966AD30020077DA795C3C18C52558 /* BlendingShaders.metal */ = {isa = PBXFileReference; includeInIndex = 1; path = BlendingShaders.metal; sourceTree = "<group>"; };
+		679A37895EC9F27F8BC5396FC3FEF6BF /* MTIBlendFormulaSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIBlendFormulaSupport.h; sourceTree = "<group>"; };
+		6811B094931CE1FEAE894C427B4DE5C7 /* MTIPixellateFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIPixellateFilter.h; sourceTree = "<group>"; };
+		68B5CCEC43F83625FC32B5302B7F9477 /* MTIImageOrientation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIImageOrientation.h; sourceTree = "<group>"; };
+		6B854D2B3F34C29959D5D41EC66080F7 /* MTIRGBToneCurveFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRGBToneCurveFilter.h; sourceTree = "<group>"; };
+		6C69C797E40401744545441EFEB071D9 /* MTIShaderLib.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIShaderLib.h; sourceTree = "<group>"; };
+		6CB5FEAD683A0979A40A4A5AF0C5C62E /* MTIColorMatrixFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIColorMatrixFilter.h; sourceTree = "<group>"; };
 		6CF239292141F3924BF4C6579225E2D0 /* MTIFunctionDescriptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIFunctionDescriptor.swift; sourceTree = "<group>"; };
 		6D49B2552395A22B949533199A9EE699 /* MTICropRegion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTICropRegion.swift; sourceTree = "<group>"; };
+		6E41DBB1BD4BE7CDA82345FE6D53A524 /* MTIRenderTask.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIRenderTask.m; sourceTree = "<group>"; };
 		6EE04A67933AF897CCE4BA65DF272949 /* Pods-MetalPetalDemo-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-MetalPetalDemo-dummy.m"; sourceTree = "<group>"; };
-		6F4A6393034641F4798CBB3D2C79BF27 /* MTIMPSGaussianBlurFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMPSGaussianBlurFilter.m; sourceTree = "<group>"; };
-		6F75F8E55D72FC0AAE6AF558354893E6 /* MTIRenderPipelineKernel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIRenderPipelineKernel.m; sourceTree = "<group>"; };
-		6FAED1CF584C5CA4009EA1E105DA699C /* MTIMPSUnsharpMaskFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMPSUnsharpMaskFilter.h; sourceTree = "<group>"; };
-		70CF84F0A31BE3EDBE794B17389DBEE9 /* MTIHighPassSkinSmoothingFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIHighPassSkinSmoothingFilter.h; sourceTree = "<group>"; };
-		7143ADF1023D9F602ED861D42D6E9A6F /* MTIImage+Filters.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "MTIImage+Filters.m"; sourceTree = "<group>"; };
+		6FE8837A7BB63E3F7156A222C5073B03 /* MTICVMetalTextureBridging.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICVMetalTextureBridging.h; sourceTree = "<group>"; };
+		70373E960472CA0797C7F4DD8668BD94 /* MTIGeometryUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIGeometryUtilities.h; sourceTree = "<group>"; };
+		72091B0D243215EAC1AC78211BC1D1B5 /* MTIMPSBoxBlurFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMPSBoxBlurFilter.h; sourceTree = "<group>"; };
+		72BA29B2881466D8F2D01877989CCB9B /* MTIImage+Promise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MTIImage+Promise.h"; sourceTree = "<group>"; };
+		72E1C5AA10525212DBBD50DC8FCD79A5 /* MTILibrarySource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTILibrarySource.h; sourceTree = "<group>"; };
 		73010CC983E3809BECEE5348DA1BB8C6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		74061F6AAECA5B7ABF7500FB689EA692 /* MTIImageOrientation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIImageOrientation.m; sourceTree = "<group>"; };
-		7480CDF9696845AAE86B3FE3A1282323 /* MTIColorMatrix.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIColorMatrix.h; sourceTree = "<group>"; };
+		749C7EA36E5F8012D001DF2695696D0E /* MTIColorHalftoneFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIColorHalftoneFilter.m; sourceTree = "<group>"; };
 		750AC49FEFAF77A7C94435E8445DD011 /* Pods-MetalPetalDemo-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-MetalPetalDemo-frameworks.sh"; sourceTree = "<group>"; };
-		765CD1D513DCC53DF5E439FAB1C8475A /* Halftone.metal */ = {isa = PBXFileReference; includeInIndex = 1; path = Halftone.metal; sourceTree = "<group>"; };
-		76CEB5758B60E3B42FB780A8BBEE75B4 /* MTIContext+Rendering.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "MTIContext+Rendering.m"; sourceTree = "<group>"; };
-		771793A2A60E4341F83C7FC36DDB4216 /* MTIComputePipeline.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIComputePipeline.m; sourceTree = "<group>"; };
-		78BE5AC27645F3E7CB1D1BD955CF9C7A /* MTIRenderGraphOptimization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIRenderGraphOptimization.m; sourceTree = "<group>"; };
-		78C43373C8E7DC3522A292CB68C4BE9E /* MTIImageOrientation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIImageOrientation.h; sourceTree = "<group>"; };
-		79202407595B995A13EA91C0416CC03C /* HighPassSkinSmoothing.metal */ = {isa = PBXFileReference; includeInIndex = 1; path = HighPassSkinSmoothing.metal; sourceTree = "<group>"; };
-		79598357110B01300FE1C1C13EC4782D /* MTIFunctionDescriptor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIFunctionDescriptor.m; sourceTree = "<group>"; };
-		7963DF11BA0077E8E375441D92A514C5 /* MTIMPSGaussianBlurFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMPSGaussianBlurFilter.h; sourceTree = "<group>"; };
-		7A863AA532943C9EA9E79603515C3594 /* MTIGeometryUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIGeometryUtilities.m; sourceTree = "<group>"; };
-		7B9A5C5872D5A8F0334590A3855B0DBA /* MTIContext+Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MTIContext+Internal.h"; sourceTree = "<group>"; };
-		7C40AB7CDF7B77E1AB437A2CD2801C78 /* MTIDefer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIDefer.h; sourceTree = "<group>"; };
-		7DF1BFDED9A39703FEF7CEF979229440 /* MTIMemoryWarningObserver.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMemoryWarningObserver.m; sourceTree = "<group>"; };
-		7E55274F6B0BF74DC5390057766E0FC6 /* MTIPixellateFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIPixellateFilter.h; sourceTree = "<group>"; };
-		7FA9A3F636E1BC52D86EE736D0F908E5 /* MTIImageView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIImageView.h; sourceTree = "<group>"; };
+		75A8528944308AB6F22335710D46D955 /* MTITextureLoader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTITextureLoader.h; sourceTree = "<group>"; };
+		7849F3C8538B419AD017F5D050446D2A /* MetalPetal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MetalPetal.h; sourceTree = "<group>"; };
+		79655AC00AED64FE8A16577D885ECAC7 /* MTIAlphaPremultiplicationFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIAlphaPremultiplicationFilter.h; sourceTree = "<group>"; };
+		7C47F8067AA6C4C6BF3396C40AE9C233 /* MTISCNSceneRenderer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTISCNSceneRenderer.h; sourceTree = "<group>"; };
+		7D7E129DCBA4E7779C331C7F17C30EA5 /* MTIColorLookupFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIColorLookupFilter.m; sourceTree = "<group>"; };
+		7E80B756B982A36B3D292D6C93A900B9 /* MTITransform.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTITransform.m; sourceTree = "<group>"; };
+		7F0AD4AA5EAEF72BC66DB4A8F1FBBDC2 /* MTITextureDescriptor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTITextureDescriptor.h; sourceTree = "<group>"; };
+		7FE5E3474304EBC74E4D050B97716F4F /* MTIImageOrientation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIImageOrientation.m; sourceTree = "<group>"; };
+		7FEC3E6303CC592CDFCFD2C903670437 /* MTITexturePool.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = MTITexturePool.mm; sourceTree = "<group>"; };
 		802DFD3E4FD6ED2021754259AE439197 /* MetalPetal.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = MetalPetal.modulemap; sourceTree = "<group>"; };
-		80E8535AF70B8B0BA370C1F8681B3EB4 /* MTIKernel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIKernel.h; sourceTree = "<group>"; };
-		8149A338AC9B24DCADC5C9DDD30E40CE /* MTICVPixelBufferPool.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICVPixelBufferPool.h; sourceTree = "<group>"; };
 		817E2B62184F77F2F437A2226E162A67 /* MTIColorMatrix.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIColorMatrix.swift; sourceTree = "<group>"; };
-		82198882F891F495127AF2EE5EF1DC85 /* MTIShaderLib.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIShaderLib.h; sourceTree = "<group>"; };
-		822B374D1B7AC61401EDF66E89E801D0 /* MTIWeakToStrongObjectsMapTable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIWeakToStrongObjectsMapTable.h; sourceTree = "<group>"; };
-		825C53F63F41C797BC4981CCF22343F8 /* MTILayer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTILayer.m; sourceTree = "<group>"; };
-		827513924F896DCB764FE701AEFCA9C5 /* MTIMemoryWarningObserver.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMemoryWarningObserver.h; sourceTree = "<group>"; };
-		83777152C6ACEC39F21DF11858ADA6A7 /* MTIVertex.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIVertex.h; sourceTree = "<group>"; };
 		839828DBAF7622F615BED791E9F0DE2C /* MTIPixelFormat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIPixelFormat.swift; sourceTree = "<group>"; };
-		84CB0268F88EE6A80D8F07052EA7A69D /* MTIColor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIColor.h; sourceTree = "<group>"; };
-		84F5AC24AA37EEEF84D3E1CDE7B5E606 /* MTIHighPassSkinSmoothingFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIHighPassSkinSmoothingFilter.m; sourceTree = "<group>"; };
-		86DA02E3BE110C898754DC50D588A626 /* MTIGeometry.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIGeometry.m; sourceTree = "<group>"; };
-		87D8F15A54A9F2FC9ACC0BD652B5A248 /* MTIRGBColorSpaceConversionFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRGBColorSpaceConversionFilter.h; sourceTree = "<group>"; };
-		88614D896761050099A8A798078CAD80 /* LensBlur.metal */ = {isa = PBXFileReference; includeInIndex = 1; path = LensBlur.metal; sourceTree = "<group>"; };
-		89AC1520E80D4FD3E9C005B8999395EF /* MTIMultilayerCompositingFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMultilayerCompositingFilter.h; sourceTree = "<group>"; };
-		8A91AB0A419FE0AB6226B47C35DC34C0 /* MTIMultilayerCompositeKernel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMultilayerCompositeKernel.m; sourceTree = "<group>"; };
+		89A372D6E21F515D9907A8A5523C3F8A /* MTIError.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIError.h; sourceTree = "<group>"; };
+		89FEA9B7C91BC359581BACDC57D6F8B1 /* MTIImageRenderingContext+Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MTIImageRenderingContext+Internal.h"; sourceTree = "<group>"; };
 		8C14D184B546F25F00AC1B3358AEFECD /* MetalPetal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MetalPetal.swift; sourceTree = "<group>"; };
-		8C5688196AC43221CC7F06788E4F44CF /* MTICVPixelBufferPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTICVPixelBufferPromise.m; sourceTree = "<group>"; };
-		8E2FDC2CF0ADB745A7F21E2913358013 /* MTICVPixelBufferRendering.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICVPixelBufferRendering.h; sourceTree = "<group>"; };
-		8F31F4C77536F54DB56F54B731F465D1 /* MTIMPSBoxBlurFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMPSBoxBlurFilter.m; sourceTree = "<group>"; };
-		9081AA72F478E687A6E8F3B5D7D2C695 /* MTIBlendModes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIBlendModes.h; sourceTree = "<group>"; };
-		90D4397D716DA7D688ED77CE9CCB5369 /* MTIComputePipeline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIComputePipeline.h; sourceTree = "<group>"; };
-		91B7AE11A52CF2257DDFD39FC4639BEE /* MTIMPSKernel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMPSKernel.h; sourceTree = "<group>"; };
-		920019B9E8653C980E7384086452A571 /* MTIMPSHistogramFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMPSHistogramFilter.m; sourceTree = "<group>"; };
-		92FC9F8B0D958B462B847FD6F41E1BCB /* MTILock.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTILock.m; sourceTree = "<group>"; };
-		935FDC03670DF769B93631BF0ECFB04A /* MTIImageRenderingContext+Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MTIImageRenderingContext+Internal.h"; sourceTree = "<group>"; };
-		94B7EB9DE2F53BD26A69F2745A6923D3 /* MTIPixelFormat.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIPixelFormat.m; sourceTree = "<group>"; };
-		9A1D58E560C44C6DBDD985E536D6BFDE /* MTIBlendWithMaskFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIBlendWithMaskFilter.h; sourceTree = "<group>"; };
+		8D339E430650471E788ABF006A21758D /* MTIBulgeDistortionFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIBulgeDistortionFilter.m; sourceTree = "<group>"; };
+		8D92E4F5CBED7A5A7D81D9C311029B47 /* MTITexturePool.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTITexturePool.h; sourceTree = "<group>"; };
+		8DD28B6BAE689B1C53CE1071A179D5D7 /* MTIMultilayerCompositeKernel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMultilayerCompositeKernel.h; sourceTree = "<group>"; };
+		916B7A8A1D2A74910A90EAC3A80FECE0 /* MTIMPSBoxBlurFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMPSBoxBlurFilter.m; sourceTree = "<group>"; };
+		91C7F17C15A73D10297190DF6CBC4825 /* MTIMPSGaussianBlurFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMPSGaussianBlurFilter.m; sourceTree = "<group>"; };
+		920B9E425DFC7C31D98C55CC861A0F73 /* MTISKSceneRenderer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTISKSceneRenderer.m; sourceTree = "<group>"; };
+		95E031DFFD3F4A30E6F4B6CB0E414B72 /* MTIRenderPassOutputDescriptor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIRenderPassOutputDescriptor.m; sourceTree = "<group>"; };
+		99388288BE9BD3B425D97C4AA053BDD7 /* MTIDrawableRendering.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIDrawableRendering.m; sourceTree = "<group>"; };
+		9B3EF613A9DF583F91FD2B6CEC95D6F8 /* MTIPixelFormat.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIPixelFormat.h; sourceTree = "<group>"; };
+		9CAD2273320E618C229D82E3F500B4CF /* MTIContext+Rendering.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MTIContext+Rendering.h"; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		9DDF88D24AECEEB18B2D9B4288BF6C02 /* MTIDrawableRendering.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIDrawableRendering.m; sourceTree = "<group>"; };
-		A08CCF290B4005CC0BC5DC52BF770D4B /* MTIDotScreenFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIDotScreenFilter.m; sourceTree = "<group>"; };
-		A1E9946A80A087C34E0392DC001BC1B3 /* MTIUnaryImageRenderingFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIUnaryImageRenderingFilter.m; sourceTree = "<group>"; };
-		A431037551AAF3CA52FCAF307E2BD93A /* MTIBlendModes.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIBlendModes.m; sourceTree = "<group>"; };
-		A4E3C9EC289989036013422F5B6AF4C8 /* MTIMPSDefinitionFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMPSDefinitionFilter.m; sourceTree = "<group>"; };
-		A5796517B48A5D5532483528B2CAC31B /* MTIVector.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIVector.m; sourceTree = "<group>"; };
-		A6802FEA6C73888CAE5CF06B860A7BF4 /* MTIContext.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIContext.m; sourceTree = "<group>"; };
-		A6F8624B08A618DE7C915EC491E998AD /* BlendingShaders.metal */ = {isa = PBXFileReference; includeInIndex = 1; path = BlendingShaders.metal; sourceTree = "<group>"; };
-		A78EE2CA9D1B0F614AF227FD4FA86A07 /* MTIRoundCornerFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRoundCornerFilter.h; sourceTree = "<group>"; };
-		A817A8F3ED1400371D5A3C53DB9C48CD /* MTIError.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIError.h; sourceTree = "<group>"; };
-		A8F7E869E863C72F0010F9451DD1B502 /* MTIRenderCommand.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRenderCommand.h; sourceTree = "<group>"; };
-		A940799E64A89F80E8498F3420D15260 /* MTIComputePipelineKernel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIComputePipelineKernel.h; sourceTree = "<group>"; };
-		ABF631EB1B40A6CB8DFBA45BD271EACE /* MTISamplerDescriptor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTISamplerDescriptor.h; sourceTree = "<group>"; };
+		9E3210E6A5683F8D448047A8D153D3D2 /* MTITransform.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTITransform.h; sourceTree = "<group>"; };
+		9EA016D063952EE35D8B939A79CDC459 /* MTILock.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTILock.h; sourceTree = "<group>"; };
+		9F369250749CEA3FD05B2E2E6D8BEA0C /* MTIBlendModes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIBlendModes.h; sourceTree = "<group>"; };
+		A1BEE5582D885439E9BF198942052088 /* MTISKSceneRenderer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTISKSceneRenderer.h; sourceTree = "<group>"; };
+		A2A5AE3DE15150AF151C33405438F5D7 /* MTIMultilayerCompositeKernel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMultilayerCompositeKernel.m; sourceTree = "<group>"; };
+		A324DCB96C0FFFE3FA21C097A7126AC3 /* MTIWeakToStrongObjectsMapTable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIWeakToStrongObjectsMapTable.h; sourceTree = "<group>"; };
+		A48BB00E5FA51B17E49206D3648D8B16 /* MTILayer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTILayer.h; sourceTree = "<group>"; };
+		A4A858DAAD6A965BCF2E594658D583AB /* MTIRenderPipelineKernel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIRenderPipelineKernel.m; sourceTree = "<group>"; };
+		A6F34B48D4ABB15DEEBE2FD171A20847 /* MTISCNSceneRenderer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTISCNSceneRenderer.m; sourceTree = "<group>"; };
+		A721B1ACEAD3E9D9DA3E515AA4462584 /* MTIContext+Rendering.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "MTIContext+Rendering.m"; sourceTree = "<group>"; };
+		A7B9C14E61E56A83D9368EF3A09C8C61 /* MTIPixelFormat.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIPixelFormat.m; sourceTree = "<group>"; };
+		A83710B5CCF3635F0608BCBB58917AB8 /* MTIRoundCornerFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRoundCornerFilter.h; sourceTree = "<group>"; };
+		A98CA48DA90740DA3A5ED193A9D9C7E5 /* MTITextureDimensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTITextureDimensions.h; sourceTree = "<group>"; };
 		AC90562A0EF7B2FE5B145FC20965C80E /* Pods-MetalPetalDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-MetalPetalDemo.debug.xcconfig"; sourceTree = "<group>"; };
+		ACC3B9BA82EAA846CB3E21DFC42B65BC /* MTICVPixelBufferPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICVPixelBufferPromise.h; sourceTree = "<group>"; };
+		ACD44E37F73AFF532F6F2E4C26A29209 /* MTIDrawableRendering.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIDrawableRendering.h; sourceTree = "<group>"; };
+		AD17B52170742E4D3F0FDBEB6BEDDC11 /* MTIVector+SIMD.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "MTIVector+SIMD.m"; sourceTree = "<group>"; };
 		AFD47C32A0A4B685F66FBB8585E74674 /* Pods-MetalPetalDemo-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-MetalPetalDemo-acknowledgements.plist"; sourceTree = "<group>"; };
-		B123F941C7582F65A46EB59FABF250A4 /* MTICropFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTICropFilter.m; sourceTree = "<group>"; };
-		B1C7EFF766AB01017BA6E7AD2872CDEE /* MTITransformFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTITransformFilter.m; sourceTree = "<group>"; };
-		B1EE4F5B4A078E85AFA072199F881C17 /* MTIBlendFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIBlendFilter.h; sourceTree = "<group>"; };
-		B201151C616B126936CFBF624AB97D7B /* MTIRenderTask.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIRenderTask.m; sourceTree = "<group>"; };
+		B1043298318B39A854A07DADB624A814 /* MTIImageView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIImageView.h; sourceTree = "<group>"; };
+		B2EAA5288D9AB128D1D2C4232528F283 /* MTIShaderFunctionConstants.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIShaderFunctionConstants.h; sourceTree = "<group>"; };
 		B2F078B6BC4782A2563EF651AF36398C /* MetalPetal-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "MetalPetal-dummy.m"; sourceTree = "<group>"; };
-		B40915E5D0F2D2231739A8850E333C2C /* MTIRoundCornerFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIRoundCornerFilter.m; sourceTree = "<group>"; };
+		B30F1E69C911CB2468E77FA1A76A14E8 /* MTIVibranceFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIVibranceFilter.m; sourceTree = "<group>"; };
+		B4265EEB236C009CB0DFDF4D954F33AB /* MTIHasher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIHasher.h; sourceTree = "<group>"; };
 		B47A88629BB44E32672F8094ACD95596 /* MetalPetal-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "MetalPetal-Info.plist"; sourceTree = "<group>"; };
-		B600A87CA39082EA4BAE8025F471B8DE /* MTIHexagonalBokehBlurFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIHexagonalBokehBlurFilter.m; sourceTree = "<group>"; };
-		B761B42FA4E54934723152A21E74A3D5 /* MTITexturePool.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = MTITexturePool.mm; sourceTree = "<group>"; };
-		B76A35A22A307B122ADDC35870B575B8 /* MTIVertex.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIVertex.m; sourceTree = "<group>"; };
-		B7DE8BC55DB2B3E345E4092D21340132 /* MTIRGBToneCurveFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIRGBToneCurveFilter.m; sourceTree = "<group>"; };
-		BAFE24041771958D747DC76A98F2F320 /* MTIMPSConvolutionFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMPSConvolutionFilter.h; sourceTree = "<group>"; };
-		BC5E0F4AB88F9140148CF4FCB36FA836 /* MTIRenderPipeline.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIRenderPipeline.m; sourceTree = "<group>"; };
-		BF690F8C9F79671A66CE8E9BE6A6D5E0 /* MTIVector.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIVector.h; sourceTree = "<group>"; };
-		BFDFDF4F5452205A4C8366819FA0149D /* MTIFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIFilter.m; sourceTree = "<group>"; };
-		C020930B4362CBF063F0EAAA6162FF45 /* MTIColor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIColor.m; sourceTree = "<group>"; };
-		C148193F3B729CEFD8B8A282D4E0B37B /* MTIBuffer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIBuffer.h; sourceTree = "<group>"; };
-		C1C5EDF47FF82766EF253886656FA74A /* MTIRenderPipelineKernel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRenderPipelineKernel.h; sourceTree = "<group>"; };
-		C31694634F18EB151F94CDDCC4A1C1CA /* MTICVMetalTextureBridging.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICVMetalTextureBridging.h; sourceTree = "<group>"; };
-		C40E942AC5FEDE1B917A3EC8DF038ED1 /* MTITextureLoader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTITextureLoader.h; sourceTree = "<group>"; };
-		C4E271B5D630FF9B70789A757064FF56 /* MTIRGBToneCurveFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRGBToneCurveFilter.h; sourceTree = "<group>"; };
-		C4FE10061A867C198269C2D587DCEF2C /* MTICLAHEFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICLAHEFilter.h; sourceTree = "<group>"; };
+		B595DAD1C234B1F70C90D054860B0FB6 /* MTIImage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIImage.m; sourceTree = "<group>"; };
+		B59C493FE6FDD5D2B8333AD90A088C17 /* MTICLAHEFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICLAHEFilter.h; sourceTree = "<group>"; };
+		B7C61DED1E4EFA9CB46233160E9F2EBB /* MTIImageRenderingContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIImageRenderingContext.h; sourceTree = "<group>"; };
+		B864E44D9A93D5B877CC1FCF099CD527 /* MTIFunctionDescriptor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIFunctionDescriptor.m; sourceTree = "<group>"; };
+		BA8891D1A558E880C80BAC28DEABE906 /* MTIImagePromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIImagePromise.m; sourceTree = "<group>"; };
+		BCA1A737A5543861CFCF486A4BEAD173 /* MTIColorLookupFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIColorLookupFilter.h; sourceTree = "<group>"; };
+		BE357AC542883DB4D087D84CC1DDA02E /* MTIContext.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIContext.m; sourceTree = "<group>"; };
+		BE7948D8AB11AF33255EC4BD5256AF7D /* MTIBlendModes.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIBlendModes.m; sourceTree = "<group>"; };
+		BEED677BCAF818A7E241223566B45F4F /* MTIRenderPipeline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRenderPipeline.h; sourceTree = "<group>"; };
+		C32FC755A52CE99E274D243DB60DDB3B /* MTIMPSKernel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMPSKernel.m; sourceTree = "<group>"; };
+		C51E35307EB9E571F5ADD641ABC5C0CB /* MTIRGBColorSpaceConversionFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRGBColorSpaceConversionFilter.h; sourceTree = "<group>"; };
+		C6479525A04A41BA443EE169937ACE75 /* MTIAlphaType.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIAlphaType.h; sourceTree = "<group>"; };
 		C6B979E33E65E208114577BE0065A178 /* MTIColor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIColor.swift; sourceTree = "<group>"; };
-		C7BDD6D47791C4508C03C47289A3382B /* MTIMPSBoxBlurFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMPSBoxBlurFilter.h; sourceTree = "<group>"; };
-		C84B38774E5EF7F53888666906AB5FAA /* MTIGeometry.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIGeometry.h; sourceTree = "<group>"; };
-		C9341F7A1F3E62D93D34ACB037FCF283 /* MTIColorMatrix.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIColorMatrix.m; sourceTree = "<group>"; };
-		C9989AE6C184FA9CD9DD586953E3433A /* MTIColorMatrixFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIColorMatrixFilter.m; sourceTree = "<group>"; };
 		CA1404B4E201A66CED54798A0A414FCF /* MTITextureDimensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTITextureDimensions.swift; sourceTree = "<group>"; };
-		CB37301CCDE806AB3B461B46D4A0892D /* MTIBlendWithMaskFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIBlendWithMaskFilter.m; sourceTree = "<group>"; };
-		CBD4ADD0029458CD8379EAE8E7358007 /* MTIImageProperties.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIImageProperties.h; sourceTree = "<group>"; };
-		CC302A734DCF5CF01F83752AB33FE076 /* MTIFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIFilter.h; sourceTree = "<group>"; };
-		CC8245F807EEDFD9F98FCEF1B351D3C7 /* MTIImagePromiseDebug.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIImagePromiseDebug.m; sourceTree = "<group>"; };
-		CC960FB45A6A1F47881BFA02883F1C96 /* CLAHE.metal */ = {isa = PBXFileReference; includeInIndex = 1; path = CLAHE.metal; sourceTree = "<group>"; };
-		CFF3B11C4EA905C987073D3924975F67 /* MultilayerCompositeShaders.metal */ = {isa = PBXFileReference; includeInIndex = 1; path = MultilayerCompositeShaders.metal; sourceTree = "<group>"; };
-		CFFF513AA45E92258F737206085A1FB6 /* MTISKSceneRenderer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTISKSceneRenderer.h; sourceTree = "<group>"; };
+		CA86E9784DC4C48C67C3DCC6FB024DCB /* MTIRenderGraphOptimization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRenderGraphOptimization.h; sourceTree = "<group>"; };
+		CBD8D80E592D7A2183E4F190A68ADBAA /* MTIDotScreenFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIDotScreenFilter.h; sourceTree = "<group>"; };
+		CBF0F576E50377C64B8C9F79A55963D4 /* MTIMultilayerCompositingFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMultilayerCompositingFilter.h; sourceTree = "<group>"; };
+		CE50B20A2C3620CCEFE6014D9DB6DA65 /* MTIMPSKernel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMPSKernel.h; sourceTree = "<group>"; };
+		CE669A1E167194251732A995A577ADE4 /* MTIVector+SIMD.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MTIVector+SIMD.h"; sourceTree = "<group>"; };
+		CF241CDA8F6B441BB4953C664E14CBCB /* MTIBlendFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIBlendFilter.m; sourceTree = "<group>"; };
+		CFED737389BF486E8363CCF28E2DA40D /* MTICVPixelBufferRendering.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTICVPixelBufferRendering.m; sourceTree = "<group>"; };
+		D0C2E2A565343BD3C34EF9EE7761C03A /* MTIColorMatrix.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIColorMatrix.h; sourceTree = "<group>"; };
+		D10BE2C75A6C593F298042CD00913640 /* MTIMPSConvolutionFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMPSConvolutionFilter.m; sourceTree = "<group>"; };
+		D114BA13F24EF82E279FF3669CBD77AE /* MTITextureLoader.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTITextureLoader.m; sourceTree = "<group>"; };
 		D1781EE46FE30A1C38E19F36EF1B44B5 /* MTICoreImageExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTICoreImageExtension.swift; sourceTree = "<group>"; };
-		D1C68188E9EF03F3E41F6EDD633B44D0 /* MTIImagePromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIImagePromise.m; sourceTree = "<group>"; };
-		D1DE18D9F58B6EF781D4EFC6CAC8A446 /* MTILayer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTILayer.h; sourceTree = "<group>"; };
-		D2696BB30F7D660904F5CBC010AD3415 /* MTIRenderPassOutputDescriptor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRenderPassOutputDescriptor.h; sourceTree = "<group>"; };
-		D5512E421942EBB49268D69EE940CE00 /* MTIImageProperties.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIImageProperties.m; sourceTree = "<group>"; };
-		D60AADA47F1834E755A0C41B6042CCAF /* MTIBuffer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIBuffer.m; sourceTree = "<group>"; };
-		D918C587147DAC53E119C134F088916E /* MTISKSceneRenderer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTISKSceneRenderer.m; sourceTree = "<group>"; };
-		DE020F57431B0DF4121CAAE397734F8A /* MTITransform.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTITransform.m; sourceTree = "<group>"; };
-		DEC0DCDB61AFEC013ADA8C8A0E060D6F /* MTIRenderCommand.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIRenderCommand.m; sourceTree = "<group>"; };
-		DF537F7A9A72644759B75F600A566DE1 /* MTICVMetalIOSurfaceBridge.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTICVMetalIOSurfaceBridge.m; sourceTree = "<group>"; };
-		DF5FD054F0E76B597090379B7D703AFB /* MTITexturePool.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTITexturePool.h; sourceTree = "<group>"; };
-		DFA64C8D21F1C7851C9B0D475A9543A6 /* MTIColorHalftoneFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIColorHalftoneFilter.h; sourceTree = "<group>"; };
+		D3C7B6E32479024359634B347A91E0D4 /* CLAHE.metal */ = {isa = PBXFileReference; includeInIndex = 1; path = CLAHE.metal; sourceTree = "<group>"; };
+		D62FB9CAE1D00D594FF8AA44C1E69465 /* MTIMultilayerCompositingFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMultilayerCompositingFilter.m; sourceTree = "<group>"; };
+		DB66AFD5F859F2417471C27B890DB139 /* MTITransformFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTITransformFilter.h; sourceTree = "<group>"; };
+		DE7351B22C7AB93628DC57B4D2CDA6F8 /* MTIAlphaType.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIAlphaType.m; sourceTree = "<group>"; };
+		DF9A879D13E400B915610E773F2F9106 /* MTIFunctionDescriptor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIFunctionDescriptor.h; sourceTree = "<group>"; };
+		E053B8E9CCD0F411B22A2AE5A31545AC /* MTIMPSGaussianBlurFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMPSGaussianBlurFilter.h; sourceTree = "<group>"; };
 		E069528B6E4B104DF5E3FB5CA9DDE988 /* Filter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Filter.swift; sourceTree = "<group>"; };
 		E088201C1E99269CE1275A77A408C753 /* MetalPetal.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = MetalPetal.debug.xcconfig; sourceTree = "<group>"; };
-		E11B72D9BE78E58E2A89D94CFDD502D4 /* MTIVibranceFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIVibranceFilter.h; sourceTree = "<group>"; };
-		E184EC58E8EBBB081F2AA233F3FA1AE4 /* MTIMPSSobelFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMPSSobelFilter.h; sourceTree = "<group>"; };
-		E186B4EF06532CD3702854030AC50048 /* ColorConversionShaders.metal */ = {isa = PBXFileReference; includeInIndex = 1; path = ColorConversionShaders.metal; sourceTree = "<group>"; };
-		E683F9E1DE6AF4709C7E566B27EE0BE9 /* MTIImage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIImage.h; sourceTree = "<group>"; };
-		E6CFF1002699AB1C75E6D7169AD10772 /* MTIPixelFormat.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIPixelFormat.h; sourceTree = "<group>"; };
-		E6D6D3137D202883FCD337168C3410C2 /* MTIFunctionArgumentsEncoder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIFunctionArgumentsEncoder.h; sourceTree = "<group>"; };
-		E72464AB19C80A06A585AF6569B35054 /* MTIImage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIImage.m; sourceTree = "<group>"; };
-		E78BAFBC08B2773B47E9449DA6A8D336 /* Shaders.metal */ = {isa = PBXFileReference; includeInIndex = 1; path = Shaders.metal; sourceTree = "<group>"; };
-		E9BA8DEA27E8473D0496E03599269227 /* MTIHasher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIHasher.h; sourceTree = "<group>"; };
+		E09E4D72E0A0564E93051813AEDA135E /* MTIHighPassSkinSmoothingFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIHighPassSkinSmoothingFilter.h; sourceTree = "<group>"; };
+		E181A25A6EC0192F4F1DDE8663024BC1 /* MTIRenderGraphOptimization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIRenderGraphOptimization.m; sourceTree = "<group>"; };
+		E26357780DD62E344BD10535B3506ED0 /* MTIImageRenderingContext.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = MTIImageRenderingContext.mm; sourceTree = "<group>"; };
+		E2C57730B41EDFAE73C8D8B27CBE6141 /* MTIMPSHistogramFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMPSHistogramFilter.h; sourceTree = "<group>"; };
+		E37586BF578B4525A0B57C8582D0806F /* MTIMPSUnsharpMaskFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMPSUnsharpMaskFilter.m; sourceTree = "<group>"; };
+		E38442D57A8DACAF91730D558EF79B1F /* MTIRenderPassOutputDescriptor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRenderPassOutputDescriptor.h; sourceTree = "<group>"; };
+		E3FA2955EA8BA3CB3A227F45B4AF157F /* MTIPrint.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIPrint.h; sourceTree = "<group>"; };
+		E4EA106367C04661E8A3F5B965F7BE99 /* MTIBlendWithMaskFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIBlendWithMaskFilter.h; sourceTree = "<group>"; };
+		E6FD6F97D9EFA6B45B9940556F254FED /* MTIMPSUnsharpMaskFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMPSUnsharpMaskFilter.h; sourceTree = "<group>"; };
+		E920DDB803B2B025ECF52E333E3C019D /* MTIGeometry.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIGeometry.h; sourceTree = "<group>"; };
+		EA242206C2A041F41FFF9ABEA6EC9E83 /* MTIChromaKeyBlendFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIChromaKeyBlendFilter.m; sourceTree = "<group>"; };
 		EAEC6C95B85D55EF3D014027CCE1C13C /* Pods-MetalPetalDemo-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-MetalPetalDemo-Info.plist"; sourceTree = "<group>"; };
+		ECD39D4C09DA6FBAF0A4054864838409 /* MTIHighPassSkinSmoothingFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIHighPassSkinSmoothingFilter.m; sourceTree = "<group>"; };
 		ED967B218BF3820C9841DDAD64AFCA4C /* MultilayerCompositingFilter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MultilayerCompositingFilter.swift; sourceTree = "<group>"; };
-		EE8480BF4E03B23C283F26BCED87275C /* MTIBulgeDistortionFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIBulgeDistortionFilter.h; sourceTree = "<group>"; };
-		F045DF47046828B214B57A01EE2CE1CB /* MTITransformFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTITransformFilter.h; sourceTree = "<group>"; };
-		F09AB7E786103C9423194FA6801C22C5 /* MTIGeometryUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIGeometryUtilities.h; sourceTree = "<group>"; };
-		F1DAC9B5A3B49A9ADC814F3FC039DE86 /* MTIUnaryImageRenderingFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIUnaryImageRenderingFilter.h; sourceTree = "<group>"; };
+		EEEEA1D2382D37319085A3C7E019A115 /* MTIError.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIError.m; sourceTree = "<group>"; };
+		EF5CA4F1A19F24699089C00C27638B20 /* MTIUnaryImageRenderingFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIUnaryImageRenderingFilter.h; sourceTree = "<group>"; };
+		F0AAC758A632963D76270F37E3A0FDF4 /* MTIVector.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIVector.m; sourceTree = "<group>"; };
+		F129A8C0AEAD9A4A17CDD39989E2FF52 /* MTISamplerDescriptor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTISamplerDescriptor.m; sourceTree = "<group>"; };
+		F2856969EB19D2C5D930FF3F776944EE /* MTIComputePipeline.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIComputePipeline.m; sourceTree = "<group>"; };
+		F2C65459BB7F43240B20E55F19FAF375 /* MTIVertex.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIVertex.h; sourceTree = "<group>"; };
+		F504AA4539923C2283DCECE5B242F5E5 /* MTIMemoryWarningObserver.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMemoryWarningObserver.h; sourceTree = "<group>"; };
+		F6108799C47A88E63AF47ACADF3A00FD /* MTIDotScreenFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIDotScreenFilter.m; sourceTree = "<group>"; };
 		F6956F80885792D34F389794FF5515D9 /* MTISIMDArgumentEncoder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTISIMDArgumentEncoder.swift; sourceTree = "<group>"; };
-		F772F315645B48157EA0D1CF9B5CF156 /* MTIChromaKeyBlendFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIChromaKeyBlendFilter.m; sourceTree = "<group>"; };
-		F83BE4B1777D61472E81650FB4856E60 /* MTIRenderGraphOptimization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRenderGraphOptimization.h; sourceTree = "<group>"; };
-		F9A17AAE698190BA322F3EF9B5A65A31 /* MTIBlendFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIBlendFilter.m; sourceTree = "<group>"; };
-		FC8A2DCE49C750BE184056A2DC8D6094 /* MTICVMetalTextureCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICVMetalTextureCache.h; sourceTree = "<group>"; };
-		FD5E74278D4181FCEF4726543190DE5F /* MTIImageRenderingContext.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = MTIImageRenderingContext.mm; sourceTree = "<group>"; };
-		FDE03ED95EE77C567C4AEF8E5A1513A0 /* MTIContext+Rendering.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MTIContext+Rendering.h"; sourceTree = "<group>"; };
-		FE75488F101C48B296323A7CB423CABF /* MTICoreImageRendering.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICoreImageRendering.h; sourceTree = "<group>"; };
+		F6E359C6A48CB2155DF5A0DDA9632E35 /* MTIRenderCommand.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIRenderCommand.m; sourceTree = "<group>"; };
+		F83F1920910E673263CFB9E45D61E24B /* MTIHexagonalBokehBlurFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIHexagonalBokehBlurFilter.h; sourceTree = "<group>"; };
+		FB66385CD659C33619A6F89BC435A041 /* MTIContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIContext.h; sourceTree = "<group>"; };
+		FCA76D8C59404EABF5C3DF143DD12B02 /* MTIImage+Filters.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "MTIImage+Filters.m"; sourceTree = "<group>"; };
+		FE331423244833C1C311ED905A3894E1 /* MTICVPixelBufferPool.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICVPixelBufferPool.h; sourceTree = "<group>"; };
+		FE6915BEFC927DF11C1D78E302D60A1F /* MTIBlendWithMaskFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIBlendWithMaskFilter.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -482,11 +484,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		F876E874174818DBB04C368CFE1F0CF0 /* Frameworks */ = {
+		A2E29C7E95E1B2000DDFA5B982916C3F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				698CFEF202E062B62E46A374EFAAE70D /* Foundation.framework in Frameworks */,
+				1FD50FC568A7D704F63A2D7F208DE670 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -519,6 +521,141 @@
 			name = Swift;
 			sourceTree = "<group>";
 		};
+		10A346B45DA3EE9488B4217127D0D3C6 /* Shaders */ = {
+			isa = PBXGroup;
+			children = (
+				667966AD30020077DA795C3C18C52558 /* BlendingShaders.metal */,
+				D3C7B6E32479024359634B347A91E0D4 /* CLAHE.metal */,
+				02579605A28E576467C92615450AC894 /* ColorConversionShaders.metal */,
+				536313D4BBEFB5BD20C7CAFA097AB693 /* Halftone.metal */,
+				5A94EB3B45C2C5B6C13888F920C4D3ED /* HighPassSkinSmoothing.metal */,
+				0BC009493F548ADCBC1ADE0611B51F95 /* LensBlur.metal */,
+				B2EAA5288D9AB128D1D2C4232528F283 /* MTIShaderFunctionConstants.h */,
+				6C69C797E40401744545441EFEB071D9 /* MTIShaderLib.h */,
+				270481E63FC9B9128C135FD1450ED4B8 /* MultilayerCompositeShaders.metal */,
+				4B8A56911E6F355A867C448317A24ED8 /* Shaders.metal */,
+			);
+			name = Shaders;
+			path = Shaders;
+			sourceTree = "<group>";
+		};
+		1C4FC2D8E3A775E52F591D874244319E /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				7849F3C8538B419AD017F5D050446D2A /* MetalPetal.h */,
+				C6479525A04A41BA443EE169937ACE75 /* MTIAlphaType.h */,
+				DE7351B22C7AB93628DC57B4D2CDA6F8 /* MTIAlphaType.m */,
+				679A37895EC9F27F8BC5396FC3FEF6BF /* MTIBlendFormulaSupport.h */,
+				05C66E6AFF20587B07B2E966A6A1D0A9 /* MTIBlendFormulaSupport.mm */,
+				9F369250749CEA3FD05B2E2E6D8BEA0C /* MTIBlendModes.h */,
+				BE7948D8AB11AF33255EC4BD5256AF7D /* MTIBlendModes.m */,
+				0EF4C6CCA87B0A7ED6B528B9EF00391F /* MTIBuffer.h */,
+				32C678968CF2E2CC996CC4F70CEED2B6 /* MTIBuffer.m */,
+				0AD143EFB1556A622006CAA5324049C6 /* MTIColor.h */,
+				1D8F08D4FD37615A67EDD83D4E2176B2 /* MTIColor.m */,
+				D0C2E2A565343BD3C34EF9EE7761C03A /* MTIColorMatrix.h */,
+				05A4935EB223201339B14A22D2FE7845 /* MTIColorMatrix.m */,
+				13126AEAEF3D8AE022EB95AA6D2FB2D6 /* MTIComputePipeline.h */,
+				F2856969EB19D2C5D930FF3F776944EE /* MTIComputePipeline.m */,
+				FB66385CD659C33619A6F89BC435A041 /* MTIContext.h */,
+				BE357AC542883DB4D087D84CC1DDA02E /* MTIContext.m */,
+				4DEFE522353775645479595270728273 /* MTIContext+Internal.h */,
+				9CAD2273320E618C229D82E3F500B4CF /* MTIContext+Rendering.h */,
+				A721B1ACEAD3E9D9DA3E515AA4462584 /* MTIContext+Rendering.m */,
+				4D6A57A0CBF92626D2F1CBBB6468E979 /* MTICoreImageRendering.h */,
+				2898A7973E4E644DA8B782690238C0DA /* MTICoreImageRendering.m */,
+				634D3C18B59D7AA2B67EDEA17C00E7EA /* MTICVMetalIOSurfaceBridge.h */,
+				1EE350F6CCD35817F08499268062BCEF /* MTICVMetalIOSurfaceBridge.m */,
+				6FE8837A7BB63E3F7156A222C5073B03 /* MTICVMetalTextureBridging.h */,
+				0ED8D5077B159E8DDF17721711D92723 /* MTICVMetalTextureCache.h */,
+				4B91F6134F13DAC7E31458970C968234 /* MTICVMetalTextureCache.m */,
+				FE331423244833C1C311ED905A3894E1 /* MTICVPixelBufferPool.h */,
+				3D8E3C7C6C0AD69A5BF8A49E54A63C04 /* MTICVPixelBufferPool.m */,
+				ACC3B9BA82EAA846CB3E21DFC42B65BC /* MTICVPixelBufferPromise.h */,
+				0F3835D9C09A2F3027A6ADD33EB0AE24 /* MTICVPixelBufferPromise.m */,
+				43609648848E5F567A7FABD1218CAE1D /* MTICVPixelBufferRendering.h */,
+				CFED737389BF486E8363CCF28E2DA40D /* MTICVPixelBufferRendering.m */,
+				61EFE1B44FF83757530F511DEB7D8BC0 /* MTIDefer.h */,
+				6222FCFB35B35E00038476E09741B9EA /* MTIDefer.m */,
+				ACD44E37F73AFF532F6F2E4C26A29209 /* MTIDrawableRendering.h */,
+				99388288BE9BD3B425D97C4AA053BDD7 /* MTIDrawableRendering.m */,
+				89A372D6E21F515D9907A8A5523C3F8A /* MTIError.h */,
+				EEEEA1D2382D37319085A3C7E019A115 /* MTIError.m */,
+				4F1584D72463FD5A4B2317C6B619EE44 /* MTIFunctionArgumentsEncoder.h */,
+				0D780E63B6B0F03C292D25BC4BF52CAD /* MTIFunctionArgumentsEncoder.m */,
+				DF9A879D13E400B915610E773F2F9106 /* MTIFunctionDescriptor.h */,
+				B864E44D9A93D5B877CC1FCF099CD527 /* MTIFunctionDescriptor.m */,
+				E920DDB803B2B025ECF52E333E3C019D /* MTIGeometry.h */,
+				178E40ECCDB78DB0FD9B2D40AD655F24 /* MTIGeometry.m */,
+				70373E960472CA0797C7F4DD8668BD94 /* MTIGeometryUtilities.h */,
+				27C22BD1826DBD424CB535FDE5EAB186 /* MTIGeometryUtilities.m */,
+				B4265EEB236C009CB0DFDF4D954F33AB /* MTIHasher.h */,
+				1C78A301CC30E1A77B3474864AE36D7A /* MTIHasher.m */,
+				398B73A915C2D59188AA9D5D4FB70E0D /* MTIImage.h */,
+				B595DAD1C234B1F70C90D054860B0FB6 /* MTIImage.m */,
+				72BA29B2881466D8F2D01877989CCB9B /* MTIImage+Promise.h */,
+				68B5CCEC43F83625FC32B5302B7F9477 /* MTIImageOrientation.h */,
+				7FE5E3474304EBC74E4D050B97716F4F /* MTIImageOrientation.m */,
+				55EFE23113DA1F16D2F4AF25D0FEB371 /* MTIImagePromise.h */,
+				BA8891D1A558E880C80BAC28DEABE906 /* MTIImagePromise.m */,
+				25BD9BA7AE2F69C2CCBA1A2B35F105E1 /* MTIImagePromiseDebug.h */,
+				5A376CED1F2B72D755F0725F4F267A93 /* MTIImagePromiseDebug.m */,
+				490807A8C291D7C2E0BD9F2E16A646E4 /* MTIImageProperties.h */,
+				160151F161CB13F459B062CED8802237 /* MTIImageProperties.m */,
+				B7C61DED1E4EFA9CB46233160E9F2EBB /* MTIImageRenderingContext.h */,
+				E26357780DD62E344BD10535B3506ED0 /* MTIImageRenderingContext.mm */,
+				89FEA9B7C91BC359581BACDC57D6F8B1 /* MTIImageRenderingContext+Internal.h */,
+				A48BB00E5FA51B17E49206D3648D8B16 /* MTILayer.h */,
+				57FB1E7FCF1B44DA4A5E7F23EB244A82 /* MTILayer.m */,
+				72E1C5AA10525212DBBD50DC8FCD79A5 /* MTILibrarySource.h */,
+				26646DD1E036FB52BDF6AFA612989DC3 /* MTILibrarySource.m */,
+				9EA016D063952EE35D8B939A79CDC459 /* MTILock.h */,
+				2C4A0F1CA12FECB5365A8153685A66FB /* MTILock.m */,
+				2AD0C95DE4CC49839465DDBE56B4CB27 /* MTIMask.h */,
+				42CA419BDB2F8F6E46CF3B582812299B /* MTIMask.m */,
+				F504AA4539923C2283DCECE5B242F5E5 /* MTIMemoryWarningObserver.h */,
+				03211368F7652876292FE0561439A47B /* MTIMemoryWarningObserver.m */,
+				9B3EF613A9DF583F91FD2B6CEC95D6F8 /* MTIPixelFormat.h */,
+				A7B9C14E61E56A83D9368EF3A09C8C61 /* MTIPixelFormat.m */,
+				E3FA2955EA8BA3CB3A227F45B4AF157F /* MTIPrint.h */,
+				CA86E9784DC4C48C67C3DCC6FB024DCB /* MTIRenderGraphOptimization.h */,
+				E181A25A6EC0192F4F1DDE8663024BC1 /* MTIRenderGraphOptimization.m */,
+				E38442D57A8DACAF91730D558EF79B1F /* MTIRenderPassOutputDescriptor.h */,
+				95E031DFFD3F4A30E6F4B6CB0E414B72 /* MTIRenderPassOutputDescriptor.m */,
+				BEED677BCAF818A7E241223566B45F4F /* MTIRenderPipeline.h */,
+				34079501D0E96E94E89259340717F0A3 /* MTIRenderPipeline.m */,
+				58DB4177664FD7FE0CE6C226EBD618D1 /* MTIRenderTask.h */,
+				6E41DBB1BD4BE7CDA82345FE6D53A524 /* MTIRenderTask.m */,
+				653B817921D29F09E0CF496BA38303EF /* MTISamplerDescriptor.h */,
+				F129A8C0AEAD9A4A17CDD39989E2FF52 /* MTISamplerDescriptor.m */,
+				7F0AD4AA5EAEF72BC66DB4A8F1FBBDC2 /* MTITextureDescriptor.h */,
+				1765F24DA26B8F34E3FE119C1FD84487 /* MTITextureDescriptor.m */,
+				A98CA48DA90740DA3A5ED193A9D9C7E5 /* MTITextureDimensions.h */,
+				062C600B5E9D962937EBDC1A4B9323F4 /* MTITextureDimensions.m */,
+				75A8528944308AB6F22335710D46D955 /* MTITextureLoader.h */,
+				D114BA13F24EF82E279FF3669CBD77AE /* MTITextureLoader.m */,
+				8D92E4F5CBED7A5A7D81D9C311029B47 /* MTITexturePool.h */,
+				7FEC3E6303CC592CDFCFD2C903670437 /* MTITexturePool.mm */,
+				9E3210E6A5683F8D448047A8D153D3D2 /* MTITransform.h */,
+				7E80B756B982A36B3D292D6C93A900B9 /* MTITransform.m */,
+				36A21F2F754582A8D6EABA982DB005D3 /* MTIVector.h */,
+				F0AAC758A632963D76270F37E3A0FDF4 /* MTIVector.m */,
+				CE669A1E167194251732A995A577ADE4 /* MTIVector+SIMD.h */,
+				AD17B52170742E4D3F0FDBEB6BEDDC11 /* MTIVector+SIMD.m */,
+				F2C65459BB7F43240B20E55F19FAF375 /* MTIVertex.h */,
+				022EFC32DB63E480A2840CD46BC4C4F0 /* MTIVertex.m */,
+				A324DCB96C0FFFE3FA21C097A7126AC3 /* MTIWeakToStrongObjectsMapTable.h */,
+				2392A2383A76EE8F4020EADDC119D1C4 /* MTIWeakToStrongObjectsMapTable.m */,
+				8576963ECD654AE349E28C06B8D78A54 /* Filters */,
+				5C34A01EEED09BDF60112D2CEC249DB3 /* Kernels */,
+				F7BA75F78E39EE438B7968C0EFE52686 /* SceneKit */,
+				10A346B45DA3EE9488B4217127D0D3C6 /* Shaders */,
+				4E8890A7C8F78B476F23C9AA7220C508 /* SpriteKit */,
+				F9707FDB3D92B15734937F1A1626C808 /* UI */,
+			);
+			name = Core;
+			sourceTree = "<group>";
+		};
 		277A376137F7DAD2A152467C0D20421B /* Pod */ = {
 			isa = PBXGroup;
 			children = (
@@ -526,159 +663,6 @@
 				005DFD14213AA63B85AE55644C51BEA9 /* MetalPetal.podspec */,
 			);
 			name = Pod;
-			sourceTree = "<group>";
-		};
-		37294C6446EBC66686DA3AE69C094C27 /* Core */ = {
-			isa = PBXGroup;
-			children = (
-				29B708591E96EFA4BC1BC999DA114D3D /* MetalPetal.h */,
-				3D34335ADC9ED66E82E9CF8DFB63F3F3 /* MTIAlphaType.h */,
-				5DC3F8207CFAAC737A1DFF48239199B0 /* MTIAlphaType.m */,
-				6A3AA61E4DC06647448CA24CEF27AD9D /* MTIBlendFormulaSupport.h */,
-				682900B3D786C9F4B3A58B3C142F054E /* MTIBlendFormulaSupport.mm */,
-				9081AA72F478E687A6E8F3B5D7D2C695 /* MTIBlendModes.h */,
-				A431037551AAF3CA52FCAF307E2BD93A /* MTIBlendModes.m */,
-				C148193F3B729CEFD8B8A282D4E0B37B /* MTIBuffer.h */,
-				D60AADA47F1834E755A0C41B6042CCAF /* MTIBuffer.m */,
-				84CB0268F88EE6A80D8F07052EA7A69D /* MTIColor.h */,
-				C020930B4362CBF063F0EAAA6162FF45 /* MTIColor.m */,
-				7480CDF9696845AAE86B3FE3A1282323 /* MTIColorMatrix.h */,
-				C9341F7A1F3E62D93D34ACB037FCF283 /* MTIColorMatrix.m */,
-				90D4397D716DA7D688ED77CE9CCB5369 /* MTIComputePipeline.h */,
-				771793A2A60E4341F83C7FC36DDB4216 /* MTIComputePipeline.m */,
-				10A1A9ED09C7E9FAF2F6D5E6ECF7707C /* MTIContext.h */,
-				A6802FEA6C73888CAE5CF06B860A7BF4 /* MTIContext.m */,
-				7B9A5C5872D5A8F0334590A3855B0DBA /* MTIContext+Internal.h */,
-				FDE03ED95EE77C567C4AEF8E5A1513A0 /* MTIContext+Rendering.h */,
-				76CEB5758B60E3B42FB780A8BBEE75B4 /* MTIContext+Rendering.m */,
-				FE75488F101C48B296323A7CB423CABF /* MTICoreImageRendering.h */,
-				2A897E1269E33424151E7A242885A423 /* MTICoreImageRendering.m */,
-				41E39614F2AEEB175FCC6F0F428747FF /* MTICVMetalIOSurfaceBridge.h */,
-				DF537F7A9A72644759B75F600A566DE1 /* MTICVMetalIOSurfaceBridge.m */,
-				C31694634F18EB151F94CDDCC4A1C1CA /* MTICVMetalTextureBridging.h */,
-				FC8A2DCE49C750BE184056A2DC8D6094 /* MTICVMetalTextureCache.h */,
-				3A349F92F03DC2A923845D2C00AF9486 /* MTICVMetalTextureCache.m */,
-				8149A338AC9B24DCADC5C9DDD30E40CE /* MTICVPixelBufferPool.h */,
-				0F2E6A40946FCA93AA656A0E66A0F0B4 /* MTICVPixelBufferPool.m */,
-				411EAD7B92F9A6F4ABF5B93C0FFFAB1E /* MTICVPixelBufferPromise.h */,
-				8C5688196AC43221CC7F06788E4F44CF /* MTICVPixelBufferPromise.m */,
-				8E2FDC2CF0ADB745A7F21E2913358013 /* MTICVPixelBufferRendering.h */,
-				2704D4D68ECBEF5F74393C96D657EC44 /* MTICVPixelBufferRendering.m */,
-				7C40AB7CDF7B77E1AB437A2CD2801C78 /* MTIDefer.h */,
-				56FAA0A2415D05D5CBDB5EF54E9734BF /* MTIDefer.m */,
-				42D226BA2B4C19500965081D4EA294A7 /* MTIDrawableRendering.h */,
-				9DDF88D24AECEEB18B2D9B4288BF6C02 /* MTIDrawableRendering.m */,
-				A817A8F3ED1400371D5A3C53DB9C48CD /* MTIError.h */,
-				54465B216A991179386A9001C8AD45D0 /* MTIError.m */,
-				E6D6D3137D202883FCD337168C3410C2 /* MTIFunctionArgumentsEncoder.h */,
-				583BA45980FE3F5172DD0DFB878C5D5A /* MTIFunctionArgumentsEncoder.m */,
-				22F41B70EACCBF98657AD2CC6A9D6892 /* MTIFunctionDescriptor.h */,
-				79598357110B01300FE1C1C13EC4782D /* MTIFunctionDescriptor.m */,
-				C84B38774E5EF7F53888666906AB5FAA /* MTIGeometry.h */,
-				86DA02E3BE110C898754DC50D588A626 /* MTIGeometry.m */,
-				F09AB7E786103C9423194FA6801C22C5 /* MTIGeometryUtilities.h */,
-				7A863AA532943C9EA9E79603515C3594 /* MTIGeometryUtilities.m */,
-				E9BA8DEA27E8473D0496E03599269227 /* MTIHasher.h */,
-				46BA53C30D5C5BD0640A42DDFEC91E33 /* MTIHasher.m */,
-				E683F9E1DE6AF4709C7E566B27EE0BE9 /* MTIImage.h */,
-				E72464AB19C80A06A585AF6569B35054 /* MTIImage.m */,
-				3F38149B2B9EF53FB1AB1BFEB4D642C2 /* MTIImage+Promise.h */,
-				78C43373C8E7DC3522A292CB68C4BE9E /* MTIImageOrientation.h */,
-				74061F6AAECA5B7ABF7500FB689EA692 /* MTIImageOrientation.m */,
-				462DED185217EBC002A82A9BC744ACD5 /* MTIImagePromise.h */,
-				D1C68188E9EF03F3E41F6EDD633B44D0 /* MTIImagePromise.m */,
-				3A8BF44F331C40A4A5A9A855182A2161 /* MTIImagePromiseDebug.h */,
-				CC8245F807EEDFD9F98FCEF1B351D3C7 /* MTIImagePromiseDebug.m */,
-				CBD4ADD0029458CD8379EAE8E7358007 /* MTIImageProperties.h */,
-				D5512E421942EBB49268D69EE940CE00 /* MTIImageProperties.m */,
-				691D273F8D681266E9B10752D0CD0454 /* MTIImageRenderingContext.h */,
-				FD5E74278D4181FCEF4726543190DE5F /* MTIImageRenderingContext.mm */,
-				935FDC03670DF769B93631BF0ECFB04A /* MTIImageRenderingContext+Internal.h */,
-				D1DE18D9F58B6EF781D4EFC6CAC8A446 /* MTILayer.h */,
-				825C53F63F41C797BC4981CCF22343F8 /* MTILayer.m */,
-				334D1276AB7BB37A7966E6CEDDC506EC /* MTILibrarySource.h */,
-				0447D7BAE13A371E68D47BA41528269A /* MTILibrarySource.m */,
-				376981EFA3B717CCE86297270C7B2E58 /* MTILock.h */,
-				92FC9F8B0D958B462B847FD6F41E1BCB /* MTILock.m */,
-				60E2ED62310B9ADBA4C447F7851C2722 /* MTIMask.h */,
-				1BD88D7605EC9D4FE51AFEB36C5CE2F3 /* MTIMask.m */,
-				827513924F896DCB764FE701AEFCA9C5 /* MTIMemoryWarningObserver.h */,
-				7DF1BFDED9A39703FEF7CEF979229440 /* MTIMemoryWarningObserver.m */,
-				E6CFF1002699AB1C75E6D7169AD10772 /* MTIPixelFormat.h */,
-				94B7EB9DE2F53BD26A69F2745A6923D3 /* MTIPixelFormat.m */,
-				3256B897FDD8338AC18560B1DA10C0A0 /* MTIPrint.h */,
-				F83BE4B1777D61472E81650FB4856E60 /* MTIRenderGraphOptimization.h */,
-				78BE5AC27645F3E7CB1D1BD955CF9C7A /* MTIRenderGraphOptimization.m */,
-				D2696BB30F7D660904F5CBC010AD3415 /* MTIRenderPassOutputDescriptor.h */,
-				4C62938684F93FE4ABD8F01C03618074 /* MTIRenderPassOutputDescriptor.m */,
-				17448C2E4F9235E3A1EBB2ABCF84A0EE /* MTIRenderPipeline.h */,
-				BC5E0F4AB88F9140148CF4FCB36FA836 /* MTIRenderPipeline.m */,
-				5E32DDB1FE676E809383369ABB3347EE /* MTIRenderTask.h */,
-				B201151C616B126936CFBF624AB97D7B /* MTIRenderTask.m */,
-				ABF631EB1B40A6CB8DFBA45BD271EACE /* MTISamplerDescriptor.h */,
-				0DFB3E6CA7B5FBF44D0AEB9C5E46FDA1 /* MTISamplerDescriptor.m */,
-				0A0EED9736CC728C77562D4836D644AE /* MTITextureDescriptor.h */,
-				5EECD0ADFA2ABB7E0DD686573C413F5B /* MTITextureDescriptor.m */,
-				182194D34BA8667C762FB8BB906B9789 /* MTITextureDimensions.h */,
-				3DB0AD25B9D6A79975853E926F3DA0CB /* MTITextureDimensions.m */,
-				C40E942AC5FEDE1B917A3EC8DF038ED1 /* MTITextureLoader.h */,
-				692136E53CACE8CAAE2910F5A7DFCEAE /* MTITextureLoader.m */,
-				DF5FD054F0E76B597090379B7D703AFB /* MTITexturePool.h */,
-				B761B42FA4E54934723152A21E74A3D5 /* MTITexturePool.mm */,
-				6A348ABAE37C19B03E2184C2D92B1188 /* MTITransform.h */,
-				DE020F57431B0DF4121CAAE397734F8A /* MTITransform.m */,
-				BF690F8C9F79671A66CE8E9BE6A6D5E0 /* MTIVector.h */,
-				A5796517B48A5D5532483528B2CAC31B /* MTIVector.m */,
-				4F9DF86342B4EC11138454DF936D55D4 /* MTIVector+SIMD.h */,
-				30D1E273724BFDF49C8ECBEFFF5A5BA0 /* MTIVector+SIMD.m */,
-				83777152C6ACEC39F21DF11858ADA6A7 /* MTIVertex.h */,
-				B76A35A22A307B122ADDC35870B575B8 /* MTIVertex.m */,
-				822B374D1B7AC61401EDF66E89E801D0 /* MTIWeakToStrongObjectsMapTable.h */,
-				17B89A6774A590C405D8CB8F871AC395 /* MTIWeakToStrongObjectsMapTable.m */,
-				62BBBA24A45BEAA900B0F0E89D0F5A3D /* Filters */,
-				44D62716C36BD357DE21921982937A0A /* Kernels */,
-				C0F1294030CAB380CEC784EA5A60765E /* SceneKit */,
-				3B09619234C212D6AF52E9FF760862A6 /* Shaders */,
-				AF9ECBE522D78FE07B7AE5CFF16CC83F /* SpriteKit */,
-				5F564B2060464258E3C30BEA2034CE19 /* UI */,
-			);
-			name = Core;
-			sourceTree = "<group>";
-		};
-		3B09619234C212D6AF52E9FF760862A6 /* Shaders */ = {
-			isa = PBXGroup;
-			children = (
-				A6F8624B08A618DE7C915EC491E998AD /* BlendingShaders.metal */,
-				CC960FB45A6A1F47881BFA02883F1C96 /* CLAHE.metal */,
-				E186B4EF06532CD3702854030AC50048 /* ColorConversionShaders.metal */,
-				765CD1D513DCC53DF5E439FAB1C8475A /* Halftone.metal */,
-				79202407595B995A13EA91C0416CC03C /* HighPassSkinSmoothing.metal */,
-				88614D896761050099A8A798078CAD80 /* LensBlur.metal */,
-				82198882F891F495127AF2EE5EF1DC85 /* MTIShaderLib.h */,
-				CFF3B11C4EA905C987073D3924975F67 /* MultilayerCompositeShaders.metal */,
-				E78BAFBC08B2773B47E9449DA6A8D336 /* Shaders.metal */,
-			);
-			name = Shaders;
-			path = Shaders;
-			sourceTree = "<group>";
-		};
-		44D62716C36BD357DE21921982937A0A /* Kernels */ = {
-			isa = PBXGroup;
-			children = (
-				A940799E64A89F80E8498F3420D15260 /* MTIComputePipelineKernel.h */,
-				6350A1CB8B7A21F46B78F7B2E98B0521 /* MTIComputePipelineKernel.m */,
-				80E8535AF70B8B0BA370C1F8681B3EB4 /* MTIKernel.h */,
-				91B7AE11A52CF2257DDFD39FC4639BEE /* MTIMPSKernel.h */,
-				04021D79209A22A71378929D740E21BF /* MTIMPSKernel.m */,
-				32FFE8A4A958E6BCE240E1054C901B14 /* MTIMultilayerCompositeKernel.h */,
-				8A91AB0A419FE0AB6226B47C35DC34C0 /* MTIMultilayerCompositeKernel.m */,
-				A8F7E869E863C72F0010F9451DD1B502 /* MTIRenderCommand.h */,
-				DEC0DCDB61AFEC013ADA8C8A0E060D6F /* MTIRenderCommand.m */,
-				C1C5EDF47FF82766EF253886656FA74A /* MTIRenderPipelineKernel.h */,
-				6F75F8E55D72FC0AAE6AF558354893E6 /* MTIRenderPipelineKernel.m */,
-			);
-			name = Kernels;
-			path = Kernels;
 			sourceTree = "<group>";
 		};
 		4D8547F86081AE6DE8622964FD193CEC /* Filters */ = {
@@ -692,6 +676,16 @@
 			path = Filters;
 			sourceTree = "<group>";
 		};
+		4E8890A7C8F78B476F23C9AA7220C508 /* SpriteKit */ = {
+			isa = PBXGroup;
+			children = (
+				A1BEE5582D885439E9BF198942052088 /* MTISKSceneRenderer.h */,
+				920B9E425DFC7C31D98C55CC861A0F73 /* MTISKSceneRenderer.m */,
+			);
+			name = SpriteKit;
+			path = SpriteKit;
+			sourceTree = "<group>";
+		};
 		578452D2E740E91742655AC8F1636D1F /* iOS */ = {
 			isa = PBXGroup;
 			children = (
@@ -700,84 +694,23 @@
 			name = iOS;
 			sourceTree = "<group>";
 		};
-		5F564B2060464258E3C30BEA2034CE19 /* UI */ = {
+		5C34A01EEED09BDF60112D2CEC249DB3 /* Kernels */ = {
 			isa = PBXGroup;
 			children = (
-				7FA9A3F636E1BC52D86EE736D0F908E5 /* MTIImageView.h */,
-				60DE3B29A8D244B28096E314A9F38DB6 /* MTIImageView.m */,
-				3A73490F7FBC21A2D26096D7346BDE0F /* MTIThreadSafeImageView.h */,
-				5C70E88E5545B63745C2B2D3AB03EE68 /* MTIThreadSafeImageView.m */,
+				134654EA038168008A67DE508D6D4B07 /* MTIComputePipelineKernel.h */,
+				1840031625149F92C9D4B6F5263C6508 /* MTIComputePipelineKernel.m */,
+				52B9D0F2C4A0C54888681D4BFC252079 /* MTIKernel.h */,
+				CE50B20A2C3620CCEFE6014D9DB6DA65 /* MTIMPSKernel.h */,
+				C32FC755A52CE99E274D243DB60DDB3B /* MTIMPSKernel.m */,
+				8DD28B6BAE689B1C53CE1071A179D5D7 /* MTIMultilayerCompositeKernel.h */,
+				A2A5AE3DE15150AF151C33405438F5D7 /* MTIMultilayerCompositeKernel.m */,
+				6023C5FC0CA683525D59511FA9B15748 /* MTIRenderCommand.h */,
+				F6E359C6A48CB2155DF5A0DDA9632E35 /* MTIRenderCommand.m */,
+				1190F7C1CBDDC5F4E9758676F2AE014F /* MTIRenderPipelineKernel.h */,
+				A4A858DAAD6A965BCF2E594658D583AB /* MTIRenderPipelineKernel.m */,
 			);
-			name = UI;
-			path = UI;
-			sourceTree = "<group>";
-		};
-		62BBBA24A45BEAA900B0F0E89D0F5A3D /* Filters */ = {
-			isa = PBXGroup;
-			children = (
-				4BF1D573A3D2FB02D5394C021B7190BB /* MTIAlphaPremultiplicationFilter.h */,
-				017E8CEBEC7896E0BD86B0BFC883F38E /* MTIAlphaPremultiplicationFilter.m */,
-				B1EE4F5B4A078E85AFA072199F881C17 /* MTIBlendFilter.h */,
-				F9A17AAE698190BA322F3EF9B5A65A31 /* MTIBlendFilter.m */,
-				9A1D58E560C44C6DBDD985E536D6BFDE /* MTIBlendWithMaskFilter.h */,
-				CB37301CCDE806AB3B461B46D4A0892D /* MTIBlendWithMaskFilter.m */,
-				EE8480BF4E03B23C283F26BCED87275C /* MTIBulgeDistortionFilter.h */,
-				2E0D90CC84894318DB55CE51578E507B /* MTIBulgeDistortionFilter.m */,
-				508ECCFFAEDBC424B2868384462985FB /* MTIChromaKeyBlendFilter.h */,
-				F772F315645B48157EA0D1CF9B5CF156 /* MTIChromaKeyBlendFilter.m */,
-				C4FE10061A867C198269C2D587DCEF2C /* MTICLAHEFilter.h */,
-				2BF80F72D70ACE02C8A43B666886282F /* MTICLAHEFilter.m */,
-				DFA64C8D21F1C7851C9B0D475A9543A6 /* MTIColorHalftoneFilter.h */,
-				21AA4C22D9BE7F8481CB8F165BFFDE4B /* MTIColorHalftoneFilter.m */,
-				081D0B68C18113024A52925BA2D7F723 /* MTIColorLookupFilter.h */,
-				620CB9D86964842C0E9F224DFD8EEAF4 /* MTIColorLookupFilter.m */,
-				50CFD0757D9AC50BADE1AE2FBB4C17DC /* MTIColorMatrixFilter.h */,
-				C9989AE6C184FA9CD9DD586953E3433A /* MTIColorMatrixFilter.m */,
-				093995D246B4AF578FA9A29F74011A90 /* MTICropFilter.h */,
-				B123F941C7582F65A46EB59FABF250A4 /* MTICropFilter.m */,
-				616594FAC6B27A6075F875D7E23D0EAB /* MTIDotScreenFilter.h */,
-				A08CCF290B4005CC0BC5DC52BF770D4B /* MTIDotScreenFilter.m */,
-				CC302A734DCF5CF01F83752AB33FE076 /* MTIFilter.h */,
-				BFDFDF4F5452205A4C8366819FA0149D /* MTIFilter.m */,
-				12B4F6EDF4B1472AE0BC53723B03D9D4 /* MTIHexagonalBokehBlurFilter.h */,
-				B600A87CA39082EA4BAE8025F471B8DE /* MTIHexagonalBokehBlurFilter.m */,
-				70CF84F0A31BE3EDBE794B17389DBEE9 /* MTIHighPassSkinSmoothingFilter.h */,
-				84F5AC24AA37EEEF84D3E1CDE7B5E606 /* MTIHighPassSkinSmoothingFilter.m */,
-				090B8FDB5B7BA5A225CCC8D51A5CDB62 /* MTIImage+Filters.h */,
-				7143ADF1023D9F602ED861D42D6E9A6F /* MTIImage+Filters.m */,
-				C7BDD6D47791C4508C03C47289A3382B /* MTIMPSBoxBlurFilter.h */,
-				8F31F4C77536F54DB56F54B731F465D1 /* MTIMPSBoxBlurFilter.m */,
-				BAFE24041771958D747DC76A98F2F320 /* MTIMPSConvolutionFilter.h */,
-				364B67452ABEBD63BF0E129E642B487D /* MTIMPSConvolutionFilter.m */,
-				4C6D98518A9FB123DDAC92F1CE0B2875 /* MTIMPSDefinitionFilter.h */,
-				A4E3C9EC289989036013422F5B6AF4C8 /* MTIMPSDefinitionFilter.m */,
-				7963DF11BA0077E8E375441D92A514C5 /* MTIMPSGaussianBlurFilter.h */,
-				6F4A6393034641F4798CBB3D2C79BF27 /* MTIMPSGaussianBlurFilter.m */,
-				624F416CF5A852072F6AAEDEEBFF2186 /* MTIMPSHistogramFilter.h */,
-				920019B9E8653C980E7384086452A571 /* MTIMPSHistogramFilter.m */,
-				E184EC58E8EBBB081F2AA233F3FA1AE4 /* MTIMPSSobelFilter.h */,
-				55B87BE9699FB1674C3758931D904F7C /* MTIMPSSobelFilter.m */,
-				6FAED1CF584C5CA4009EA1E105DA699C /* MTIMPSUnsharpMaskFilter.h */,
-				0E98D625F283124D8E259BA7D2021672 /* MTIMPSUnsharpMaskFilter.m */,
-				89AC1520E80D4FD3E9C005B8999395EF /* MTIMultilayerCompositingFilter.h */,
-				5364A9F1F54B3C07262B472D30679A90 /* MTIMultilayerCompositingFilter.m */,
-				7E55274F6B0BF74DC5390057766E0FC6 /* MTIPixellateFilter.h */,
-				398C4EC9EF22FCE2ABAD722084008E21 /* MTIPixellateFilter.m */,
-				87D8F15A54A9F2FC9ACC0BD652B5A248 /* MTIRGBColorSpaceConversionFilter.h */,
-				3FBC5E880893DF658CE8C42AFDB3EFE1 /* MTIRGBColorSpaceConversionFilter.m */,
-				C4E271B5D630FF9B70789A757064FF56 /* MTIRGBToneCurveFilter.h */,
-				B7DE8BC55DB2B3E345E4092D21340132 /* MTIRGBToneCurveFilter.m */,
-				A78EE2CA9D1B0F614AF227FD4FA86A07 /* MTIRoundCornerFilter.h */,
-				B40915E5D0F2D2231739A8850E333C2C /* MTIRoundCornerFilter.m */,
-				F045DF47046828B214B57A01EE2CE1CB /* MTITransformFilter.h */,
-				B1C7EFF766AB01017BA6E7AD2872CDEE /* MTITransformFilter.m */,
-				F1DAC9B5A3B49A9ADC814F3FC039DE86 /* MTIUnaryImageRenderingFilter.h */,
-				A1E9946A80A087C34E0392DC001BC1B3 /* MTIUnaryImageRenderingFilter.m */,
-				E11B72D9BE78E58E2A89D94CFDD502D4 /* MTIVibranceFilter.h */,
-				15A01A17698EB0654EF17F29ABDECE2F /* MTIVibranceFilter.m */,
-			);
-			name = Filters;
-			path = Filters;
+			name = Kernels;
+			path = Kernels;
 			sourceTree = "<group>";
 		};
 		7095E3E89485535783835F9EDF86A572 /* UI */ = {
@@ -806,10 +739,78 @@
 			path = "Target Support Files/Pods-MetalPetalDemo";
 			sourceTree = "<group>";
 		};
+		8576963ECD654AE349E28C06B8D78A54 /* Filters */ = {
+			isa = PBXGroup;
+			children = (
+				79655AC00AED64FE8A16577D885ECAC7 /* MTIAlphaPremultiplicationFilter.h */,
+				148B6092CB5BC775E49FEE4A67E1B376 /* MTIAlphaPremultiplicationFilter.m */,
+				5AC3C84676FDF5D19F81611C5243C360 /* MTIBlendFilter.h */,
+				CF241CDA8F6B441BB4953C664E14CBCB /* MTIBlendFilter.m */,
+				E4EA106367C04661E8A3F5B965F7BE99 /* MTIBlendWithMaskFilter.h */,
+				FE6915BEFC927DF11C1D78E302D60A1F /* MTIBlendWithMaskFilter.m */,
+				3B26C9F98C517A01E012AE6D18C62AFB /* MTIBulgeDistortionFilter.h */,
+				8D339E430650471E788ABF006A21758D /* MTIBulgeDistortionFilter.m */,
+				25F2A7EE45AA430E6C49A5504107E6B8 /* MTIChromaKeyBlendFilter.h */,
+				EA242206C2A041F41FFF9ABEA6EC9E83 /* MTIChromaKeyBlendFilter.m */,
+				B59C493FE6FDD5D2B8333AD90A088C17 /* MTICLAHEFilter.h */,
+				0315CB67BA8D16F62E325BE549C850AA /* MTICLAHEFilter.m */,
+				39CE823D2A843F63980FAC74D614FFB5 /* MTIColorHalftoneFilter.h */,
+				749C7EA36E5F8012D001DF2695696D0E /* MTIColorHalftoneFilter.m */,
+				BCA1A737A5543861CFCF486A4BEAD173 /* MTIColorLookupFilter.h */,
+				7D7E129DCBA4E7779C331C7F17C30EA5 /* MTIColorLookupFilter.m */,
+				6CB5FEAD683A0979A40A4A5AF0C5C62E /* MTIColorMatrixFilter.h */,
+				5469D751D199F91FBF290D13B15EED78 /* MTIColorMatrixFilter.m */,
+				1F95686506292531717C3231DFA16277 /* MTICropFilter.h */,
+				29CF2B191746FE13A8E3A7C5A7F859D8 /* MTICropFilter.m */,
+				CBD8D80E592D7A2183E4F190A68ADBAA /* MTIDotScreenFilter.h */,
+				F6108799C47A88E63AF47ACADF3A00FD /* MTIDotScreenFilter.m */,
+				0974FB05EEA4A9D10D0B128598790F70 /* MTIFilter.h */,
+				1A10021480415F41B3C4DC24B3A10E2B /* MTIFilter.m */,
+				F83F1920910E673263CFB9E45D61E24B /* MTIHexagonalBokehBlurFilter.h */,
+				05A3AB28CC8F9CB607C20FF9BF7B72B7 /* MTIHexagonalBokehBlurFilter.m */,
+				E09E4D72E0A0564E93051813AEDA135E /* MTIHighPassSkinSmoothingFilter.h */,
+				ECD39D4C09DA6FBAF0A4054864838409 /* MTIHighPassSkinSmoothingFilter.m */,
+				192A23E62DCDA7FA27C5C2EA04252460 /* MTIImage+Filters.h */,
+				FCA76D8C59404EABF5C3DF143DD12B02 /* MTIImage+Filters.m */,
+				72091B0D243215EAC1AC78211BC1D1B5 /* MTIMPSBoxBlurFilter.h */,
+				916B7A8A1D2A74910A90EAC3A80FECE0 /* MTIMPSBoxBlurFilter.m */,
+				64DF907002280C8330B8478F6D16DCA9 /* MTIMPSConvolutionFilter.h */,
+				D10BE2C75A6C593F298042CD00913640 /* MTIMPSConvolutionFilter.m */,
+				160B83A6C820B95BD6210C47EC70DA1A /* MTIMPSDefinitionFilter.h */,
+				4DB26C42ECC81541575FED2660982F3B /* MTIMPSDefinitionFilter.m */,
+				E053B8E9CCD0F411B22A2AE5A31545AC /* MTIMPSGaussianBlurFilter.h */,
+				91C7F17C15A73D10297190DF6CBC4825 /* MTIMPSGaussianBlurFilter.m */,
+				E2C57730B41EDFAE73C8D8B27CBE6141 /* MTIMPSHistogramFilter.h */,
+				586EF6F15845B15A7B646405D9F07074 /* MTIMPSHistogramFilter.m */,
+				45AA2651BDA08AF62E8A2F4FE9752F5D /* MTIMPSSobelFilter.h */,
+				14E519B47E9A4B0DCB1B499D58E2D170 /* MTIMPSSobelFilter.m */,
+				E6FD6F97D9EFA6B45B9940556F254FED /* MTIMPSUnsharpMaskFilter.h */,
+				E37586BF578B4525A0B57C8582D0806F /* MTIMPSUnsharpMaskFilter.m */,
+				CBF0F576E50377C64B8C9F79A55963D4 /* MTIMultilayerCompositingFilter.h */,
+				D62FB9CAE1D00D594FF8AA44C1E69465 /* MTIMultilayerCompositingFilter.m */,
+				6811B094931CE1FEAE894C427B4DE5C7 /* MTIPixellateFilter.h */,
+				04AE91654A85602AE96DBA70381A36C7 /* MTIPixellateFilter.m */,
+				C51E35307EB9E571F5ADD641ABC5C0CB /* MTIRGBColorSpaceConversionFilter.h */,
+				2B0E1E9318A1609CA3E5DA382AC9B832 /* MTIRGBColorSpaceConversionFilter.m */,
+				6B854D2B3F34C29959D5D41EC66080F7 /* MTIRGBToneCurveFilter.h */,
+				613ECCEE272C2A30923E1E7C634B2545 /* MTIRGBToneCurveFilter.m */,
+				A83710B5CCF3635F0608BCBB58917AB8 /* MTIRoundCornerFilter.h */,
+				175A887448859E15D78AA5E7AA8EE781 /* MTIRoundCornerFilter.m */,
+				DB66AFD5F859F2417471C27B890DB139 /* MTITransformFilter.h */,
+				481119FA39449CC292F9E2FA10EF270E /* MTITransformFilter.m */,
+				EF5CA4F1A19F24699089C00C27638B20 /* MTIUnaryImageRenderingFilter.h */,
+				13A415962D5F0D1661591580D24DE5F9 /* MTIUnaryImageRenderingFilter.m */,
+				5F9593BD03FF7F10C70BCF33A3B18A1A /* MTIVibranceFilter.h */,
+				B30F1E69C911CB2468E77FA1A76A14E8 /* MTIVibranceFilter.m */,
+			);
+			name = Filters;
+			path = Filters;
+			sourceTree = "<group>";
+		};
 		88A8F65E1FF8ABB3DBDE095893027F30 /* MetalPetal */ = {
 			isa = PBXGroup;
 			children = (
-				37294C6446EBC66686DA3AE69C094C27 /* Core */,
+				1C4FC2D8E3A775E52F591D874244319E /* Core */,
 				277A376137F7DAD2A152467C0D20421B /* Pod */,
 				8FC11F5559D8F1BBE06B89FA301C3954 /* Support Files */,
 				0ADB30F5652C9F63DEFCFF562F9B73E9 /* Swift */,
@@ -829,26 +830,6 @@
 			);
 			name = "Support Files";
 			path = "../../Pods/Target Support Files/MetalPetal";
-			sourceTree = "<group>";
-		};
-		AF9ECBE522D78FE07B7AE5CFF16CC83F /* SpriteKit */ = {
-			isa = PBXGroup;
-			children = (
-				CFFF513AA45E92258F737206085A1FB6 /* MTISKSceneRenderer.h */,
-				D918C587147DAC53E119C134F088916E /* MTISKSceneRenderer.m */,
-			);
-			name = SpriteKit;
-			path = SpriteKit;
-			sourceTree = "<group>";
-		};
-		C0F1294030CAB380CEC784EA5A60765E /* SceneKit */ = {
-			isa = PBXGroup;
-			children = (
-				4B036B4C4978458BCDF4DE1444A564DE /* MTISCNSceneRenderer.h */,
-				14A1932D300EB6B53DF05B58B0956FC4 /* MTISCNSceneRenderer.m */,
-			);
-			name = SceneKit;
-			path = SceneKit;
 			sourceTree = "<group>";
 		};
 		CBF95486CD5AB212D56BA77C57BFB615 /* Kernels */ = {
@@ -904,109 +885,132 @@
 			name = "Development Pods";
 			sourceTree = "<group>";
 		};
+		F7BA75F78E39EE438B7968C0EFE52686 /* SceneKit */ = {
+			isa = PBXGroup;
+			children = (
+				7C47F8067AA6C4C6BF3396C40AE9C233 /* MTISCNSceneRenderer.h */,
+				A6F34B48D4ABB15DEEBE2FD171A20847 /* MTISCNSceneRenderer.m */,
+			);
+			name = SceneKit;
+			path = SceneKit;
+			sourceTree = "<group>";
+		};
+		F9707FDB3D92B15734937F1A1626C808 /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				B1043298318B39A854A07DADB624A814 /* MTIImageView.h */,
+				57BB3E1A59896225D1F028327734D60F /* MTIImageView.m */,
+				208E775116CA33DAECD4A32A6B6CE97E /* MTIThreadSafeImageView.h */,
+				4E2341333D2619A04032BC32C2D225A0 /* MTIThreadSafeImageView.m */,
+			);
+			name = UI;
+			path = UI;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		40C921D534199BEA42544DBA5E1E1879 /* Headers */ = {
+		5290498A3546E0D90F0E02596CC62A32 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				81C60763EAEA660DA5CAB95B6AAAD45F /* MetalPetal.h in Headers */,
-				3B8889065D5A963661B0D38F15C95AC0 /* MTIAlphaPremultiplicationFilter.h in Headers */,
-				6FBD9329D284285998BF912BA53267E4 /* MTIAlphaType.h in Headers */,
-				0436131A376364D03BB732B43BCBABE9 /* MTIBlendFilter.h in Headers */,
-				0C5C967871379DB2ECC2ABE523B9CF82 /* MTIBlendFormulaSupport.h in Headers */,
-				F70B755C991376176C2D19BFA2AEE6E3 /* MTIBlendModes.h in Headers */,
-				0291B60B349B40F78722194A6B73FE86 /* MTIBlendWithMaskFilter.h in Headers */,
-				E3582B390C5E78F7476812590EF75B09 /* MTIBuffer.h in Headers */,
-				1C1848E17DF84B052C5C195131C1B93A /* MTIBulgeDistortionFilter.h in Headers */,
-				36B6867FF1EE8092DAB08B0CC9B2560E /* MTIChromaKeyBlendFilter.h in Headers */,
-				2A08B5A62F7E3E55F6F506F331B8E21F /* MTICLAHEFilter.h in Headers */,
-				EE819AB76B99F835CC72CBF723BD4898 /* MTIColor.h in Headers */,
-				3FB2F8A597FA21AC7110C8732869DCED /* MTIColorHalftoneFilter.h in Headers */,
-				B0EB960DF50AA16CCACBAF7BBB84EB4F /* MTIColorLookupFilter.h in Headers */,
-				193CC58DE156D7B7595BF3D2C0C50D35 /* MTIColorMatrix.h in Headers */,
-				60E472B72D9583FBE5C918F96E9580CE /* MTIColorMatrixFilter.h in Headers */,
-				B5DE863A6D62B084AA65D5C5B72B8894 /* MTIComputePipeline.h in Headers */,
-				847718B0872A47A78A30D085129BBBE3 /* MTIComputePipelineKernel.h in Headers */,
-				4E2B94FB6055903DEA83B0C0D1F47EFA /* MTIContext+Internal.h in Headers */,
-				C79057578A3E86F27F9044AFCC648590 /* MTIContext+Rendering.h in Headers */,
-				4BFA3D04E836A89263814F7D987F865E /* MTIContext.h in Headers */,
-				A16E0804CFC138E44431791E7CA62A60 /* MTICoreImageRendering.h in Headers */,
-				EC5E87C609337EC078A161E55FA3EA84 /* MTICropFilter.h in Headers */,
-				2CE8CB191ECD9A671CA21045EFC99A6E /* MTICVMetalIOSurfaceBridge.h in Headers */,
-				53E18C0A2B98A1F11683ED9ED747BFD1 /* MTICVMetalTextureBridging.h in Headers */,
-				56B960BE76CE9589911E81AF41A473E5 /* MTICVMetalTextureCache.h in Headers */,
-				5AA050E57F014F6061F00E140B8E81E9 /* MTICVPixelBufferPool.h in Headers */,
-				58481D0E9687F6EBA5ECB8D090825ABC /* MTICVPixelBufferPromise.h in Headers */,
-				9C15AC7551063E6C82794B896F952D67 /* MTICVPixelBufferRendering.h in Headers */,
-				D68BF9BD7CAA3A8743D81C3035EC5E1D /* MTIDefer.h in Headers */,
-				3FF6BA3D8EE17A3C9FF1CEEB3D746311 /* MTIDotScreenFilter.h in Headers */,
-				FBE3F0A99E9E049C11FF3E0A08EF823E /* MTIDrawableRendering.h in Headers */,
-				E5A0B355772EF3CD18B898143B51C4B8 /* MTIError.h in Headers */,
-				B145A7C429A6418ABCC48F8916204DFF /* MTIFilter.h in Headers */,
-				D0F3177DBBC407530ED561EA6DCE6B84 /* MTIFunctionArgumentsEncoder.h in Headers */,
-				D184DAC9399E6F387FA56CE68CE87150 /* MTIFunctionDescriptor.h in Headers */,
-				0B71C713AE8B7D1893260DB0F7FD8D8A /* MTIGeometry.h in Headers */,
-				B3633352D397E4DBA11D0172B98C63E1 /* MTIGeometryUtilities.h in Headers */,
-				31BED32266DAF392241F7142B6A77F8E /* MTIHasher.h in Headers */,
-				6D507EFE1398D39E45267923DEAE5BA5 /* MTIHexagonalBokehBlurFilter.h in Headers */,
-				DADF1F6AAB71DD46EB1370E588836705 /* MTIHighPassSkinSmoothingFilter.h in Headers */,
-				DB30A62752A717127A6A7A3DDA1573F8 /* MTIImage+Filters.h in Headers */,
-				8B332E0891E65061608854C9F32CC1D8 /* MTIImage+Promise.h in Headers */,
-				659815DB5BAC54C131F5A05DB1C8E9D8 /* MTIImage.h in Headers */,
-				E50D612F58EA3C0EF605415286320718 /* MTIImageOrientation.h in Headers */,
-				F8B460900644C603859685E6611399B4 /* MTIImagePromise.h in Headers */,
-				7916E1F8ACF7FF7F013243CEE023652F /* MTIImagePromiseDebug.h in Headers */,
-				0847385D98FFCB314EBF9D21289C3748 /* MTIImageProperties.h in Headers */,
-				C2AD77EE173722AC9DB7851B9CE04E7B /* MTIImageRenderingContext+Internal.h in Headers */,
-				91FE083B6AEBA71CA7B6A877AF6C39CB /* MTIImageRenderingContext.h in Headers */,
-				8F4A80D075BF9E64F68D5DF681FBAE3B /* MTIImageView.h in Headers */,
-				4577E2FFC95477907290D8CDA8F0C3F1 /* MTIKernel.h in Headers */,
-				89F52DF0939DBD7856AA3ECB31D5419A /* MTILayer.h in Headers */,
-				2A9EAF6B9A03B7951ED066FDD6C47A07 /* MTILibrarySource.h in Headers */,
-				C2177E897495535695C1430896A67E9E /* MTILock.h in Headers */,
-				90549BC29D286476F5F2818DC6DB8DE8 /* MTIMask.h in Headers */,
-				DEA8060DCCF5188CE7CEFE83B9C970FF /* MTIMemoryWarningObserver.h in Headers */,
-				3E091DB7E79BB9A2709CC1CAE8FB6CB6 /* MTIMPSBoxBlurFilter.h in Headers */,
-				1B0ADDB0EEE9E9E0E13B2BF0BFD68C6A /* MTIMPSConvolutionFilter.h in Headers */,
-				AEC2849FCBCC0DFD6D37294BABBB817A /* MTIMPSDefinitionFilter.h in Headers */,
-				E0BE0D74D78F65D2779D25F55D184D49 /* MTIMPSGaussianBlurFilter.h in Headers */,
-				B23191C52632400F19838D6A48B314B5 /* MTIMPSHistogramFilter.h in Headers */,
-				2281BA9E88B636ACD22CE77E467D39D5 /* MTIMPSKernel.h in Headers */,
-				64F5A4DE7E114109DB6904614B995998 /* MTIMPSSobelFilter.h in Headers */,
-				8B63396338F1A00AA4BCBADD28ABD746 /* MTIMPSUnsharpMaskFilter.h in Headers */,
-				3CD5924C09EFA78D305B63F6060286D1 /* MTIMultilayerCompositeKernel.h in Headers */,
-				6664CB9CC25DCB087733A0FD0FF0C1B6 /* MTIMultilayerCompositingFilter.h in Headers */,
-				06FCC133F0969F15E99D1BA1046692C0 /* MTIPixelFormat.h in Headers */,
-				81F3C18DD466A0CDC316C98FA1578346 /* MTIPixellateFilter.h in Headers */,
-				92D21E3B21E9AD4EB7EF53F9E2CBF20F /* MTIPrint.h in Headers */,
-				D533A7F7730E969E0689DD048E71BF8E /* MTIRenderCommand.h in Headers */,
-				B6812D76B047AE8BF474CF4B89BC329A /* MTIRenderGraphOptimization.h in Headers */,
-				E67A3749F4E272E0665C1585008B404B /* MTIRenderPassOutputDescriptor.h in Headers */,
-				E7F0A3F123FBC70104D5A03AFB1C4E34 /* MTIRenderPipeline.h in Headers */,
-				D3DCB4A0D4F533D71EC28DB3D60A7E69 /* MTIRenderPipelineKernel.h in Headers */,
-				ABF576E508561959F4AC6D4FFEC5FF2B /* MTIRenderTask.h in Headers */,
-				854538A1F8FEAA1DAE78A6A867854729 /* MTIRGBColorSpaceConversionFilter.h in Headers */,
-				BD3B960CF36DA9491571FCAB1F618282 /* MTIRGBToneCurveFilter.h in Headers */,
-				EC8179F9C2BBC79FF821D645357E830B /* MTIRoundCornerFilter.h in Headers */,
-				D600241BB3EE423421DF158148F5644F /* MTISamplerDescriptor.h in Headers */,
-				578362F630F435434E28583D6836D37A /* MTISCNSceneRenderer.h in Headers */,
-				67B76A9208B7D80816E9D5E122A99F90 /* MTIShaderLib.h in Headers */,
-				2BEFBD0E58ECAA494DC431D8D49CF6BC /* MTISKSceneRenderer.h in Headers */,
-				B4F502CF6FDDF287F81DA45EC8755346 /* MTITextureDescriptor.h in Headers */,
-				2271F1422462B09CBEF70197511D4199 /* MTITextureDimensions.h in Headers */,
-				47737AB5905FD5AB3F48A1811139ECC5 /* MTITextureLoader.h in Headers */,
-				17A93991A6EE1A22BBE44B65BB45881E /* MTITexturePool.h in Headers */,
-				09AF56B1D58EBDCF2606FD0F4869EDA8 /* MTIThreadSafeImageView.h in Headers */,
-				63338396A68DAA5C9364084EE7D5CC38 /* MTITransform.h in Headers */,
-				CD299378AB0A539C4A4C520098135F0D /* MTITransformFilter.h in Headers */,
-				3814930C8647C6C48413536AE0F47CB4 /* MTIUnaryImageRenderingFilter.h in Headers */,
-				E13963DF90A2CE9B6B2680B0DA9499E1 /* MTIVector+SIMD.h in Headers */,
-				DD13274A660A947EFAAF57191277A57D /* MTIVector.h in Headers */,
-				BD4365D2341CCDD17B84FB44D3998D3B /* MTIVertex.h in Headers */,
-				F714FE715FE0121490ADF2DB366DFE91 /* MTIVibranceFilter.h in Headers */,
-				58B1CEBB296382CE203118A781B1F2A3 /* MTIWeakToStrongObjectsMapTable.h in Headers */,
+				1301C9DBF5094511860B664156DF44A5 /* MetalPetal.h in Headers */,
+				93575BBE79C9204C6947F3A8A773CD28 /* MTIAlphaPremultiplicationFilter.h in Headers */,
+				4FAD1120603975C64806288539918084 /* MTIAlphaType.h in Headers */,
+				0DADDB4FFCE808128F571927C9A62B25 /* MTIBlendFilter.h in Headers */,
+				38304241A4279B3BF6FDBAA9FA7A9BC0 /* MTIBlendFormulaSupport.h in Headers */,
+				A918483DB7EBA3179758B3A6A803A546 /* MTIBlendModes.h in Headers */,
+				CD483FF9971A021F978E934FF73DB01B /* MTIBlendWithMaskFilter.h in Headers */,
+				21655750E446A8C233F3801AF67A43ED /* MTIBuffer.h in Headers */,
+				8ED3216B604019AD6C90A8B00DDDD722 /* MTIBulgeDistortionFilter.h in Headers */,
+				84512654E46E733D130919BEB4B9AB32 /* MTIChromaKeyBlendFilter.h in Headers */,
+				38B0F34CE93918304B679D698A86672B /* MTICLAHEFilter.h in Headers */,
+				D7AE8BC7F22EF0DCFA8707DCE962474B /* MTIColor.h in Headers */,
+				D03F7058CBA660F29C9588C009991F4E /* MTIColorHalftoneFilter.h in Headers */,
+				F6AE96C842B5416B0866733FC1FCB992 /* MTIColorLookupFilter.h in Headers */,
+				B7907F4A69045D59E6282080B0DDD110 /* MTIColorMatrix.h in Headers */,
+				72E7AE45D47F7623060BF4E4C6B2DDDD /* MTIColorMatrixFilter.h in Headers */,
+				BC5741B8DBB7F5E0B8E6D6F4A2D2CC01 /* MTIComputePipeline.h in Headers */,
+				CE91E07A48EEDD50924B3472D7CB198D /* MTIComputePipelineKernel.h in Headers */,
+				2244DE8DAD8A98A45C5E75CC92FFE53F /* MTIContext+Internal.h in Headers */,
+				0891019BEA3BC04C2DA42909C7935038 /* MTIContext+Rendering.h in Headers */,
+				C81D2C1CFF6AABC745CE4564C246874A /* MTIContext.h in Headers */,
+				07FD3FA1708FA2B7668B72373369776F /* MTICoreImageRendering.h in Headers */,
+				ACCBCC1A2B6F357C7E4F85644D6B7070 /* MTICropFilter.h in Headers */,
+				51DA10A075A8332636D9AC8BE1BA840E /* MTICVMetalIOSurfaceBridge.h in Headers */,
+				84BDCAD89AAE5FB5C49AEBB136FF90C8 /* MTICVMetalTextureBridging.h in Headers */,
+				15CE2A47B7987F8D8D6466FF7C3F45B8 /* MTICVMetalTextureCache.h in Headers */,
+				626190EA7A33D05CDD96B9E2FCD4FB37 /* MTICVPixelBufferPool.h in Headers */,
+				6449F0681567C028ABF2DE8758E1DFF3 /* MTICVPixelBufferPromise.h in Headers */,
+				12B37A1CD040171E802DF7CE67539C58 /* MTICVPixelBufferRendering.h in Headers */,
+				4A8DB3904C90FB01AE4D66C31626C03E /* MTIDefer.h in Headers */,
+				CD2BAF74A16C5883C0BE0E602A94AC11 /* MTIDotScreenFilter.h in Headers */,
+				0F4B748DDC5ACD30674F2CC8E60669B8 /* MTIDrawableRendering.h in Headers */,
+				C211BB06A425BB8383D31E4D814630D9 /* MTIError.h in Headers */,
+				4AAF13642BB083C79E825B61DED4E487 /* MTIFilter.h in Headers */,
+				853F56FA7F9D8A31365D702338C1E89B /* MTIFunctionArgumentsEncoder.h in Headers */,
+				30B0B358A59AA93E2FB24EA0ADA6DABD /* MTIFunctionDescriptor.h in Headers */,
+				87B713C4F3F5626D140463998A371503 /* MTIGeometry.h in Headers */,
+				B41C90DD0AEF1E8EE37108D49DF11BF9 /* MTIGeometryUtilities.h in Headers */,
+				BA47FDB89DB71E47D75D822B0E253168 /* MTIHasher.h in Headers */,
+				A630EA528AC31959CBAF4DF5A61877D8 /* MTIHexagonalBokehBlurFilter.h in Headers */,
+				0437F52BF224ECC822DC99B9166ED928 /* MTIHighPassSkinSmoothingFilter.h in Headers */,
+				9733E3BEBEF875D093F21A935D3DCEC0 /* MTIImage+Filters.h in Headers */,
+				2A6DEC503E1C6F7EB88DCFC05EC51DAE /* MTIImage+Promise.h in Headers */,
+				7F62CFF867A2E540C904DD55CA6E3419 /* MTIImage.h in Headers */,
+				EEB36FDC4BA0808B7E9EA472FBCAAB8A /* MTIImageOrientation.h in Headers */,
+				538BDDE2ACCDA6F1DE82A86577422309 /* MTIImagePromise.h in Headers */,
+				8737DB627F284DDC40CDA8307B4C5D13 /* MTIImagePromiseDebug.h in Headers */,
+				FEA3D776AEDB52F22D23306180309C1A /* MTIImageProperties.h in Headers */,
+				D3C865485216B38CCCE626BF1C074066 /* MTIImageRenderingContext+Internal.h in Headers */,
+				E5B263707D1AB01CCE420DEBB39AAF7F /* MTIImageRenderingContext.h in Headers */,
+				82A83E087EF4FBBBF82FE29B3AC34802 /* MTIImageView.h in Headers */,
+				650F3BECA2FDDB4C09BB9D1803255761 /* MTIKernel.h in Headers */,
+				F4EDB4EAF66F1646A98187A3346A974D /* MTILayer.h in Headers */,
+				59E4CDF4F530997CCB05787F8CAFAC13 /* MTILibrarySource.h in Headers */,
+				2A1512E39043BFBE6DC8743195E60B6B /* MTILock.h in Headers */,
+				652CC49CF8EA8ED016D3C8640C0DCCB7 /* MTIMask.h in Headers */,
+				E631648C269B7D2C20C945069BCEE80B /* MTIMemoryWarningObserver.h in Headers */,
+				60E649524955B67DA54ED0F13A115468 /* MTIMPSBoxBlurFilter.h in Headers */,
+				B335759158334C4637AB2D1BA3A56478 /* MTIMPSConvolutionFilter.h in Headers */,
+				8BCBD14A8B11443FAC910B05541079BF /* MTIMPSDefinitionFilter.h in Headers */,
+				1BC25E13242789309B7C0512235C2808 /* MTIMPSGaussianBlurFilter.h in Headers */,
+				0DF2E971C6112B73AE24AACA703EEBDA /* MTIMPSHistogramFilter.h in Headers */,
+				F0111708E4176F86CEED2BC9E5E9D2E8 /* MTIMPSKernel.h in Headers */,
+				2E22414DFE177F5CDC0E8E3DB09053A2 /* MTIMPSSobelFilter.h in Headers */,
+				4404ABE4EFE9F2F077A3BC45BD07362F /* MTIMPSUnsharpMaskFilter.h in Headers */,
+				F1F802B8294DA527936ABBC49D18F13D /* MTIMultilayerCompositeKernel.h in Headers */,
+				4BBC01776F321209183754F0B300F90B /* MTIMultilayerCompositingFilter.h in Headers */,
+				FC9462BBCBF192C37A5C5E6467448E69 /* MTIPixelFormat.h in Headers */,
+				40CBB048EBF37783A3A8EBCA4974E98C /* MTIPixellateFilter.h in Headers */,
+				462C237076B2E456AF66A22C9A72414C /* MTIPrint.h in Headers */,
+				32E90C32A6017CCAD177969332C09945 /* MTIRenderCommand.h in Headers */,
+				6AF14D006FC25963B5BC36E8408E7CC2 /* MTIRenderGraphOptimization.h in Headers */,
+				E923FD1B6306AF86DB699B5AA59C35A3 /* MTIRenderPassOutputDescriptor.h in Headers */,
+				EA019E9373A79CE5E591D55DA21ABC00 /* MTIRenderPipeline.h in Headers */,
+				F4CE9BBC2F98ED3854D061CC4143308E /* MTIRenderPipelineKernel.h in Headers */,
+				D0C8205D4F22F893A479320EDD6CB3C8 /* MTIRenderTask.h in Headers */,
+				1D00C3320F0ACCD6D8C8578558C8CC58 /* MTIRGBColorSpaceConversionFilter.h in Headers */,
+				F518B9AA384F7677041283D63A233EC3 /* MTIRGBToneCurveFilter.h in Headers */,
+				070B522E85AE6BB7B781917608EE91FF /* MTIRoundCornerFilter.h in Headers */,
+				2C6F5A1EBE532C530235E82BD61F99FD /* MTISamplerDescriptor.h in Headers */,
+				691D77915207B03BD19F7D2C39C7FBDC /* MTISCNSceneRenderer.h in Headers */,
+				AD29301E4621DEAF20925A0BB0565DFE /* MTIShaderFunctionConstants.h in Headers */,
+				3B9638D435E1DBF1915FC284865B5DC2 /* MTIShaderLib.h in Headers */,
+				E87C1B5D104B7CC61B6468398450A7F2 /* MTISKSceneRenderer.h in Headers */,
+				1DB29419308FFB15A187B99FFF14DC88 /* MTITextureDescriptor.h in Headers */,
+				1590E372170CC4804F19A29488E30756 /* MTITextureDimensions.h in Headers */,
+				7E316047F3BF026ED84DEC994F599B90 /* MTITextureLoader.h in Headers */,
+				3F787F380BB07C84021ADE48AF1950C0 /* MTITexturePool.h in Headers */,
+				FE7958DB1FE99AC16921E1D08089F1A1 /* MTIThreadSafeImageView.h in Headers */,
+				F1D0F5FB6636690DC10F301C2F207084 /* MTITransform.h in Headers */,
+				02AB38B977BD4F6926B3E6A3A30873D7 /* MTITransformFilter.h in Headers */,
+				2401AAFFB3FF049B4E4094CADDB82647 /* MTIUnaryImageRenderingFilter.h in Headers */,
+				854721C2A67D5CA74C66F2A5159CBCD4 /* MTIVector+SIMD.h in Headers */,
+				58C5B8CCBBF2EBCA5349CB11C5E8B009 /* MTIVector.h in Headers */,
+				3DC8FBEF5DE64BA457CDDBDDC581D9FB /* MTIVertex.h in Headers */,
+				AF06E2759550E9C8867FCD94498C8AF7 /* MTIVibranceFilter.h in Headers */,
+				ACA4B7AF569A08682EFBBED475979CE8 /* MTIWeakToStrongObjectsMapTable.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1023,13 +1027,13 @@
 /* Begin PBXNativeTarget section */
 		D69B1B24A11703A325845EB4C86EBF64 /* MetalPetal */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 709BD198998AA345792F0345BAD3438D /* Build configuration list for PBXNativeTarget "MetalPetal" */;
+			buildConfigurationList = 6039640F305AF59DFA8A75A42B0B5348 /* Build configuration list for PBXNativeTarget "MetalPetal" */;
 			buildPhases = (
-				40C921D534199BEA42544DBA5E1E1879 /* Headers */,
-				7EAD6B2E550E64A06E4609054A9506BD /* Sources */,
-				F876E874174818DBB04C368CFE1F0CF0 /* Frameworks */,
-				1B2A1A80F50A830CF973440388E720AF /* Resources */,
-				990BAACB927D697C516824C38D313C8C /* [CP-User] Build Metal Library - MSL 2.3 */,
+				5290498A3546E0D90F0E02596CC62A32 /* Headers */,
+				4C86D405ABBFC54B7B2F367F48D6A136 /* Sources */,
+				A2E29C7E95E1B2000DDFA5B982916C3F /* Frameworks */,
+				EB0FA43646C35709B52676CD8CD1E099 /* Resources */,
+				BB631D5A8981D9DE0F52AA5CB8A4DC14 /* [CP-User] Build Metal Library - MSL 2.3 */,
 			);
 			buildRules = (
 			);
@@ -1052,7 +1056,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				8032B5D30A3346EB3B0FA0A7F6E6410D /* PBXTargetDependency */,
+				C88179F9B0E282DE06150FE3C2B1D362 /* PBXTargetDependency */,
 			);
 			name = "Pods-MetalPetalDemo";
 			productName = "Pods-MetalPetalDemo";
@@ -1088,14 +1092,14 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		1B2A1A80F50A830CF973440388E720AF /* Resources */ = {
+		2E2E5DF3A481FFF4AF72F7B594AE42B0 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		2E2E5DF3A481FFF4AF72F7B594AE42B0 /* Resources */ = {
+		EB0FA43646C35709B52676CD8CD1E099 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1105,7 +1109,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		990BAACB927D697C516824C38D313C8C /* [CP-User] Build Metal Library - MSL 2.3 */ = {
+		BB631D5A8981D9DE0F52AA5CB8A4DC14 /* [CP-User] Build Metal Library - MSL 2.3 */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1118,6 +1122,131 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		4C86D405ABBFC54B7B2F367F48D6A136 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0FFE5F60EF84D12E17E9DD7126B27E8A /* BlendingShaders.metal in Sources */,
+				9654E8FB3309E09ED60BF8A36ABCFE77 /* CLAHE.metal in Sources */,
+				9D48D2740D1F480B7EA37293C92DDDF9 /* ColorConversionShaders.metal in Sources */,
+				27486FACE2DAF4DB1D2C26E653A7E721 /* Filter.swift in Sources */,
+				A930D521094735675ED6EF7D81E2380C /* Halftone.metal in Sources */,
+				4EE0790DBBDD36C2184FF94A44010962 /* HighPassSkinSmoothing.metal in Sources */,
+				33EAD62A6528C8912FE3DCA0034056AA /* LensBlur.metal in Sources */,
+				2CC3DB5832B311741181C0EF4985AA16 /* MetalPetal-dummy.m in Sources */,
+				2B7EE0E88E32551F69E317D9CA25504F /* MetalPetal.swift in Sources */,
+				F0A09B39DDD4924417523867E1B765FF /* MTIAlphaPremultiplicationFilter.m in Sources */,
+				0CB9AB709592B926572735A1550A0AC1 /* MTIAlphaType.m in Sources */,
+				F9C3C24765AFF0950E72ECC90A49FD08 /* MTIAlphaType.swift in Sources */,
+				FACE822E597DE8650116E87A7F47E166 /* MTIBlendFilter.m in Sources */,
+				1195078819FB10C16368B109A10731CC /* MTIBlendFormulaSupport.mm in Sources */,
+				05BA3B2EA4BDBF9A40FAB12E858407DF /* MTIBlendModes.m in Sources */,
+				CA173D62E1D8921EB7AF1954C0FD96CB /* MTIBlendWithMaskFilter.m in Sources */,
+				42B46B986EC9B7511DFED617ACA23784 /* MTIBuffer.m in Sources */,
+				35880AA0EC413C004E648AB998D57FC4 /* MTIBulgeDistortionFilter.m in Sources */,
+				50AD818C1A6AF76EC88510DD93E71861 /* MTIChromaKeyBlendFilter.m in Sources */,
+				AFD42861CD6D786BA57E61BF2A066684 /* MTICLAHEFilter.m in Sources */,
+				CE96E1F4E916D861C67FF99713EEF12A /* MTIColor.m in Sources */,
+				E882D2881B31F263E764744FD078EB5F /* MTIColor.swift in Sources */,
+				2FD7A360C133FADAC995A4C2EEE576C2 /* MTIColorHalftoneFilter.m in Sources */,
+				78501A658F1B27E23D4E5E5122274AEE /* MTIColorLookupFilter.m in Sources */,
+				934F9DFA5E1DB1F3C45930B49C52115B /* MTIColorMatrix.m in Sources */,
+				DABCB0BFD3F345376B8C8BF01C0FDEEC /* MTIColorMatrix.swift in Sources */,
+				7281C81A9614CE8D6A9D969CF17F15A3 /* MTIColorMatrixFilter.m in Sources */,
+				82FA0178EC14043F58D279B7B29CAA09 /* MTIComputePipeline.m in Sources */,
+				1B441A819246EBB1A2B0497D09C93ACC /* MTIComputePipelineKernel.m in Sources */,
+				838C612F726AFA34DDA79C7B3555BD1C /* MTIComputePipelineKernel.swift in Sources */,
+				04AB9AA1682FA0BB46E52E06018A8D35 /* MTIContext+Rendering.m in Sources */,
+				2CFEEC732104CBFDA0593BBD448094DE /* MTIContext.m in Sources */,
+				4AFAAADC14836395017466AB897B4CE1 /* MTIContext.swift in Sources */,
+				B2C5CB07F7BFB833212D538F1FF730D8 /* MTICoreImageExtension.swift in Sources */,
+				E96B05D8F42FF5777C54C49919696B86 /* MTICoreImageRendering.m in Sources */,
+				7353E439E187FE737191FC56A94CC2C1 /* MTICropFilter.m in Sources */,
+				929EF105D30DBA9FC2AFD8ACE8E5625B /* MTICropRegion.swift in Sources */,
+				C689E8509CC06A5B312398E0CC844C16 /* MTICVMetalIOSurfaceBridge.m in Sources */,
+				261A57C1FECBF26786733CC67624B826 /* MTICVMetalTextureCache.m in Sources */,
+				182E75868786AAE7A6700E8B257832CC /* MTICVPixelBufferPool.m in Sources */,
+				5DC692C529BA714014BAEFB51FFA61ED /* MTICVPixelBufferPromise.m in Sources */,
+				B2A28F5EA5CBAB25C1261464CDEC917B /* MTICVPixelBufferRendering.m in Sources */,
+				2F4CD11750CA53A903990D23FCBF867E /* MTIDataBuffer.swift in Sources */,
+				B70642002F13A46D5A9244232C1419C4 /* MTIDefer.m in Sources */,
+				14C3B82888E210425F5A267FDC20C49E /* MTIDotScreenFilter.m in Sources */,
+				4334F8E7E24EFFD037917DD7BBFEBB4D /* MTIDrawableRendering.m in Sources */,
+				76D148FACCBDB25A61CBFD414491939E /* MTIError.m in Sources */,
+				DD3BA56237655971064D5FB14C793F6D /* MTIError.swift in Sources */,
+				D8303A335A94E9B3F5E37BE375281FF3 /* MTIFilter.m in Sources */,
+				AB825C96313F2D64A04A2C7AA0AC200F /* MTIFunctionArgumentsEncoder.m in Sources */,
+				2C941CAD70A17ABF95467BD24EEA442E /* MTIFunctionDescriptor.m in Sources */,
+				29775F614A788778240C885E0948E68F /* MTIFunctionDescriptor.swift in Sources */,
+				C9D32FC9F8879096FF0750B1B0707675 /* MTIGeometry.m in Sources */,
+				FCA274E613746ACE3E3DD6A137B95F0D /* MTIGeometryUtilities.m in Sources */,
+				6FCB27E858A816715BBF9F7E58B176FD /* MTIHasher.m in Sources */,
+				832A44208293731E10EAF7006E321625 /* MTIHexagonalBokehBlurFilter.m in Sources */,
+				AFABF7D47D8D0ACCB071B49DD423755C /* MTIHighPassSkinSmoothingFilter.m in Sources */,
+				A6FBCA0414DDE5118FAF896BF2B4A6B0 /* MTIImage+Filters.m in Sources */,
+				C2E1A134E22B3A5381B05989BDFE1CD2 /* MTIImage.m in Sources */,
+				F698E07D93F5A68D3E298C9BFC7A8011 /* MTIImage.swift in Sources */,
+				7EA6C6A72AABED612880D199F16D56E1 /* MTIImageOrientation.m in Sources */,
+				01B0292CFBB20E4DA8E7526EEB55663C /* MTIImagePromise.m in Sources */,
+				569F2B407C030F71466316A1685399AB /* MTIImagePromiseDebug.m in Sources */,
+				3FA3CA0CC3A4FA05A9B9172CBE68E7C6 /* MTIImageProperties.m in Sources */,
+				0C8F50D11A9424F39987AF30DD72C89F /* MTIImageRenderingContext.mm in Sources */,
+				6DD8432302789E2226F4697B9E63DADC /* MTIImageView.m in Sources */,
+				88BE36D2E0EE170397A8A9066946D530 /* MTIImageViewProtocol.swift in Sources */,
+				F7BC844B982006EC3D90FAAFC969C062 /* MTILayer.m in Sources */,
+				286ECF052F713246636415E974800705 /* MTILibrarySource.m in Sources */,
+				6A341E8BEAE279B399034D12A5F7A877 /* MTILock.m in Sources */,
+				A74F5882279DE00122527B0992F129C8 /* MTIMask.m in Sources */,
+				64290F8F8BC85CCBE13C2B4DD6BECB13 /* MTIMemoryWarningObserver.m in Sources */,
+				4ED711B32823B4B28CE6FF9F4A0C8594 /* MTIMPSBoxBlurFilter.m in Sources */,
+				457AEC8EAD560BC8F124B2EEE5650FCD /* MTIMPSConvolutionFilter.m in Sources */,
+				A09798D3E0485B1BDF2D1159AD1F0D6A /* MTIMPSDefinitionFilter.m in Sources */,
+				670D500ECA12E6C6EE32529B792231CA /* MTIMPSGaussianBlurFilter.m in Sources */,
+				B93B80DF5C1FF46F8FD4A3D664B3981A /* MTIMPSHistogramFilter.m in Sources */,
+				F9C7D14DA731F161D29ED3B983B18507 /* MTIMPSKernel.m in Sources */,
+				C4EB6B41B274093BBF19F1F70CC9A7B3 /* MTIMPSSobelFilter.m in Sources */,
+				D1D4CEF7F02C8F039E48D336D8BD0D10 /* MTIMPSUnsharpMaskFilter.m in Sources */,
+				9CED7054D9E64E20CC3C8922B358429E /* MTIMultilayerCompositeKernel.m in Sources */,
+				356D4CB414E43B057D401A7EAEF9CC75 /* MTIMultilayerCompositingFilter.m in Sources */,
+				F2E1CACEF29FA5F190A52BBFFC43DA2C /* MTIPixelFormat.m in Sources */,
+				AC6F7FAFFC3A4C80A764EC46862794A1 /* MTIPixelFormat.swift in Sources */,
+				043EAED079168285C46090966912A2B1 /* MTIPixellateFilter.m in Sources */,
+				CC1714E306B6AA0497B6C9580E513839 /* MTIRenderCommand.m in Sources */,
+				3650A36F3749E8D20634918C75F5AAD7 /* MTIRenderGraphOptimization.m in Sources */,
+				4926C84B82919E8FC4B4FC4A98046CD4 /* MTIRenderPassOutputDescriptor.m in Sources */,
+				8B662F2DD2A352ACD74A5099FBA8B914 /* MTIRenderPipeline.m in Sources */,
+				FF2E2A4EC20B11AB3E7C28D8CCE18186 /* MTIRenderPipelineKernel.m in Sources */,
+				A8B0C1B8F7C3C81DF925719DCE96F361 /* MTIRenderTask.m in Sources */,
+				7F88239EA123E3DB2562E8B02A7CD544 /* MTIRGBColorSpaceConversionFilter.m in Sources */,
+				3147587BFF33D7EFCA364614BEDA84A4 /* MTIRGBToneCurveFilter.m in Sources */,
+				F4CF88845D7CEDCE963B54334E332DB8 /* MTIRoundCornerFilter.m in Sources */,
+				73B207C3DC66DBE0A9C7B460305E7BAA /* MTISamplerDescriptor.m in Sources */,
+				90E46628B756C1881FCC6C8591180F7F /* MTISCNSceneRenderer.m in Sources */,
+				1514262303AA1FE0D10EB1CE9A7D6C9D /* MTISIMDArgumentEncoder.swift in Sources */,
+				4FDFC8EF5EE0563B9EC8AF23DBEB061A /* MTISKSceneRenderer.m in Sources */,
+				77DB477EC2E0D66B668B15D2035A5DF2 /* MTITextureDescriptor.m in Sources */,
+				E6956AF5301FDF57F2F3FB60F3925669 /* MTITextureDimensions.m in Sources */,
+				DD4E435727CF5FDB8CAD56BAD37F7BF3 /* MTITextureDimensions.swift in Sources */,
+				8EF1BD54CE206B851F39845D6875EC25 /* MTITextureLoader.m in Sources */,
+				45D86D3A643BB843FBCFAD2AFF01E2A2 /* MTITexturePool.mm in Sources */,
+				65375EBB76517260B072F274EB469FC5 /* MTIThreadSafeImageView.m in Sources */,
+				9C3C665FD93CB440DDB3DDB180D666B8 /* MTITransform.m in Sources */,
+				60AA568123305DAAB16D55D63BFA14AF /* MTITransformFilter.m in Sources */,
+				4AAC1B99A00EF3FE82DD8DAD444D025B /* MTIUnaryImageRenderingFilter.m in Sources */,
+				F613F627FA63215FB7959436725C4FF3 /* MTIVector+SIMD.m in Sources */,
+				23B5AF0B6D2C130E8EA92F5A0C385C67 /* MTIVector.m in Sources */,
+				BF81EFDB7AF66684121370E86B74FDFB /* MTIVector.swift in Sources */,
+				7808BEB6CCC017FF604AD43F44840260 /* MTIVertex.m in Sources */,
+				81640022F2679B7DE7AB4828673A7EC5 /* MTIVertex.swift in Sources */,
+				967095322D748161E0C306ACDBA7776F /* MTIVibranceFilter.m in Sources */,
+				1EDF7B1F6DAF886C33909D3F77A6E488 /* MTIWeakToStrongObjectsMapTable.m in Sources */,
+				ABDE47DAF578307E3ABB789DF1E2986E /* MultilayerCompositeShaders.metal in Sources */,
+				11D1402597087A9A101F870C8FAD7A22 /* MultilayerCompositingFilter.swift in Sources */,
+				3351308B052718EF27D84AC4293F33C6 /* Shaders.metal in Sources */,
+				FD82EFB5227C1C9108A330E35A231EA8 /* VideoProcessing.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		73C1B9350DBB60D2C3999D6E23FBD172 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1126,146 +1255,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		7EAD6B2E550E64A06E4609054A9506BD /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				65A16694FA59B822A022119D066FC1A4 /* BlendingShaders.metal in Sources */,
-				C1DA89613002FF0643B231EB6DA61645 /* CLAHE.metal in Sources */,
-				C20DBBFC6F45A1F91C23F029CA662443 /* ColorConversionShaders.metal in Sources */,
-				F2F0E55A232691FFCE4CE048ADCCF119 /* Filter.swift in Sources */,
-				045F1F10D1209F8E784A41605C402BF6 /* Halftone.metal in Sources */,
-				5FF45284C25F64C4AF099BDC97214668 /* HighPassSkinSmoothing.metal in Sources */,
-				100D11F88D01349DDEB245DCCCE5EB19 /* LensBlur.metal in Sources */,
-				92F692DA0008C7D4931BE296BE274F29 /* MetalPetal-dummy.m in Sources */,
-				6A1E79FE3E981E89E1290AF3F5FE72B4 /* MetalPetal.swift in Sources */,
-				23EDE4AF6B9C33A3DE2BB60BC3D2B8AA /* MTIAlphaPremultiplicationFilter.m in Sources */,
-				7F171EA26739DDBD1D19EBBFA6FCC86A /* MTIAlphaType.m in Sources */,
-				C4744A26A3E6B7B8C12EE354ED48217E /* MTIAlphaType.swift in Sources */,
-				6B0BA713000606421DE1A90E0ED71E05 /* MTIBlendFilter.m in Sources */,
-				8A90C7A224ACE5D851AFBE8C2C529E8B /* MTIBlendFormulaSupport.mm in Sources */,
-				3B54D81404551E37898FC880A3297305 /* MTIBlendModes.m in Sources */,
-				1BF53E63CB23B0C49FAB24D05BCC5D2B /* MTIBlendWithMaskFilter.m in Sources */,
-				B365C1698EB528BCD56960FF38D965C7 /* MTIBuffer.m in Sources */,
-				A01AA3ACA31BE323939E5E7FCCF75AF0 /* MTIBulgeDistortionFilter.m in Sources */,
-				61FDEF8B49C152E2A9997FFA75BF2AFC /* MTIChromaKeyBlendFilter.m in Sources */,
-				602690C1969246053A612D08883BE9A9 /* MTICLAHEFilter.m in Sources */,
-				F48AB242701A1F71340F8980120758E8 /* MTIColor.m in Sources */,
-				CD4F1934A4EB9DB3B823D9B127199A2D /* MTIColor.swift in Sources */,
-				038FD9E89E2FE655773268C243331DEE /* MTIColorHalftoneFilter.m in Sources */,
-				67EA6A90555BA1804EFFAB192C08A6C0 /* MTIColorLookupFilter.m in Sources */,
-				0105312D47432D4D5410C5DA59FC3FDE /* MTIColorMatrix.m in Sources */,
-				1CCA76FB4025E134DE737FEBC70FFEDE /* MTIColorMatrix.swift in Sources */,
-				C5D4B1B3333C955AC974F0774EB1C9AD /* MTIColorMatrixFilter.m in Sources */,
-				CEBB00741F9CD3504749FAB13236576D /* MTIComputePipeline.m in Sources */,
-				614C5C5F01B1D2A103D2A117F343B6BE /* MTIComputePipelineKernel.m in Sources */,
-				1EAD1FA325C68E0CF3B7680378EBCAF6 /* MTIComputePipelineKernel.swift in Sources */,
-				E21B17495886AF401B9DB5F70E136790 /* MTIContext+Rendering.m in Sources */,
-				2E4A5F65BD7B37C163CDF56FF7C1DCC3 /* MTIContext.m in Sources */,
-				91D23D5A217BDDC92ACA43C5B69C50FE /* MTIContext.swift in Sources */,
-				B7578CA065AD54AF4C8A2587AB20EDC2 /* MTICoreImageExtension.swift in Sources */,
-				5CFE3B5507B31366B51BDBFCE19DB050 /* MTICoreImageRendering.m in Sources */,
-				F77F23C585C3A4F70948CDEDFE458625 /* MTICropFilter.m in Sources */,
-				C1E1AEE4A6A6DD6B7CF3B2E85B3AD864 /* MTICropRegion.swift in Sources */,
-				07963D34AEEBB8B45812DBDE6FB2952E /* MTICVMetalIOSurfaceBridge.m in Sources */,
-				C01909C946A6A9EC4AAB3093E21FB1B0 /* MTICVMetalTextureCache.m in Sources */,
-				309CD9B501982530D6DC7C8183F600A6 /* MTICVPixelBufferPool.m in Sources */,
-				367FBC57F466D3A060D766BA9CBB85E7 /* MTICVPixelBufferPromise.m in Sources */,
-				81E8F4687A9DBF1BC83BA1B1593A697D /* MTICVPixelBufferRendering.m in Sources */,
-				602CD2485FAAC4E27AAF416B06E6B215 /* MTIDataBuffer.swift in Sources */,
-				980B4EF41BD668AD3AC852DDC71784EA /* MTIDefer.m in Sources */,
-				88DCE191EB261E62A63A1914C687B40C /* MTIDotScreenFilter.m in Sources */,
-				F4677B5BC0EA7448ACFBBD1A3C21810E /* MTIDrawableRendering.m in Sources */,
-				4EF34D6C8CCCB786C3858C8A6E180D9C /* MTIError.m in Sources */,
-				5291F00F0EFEA07D51EBEA0CA3F19F27 /* MTIError.swift in Sources */,
-				4554919085BA4D1BFF5AF7C141507B9D /* MTIFilter.m in Sources */,
-				AABADDB9FD7574FE7C445A3184DBB96F /* MTIFunctionArgumentsEncoder.m in Sources */,
-				E1230FC444EF9C7E2C47209CC8456FAE /* MTIFunctionDescriptor.m in Sources */,
-				58C1E09F4DBF7CB5941E385ABF03072D /* MTIFunctionDescriptor.swift in Sources */,
-				BC2032E67317948AC59739E19D132C75 /* MTIGeometry.m in Sources */,
-				28209CC142ED73F648C5B2F3BAF25264 /* MTIGeometryUtilities.m in Sources */,
-				E73983A93F093C178853AA21BD3F8E46 /* MTIHasher.m in Sources */,
-				90E4AD3CA04E6784257D5D91FCD9CCDD /* MTIHexagonalBokehBlurFilter.m in Sources */,
-				5CE1EEC5A8EF0E10592F988F5647C3A0 /* MTIHighPassSkinSmoothingFilter.m in Sources */,
-				8EDE4CA628A0B0EBB2EEFF7FAA4E403E /* MTIImage+Filters.m in Sources */,
-				1DF63F779E6CA8ED8A4E17DD7A908DFC /* MTIImage.m in Sources */,
-				EF5F00F5FC69AC206E3A7CA8892A71BD /* MTIImage.swift in Sources */,
-				0866FAD5FFDB9083BAA37D668D9ECCC0 /* MTIImageOrientation.m in Sources */,
-				5CBBC0DF9117B9FE845999753D8E1113 /* MTIImagePromise.m in Sources */,
-				D71ECF9577BF14E2E5F93E82FF207FC4 /* MTIImagePromiseDebug.m in Sources */,
-				9D97B17B02669A4A92836CFA1285ADFE /* MTIImageProperties.m in Sources */,
-				42CC018DBCA118DEE260853EE457B252 /* MTIImageRenderingContext.mm in Sources */,
-				071606C0D4365597BAA54E2A9E912559 /* MTIImageView.m in Sources */,
-				139C76A5D80F87173754A94805609E1F /* MTIImageViewProtocol.swift in Sources */,
-				2F64E72855CCC6602B685C119DA4C65B /* MTILayer.m in Sources */,
-				E32C84C2BE854A6675E0BD7826082A5D /* MTILibrarySource.m in Sources */,
-				3193779E163F1EA20F9D1266ED80DF60 /* MTILock.m in Sources */,
-				77C364842DE3CB8636FCC812ACDDE16D /* MTIMask.m in Sources */,
-				9F19628D133A33DC019B5501E770DAAC /* MTIMemoryWarningObserver.m in Sources */,
-				B4DA6DD1772F5E027572B2A6048466F1 /* MTIMPSBoxBlurFilter.m in Sources */,
-				BEBBA61043CDDE9F83A36D52EFF5A564 /* MTIMPSConvolutionFilter.m in Sources */,
-				8CB5D2BA69A57C31B5C0855426023C37 /* MTIMPSDefinitionFilter.m in Sources */,
-				FE6A68DDFA8124A3CE10FD3CB626F083 /* MTIMPSGaussianBlurFilter.m in Sources */,
-				1577F648289E582A1DAE3AA1D17BCC7B /* MTIMPSHistogramFilter.m in Sources */,
-				2B906F4A48DB77C83AC44D42815055E5 /* MTIMPSKernel.m in Sources */,
-				B4DF702C956429AF622A9B6BC788428F /* MTIMPSSobelFilter.m in Sources */,
-				5B4B801E603C521B608A6C3ED9C9EFF5 /* MTIMPSUnsharpMaskFilter.m in Sources */,
-				3FF847DDC4AC4F9C93BCDC93CF7D3DD7 /* MTIMultilayerCompositeKernel.m in Sources */,
-				52EA30069060F561D11C9F7A1BC55B44 /* MTIMultilayerCompositingFilter.m in Sources */,
-				98FF338195A9E10F67315F3FD08A4E09 /* MTIPixelFormat.m in Sources */,
-				813E8F7FCEFC5C7B39C05C5B1E3B3BDF /* MTIPixelFormat.swift in Sources */,
-				0FED3A746460700CE8F5F4C78A2FA285 /* MTIPixellateFilter.m in Sources */,
-				4DEFEE61AEF7F27C699DECDE98B03BFD /* MTIRenderCommand.m in Sources */,
-				F713AFE06A4216E391948FA305F91F95 /* MTIRenderGraphOptimization.m in Sources */,
-				2B1F26B99A731F69D7F63B865A41DD28 /* MTIRenderPassOutputDescriptor.m in Sources */,
-				D4A011F0ACEB46DF34C8AB2211B71AC0 /* MTIRenderPipeline.m in Sources */,
-				A0A7F8341145156F25B92DFA9DD1A257 /* MTIRenderPipelineKernel.m in Sources */,
-				BEB05302997E0BA4883B8156B5B91C05 /* MTIRenderTask.m in Sources */,
-				28E527B5682833783882D0F1A8C6A627 /* MTIRGBColorSpaceConversionFilter.m in Sources */,
-				6D1FC603B5CFA7C322A8D4FEAFF68BB6 /* MTIRGBToneCurveFilter.m in Sources */,
-				0A467BF1C4544B195098E3BD4CA40E1F /* MTIRoundCornerFilter.m in Sources */,
-				96D6D12C4F2D58AD9686884CC6422EFB /* MTISamplerDescriptor.m in Sources */,
-				4AACC34D93C4CE9B53103F26F8B7AC2B /* MTISCNSceneRenderer.m in Sources */,
-				D5A9469F11BAB1C79B648C7B8616EFF9 /* MTISIMDArgumentEncoder.swift in Sources */,
-				1208C359D8D2C0801F7A2CC465F64277 /* MTISKSceneRenderer.m in Sources */,
-				722A90779B92D3532C196FE180890492 /* MTITextureDescriptor.m in Sources */,
-				979CFE57D491D0DEDB0399A0905C6E88 /* MTITextureDimensions.m in Sources */,
-				EAF3A27D495F10A67F65BC5054F6D78B /* MTITextureDimensions.swift in Sources */,
-				7B4533FE309C6399CB00C6E76B12C7EE /* MTITextureLoader.m in Sources */,
-				A6E22306EB078C61228CAC0EBE7B06C3 /* MTITexturePool.mm in Sources */,
-				E6C97D71D7F7B233A111A11641F4067C /* MTIThreadSafeImageView.m in Sources */,
-				A9E9A9BECD2263073F0CF24110A29F8D /* MTITransform.m in Sources */,
-				3ECD3B45A3B78DC2CAB04ED06AF54087 /* MTITransformFilter.m in Sources */,
-				1CD52652DA3758546FCD269B02B0AD8F /* MTIUnaryImageRenderingFilter.m in Sources */,
-				59A4DACF0FAA235FFCE50656C64C363A /* MTIVector+SIMD.m in Sources */,
-				D9937743F7B68F6A1CA74E1B13B6B1C8 /* MTIVector.m in Sources */,
-				112AA5571FCED3D9254B4954A2CA4E07 /* MTIVector.swift in Sources */,
-				CDFCDC8332315D1D9F6BC9977A10D6C4 /* MTIVertex.m in Sources */,
-				EC625119930CAB8AEE083926C2DE9EDA /* MTIVertex.swift in Sources */,
-				62DE9195DD8207F91CE0BA79218EE32E /* MTIVibranceFilter.m in Sources */,
-				763E4AA206511022977FB0537CFBB438 /* MTIWeakToStrongObjectsMapTable.m in Sources */,
-				7368A31BE5ADC2306764868C8B7CE1ED /* MultilayerCompositeShaders.metal in Sources */,
-				26499BB0E554A67DAE1B043C60856DC2 /* MultilayerCompositingFilter.swift in Sources */,
-				EACB460EC51B3C4AC8B3919C92463022 /* Shaders.metal in Sources */,
-				6D0D4740D720E42A12CA2AAB82B894C6 /* VideoProcessing.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		8032B5D30A3346EB3B0FA0A7F6E6410D /* PBXTargetDependency */ = {
+		C88179F9B0E282DE06150FE3C2B1D362 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = MetalPetal;
 			target = D69B1B24A11703A325845EB4C86EBF64 /* MetalPetal */;
-			targetProxy = 86EF2AC7576268F092FB297A9C34B68C /* PBXContainerItemProxy */;
+			targetProxy = D934680802A8F2D1D3D4FCEB7CB55CA6 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		7519FDD50BDEC19355AC4312B4811093 /* Release */ = {
+		16FC928ECFEFDC9BA24DA7212D23D609 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 40202EEB29CDCAC5376B90DB56E4D832 /* MetalPetal.release.xcconfig */;
+			baseConfigurationReference = E088201C1E99269CE1275A77A408C753 /* MetalPetal.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -1292,11 +1296,10 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Release;
+			name = Debug;
 		};
 		7EC276E477B86BA294CB52D988E91BDC /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -1413,40 +1416,6 @@
 				SYMROOT = "${SRCROOT}/../build";
 			};
 			name = Release;
-		};
-		99E14E223A0BBA4E149192E81D9CDA8F /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = E088201C1E99269CE1275A77A408C753 /* MetalPetal.debug.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Target Support Files/MetalPetal/MetalPetal-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/MetalPetal/MetalPetal.modulemap";
-				PRODUCT_MODULE_NAME = MetalPetal;
-				PRODUCT_NAME = MetalPetal;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
 		};
 		CB58453C2A3C6763D45E466D8036BE7C /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -1569,6 +1538,41 @@
 			};
 			name = Debug;
 		};
+		E636D09C24E69E04D8A7E2D383C3BC66 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 40202EEB29CDCAC5376B90DB56E4D832 /* MetalPetal.release.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "Target Support Files/MetalPetal/MetalPetal-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/MetalPetal/MetalPetal.modulemap";
+				PRODUCT_MODULE_NAME = MetalPetal;
+				PRODUCT_NAME = MetalPetal;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1590,11 +1594,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		709BD198998AA345792F0345BAD3438D /* Build configuration list for PBXNativeTarget "MetalPetal" */ = {
+		6039640F305AF59DFA8A75A42B0B5348 /* Build configuration list for PBXNativeTarget "MetalPetal" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				99E14E223A0BBA4E149192E81D9CDA8F /* Debug */,
-				7519FDD50BDEC19355AC4312B4811093 /* Release */,
+				16FC928ECFEFDC9BA24DA7212D23D609 /* Debug */,
+				E636D09C24E69E04D8A7E2D383C3BC66 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Sources/MetalPetalObjectiveC/MTISwiftPMBuiltinLibrarySupport.mm
+++ b/Sources/MetalPetalObjectiveC/MTISwiftPMBuiltinLibrarySupport.mm
@@ -46,13 +46,19 @@ typedef struct MTICLAHELUTGeneratorInputParameters MTICLAHELUTGeneratorInputPara
 
 struct MTIMultilayerCompositingLayerShadingParameters {
     float opacity;
-    bool contentHasPremultipliedAlpha;
-    bool hasCompositingMask;
+    int maskComponent;
     int compositingMaskComponent;
-    bool usesOneMinusMaskValue;
     vector_float4 tintColor;
 };
 typedef struct MTIMultilayerCompositingLayerShadingParameters MTIMultilayerCompositingLayerShadingParameters;
+
+struct MTIMultilayerCompositingLayerVertex {
+    vector_float4 position;
+    vector_float2 textureCoordinate;
+    vector_float2 positionInLayer;
+};
+typedef struct MTIMultilayerCompositingLayerVertex MTIMultilayerCompositingLayerVertex;
+
 
 #if __METAL_MACOS__ || __METAL_IOS__
 
@@ -64,6 +70,12 @@ namespace metalpetal {
         float4 position [[ position ]];
         float2 textureCoordinate;
     } VertexOut;
+
+    typedef struct {
+        float4 position [[ position ]];
+        float2 textureCoordinate;
+        float2 positionInLayer;
+    } MTIMultilayerCompositingLayerVertexOut;
     
     // GLSL mod func for metal
     template <typename T, typename _E = typename enable_if<is_floating_point<typename make_scalar<T>::type>::value>::type>
@@ -664,6 +676,37 @@ namespace metalpetal {
 #endif /* __METAL_MACOS__ || __METAL_IOS__ */
 
 #endif /* MTIShader_h */
+//
+//  MTIFunctionConstants.h
+//  Pods
+//
+//  Created by YuAo on 2021/3/29.
+//
+
+#ifndef MTIShaderFunctionConstants_h
+#define MTIShaderFunctionConstants_h
+
+#if __METAL_MACOS__ || __METAL_IOS__
+
+#include <metal_stdlib>
+
+namespace metalpetal {
+    constant bool blend_filter_backdrop_has_premultiplied_alpha [[function_constant(1024)]];
+    constant bool blend_filter_source_has_premultiplied_alpha [[function_constant(1025)]];
+    constant bool blend_filter_outputs_premultiplied_alpha [[function_constant(1026)]];
+    constant bool blend_filter_outputs_opaque_image [[function_constant(1027)]];
+    
+    constant bool multilayer_composite_content_premultiplied [[function_constant(1028)]];
+    constant bool multilayer_composite_has_mask [[function_constant(1029)]];
+    constant bool multilayer_composite_mask_inverted [[function_constant(1030)]];
+    constant bool multilayer_composite_has_compositing_mask [[function_constant(1031)]];
+    constant bool multilayer_composite_compositing_mask_inverted [[function_constant(1032)]];
+    constant bool multilayer_composite_has_tint_color [[function_constant(1033)]];
+}
+
+#endif
+
+#endif /* MTIShaderFunctionConstants_h */
 
 //
 // This is an auto-generated source file.
@@ -673,15 +716,12 @@ namespace metalpetal {
 
 
 
+
+
 using namespace metal;
 using namespace metalpetal;
 
 namespace metalpetal {
-    
-constant bool blend_filter_backdrop_has_premultiplied_alpha [[function_constant(0)]];
-constant bool blend_filter_source_has_premultiplied_alpha [[function_constant(1)]];
-constant bool blend_filter_outputs_premultiplied_alpha [[function_constant(2)]];
-constant bool blend_filter_outputs_opaque_image [[function_constant(3)]];
 
 fragment float4 normalBlend(VertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
@@ -690,8 +730,13 @@ fragment float4 normalBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -717,8 +762,13 @@ fragment float4 darkenBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -744,8 +794,13 @@ fragment float4 multiplyBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -771,8 +826,13 @@ fragment float4 colorBurnBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -798,8 +858,13 @@ fragment float4 linearBurnBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -825,8 +890,13 @@ fragment float4 darkerColorBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -852,8 +922,13 @@ fragment float4 lightenBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -879,8 +954,13 @@ fragment float4 screenBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -906,8 +986,13 @@ fragment float4 colorDodgeBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -933,8 +1018,13 @@ fragment float4 addBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -960,8 +1050,13 @@ fragment float4 lighterColorBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -987,8 +1082,13 @@ fragment float4 overlayBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -1014,8 +1114,13 @@ fragment float4 softLightBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -1041,8 +1146,13 @@ fragment float4 hardLightBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -1068,8 +1178,13 @@ fragment float4 vividLightBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -1095,8 +1210,13 @@ fragment float4 linearLightBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -1122,8 +1242,13 @@ fragment float4 pinLightBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -1149,8 +1274,13 @@ fragment float4 hardMixBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -1176,8 +1306,13 @@ fragment float4 differenceBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -1203,8 +1338,13 @@ fragment float4 exclusionBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -1230,8 +1370,13 @@ fragment float4 subtractBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -1257,8 +1402,13 @@ fragment float4 divideBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -1284,8 +1434,13 @@ fragment float4 hueBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -1311,8 +1466,13 @@ fragment float4 saturationBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -1338,8 +1498,13 @@ fragment float4 colorBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -1365,8 +1530,13 @@ fragment float4 luminosityBlend(VertexOut vertexIn [[ stage_in ]],
                                     sampler overlaySampler [[ sampler(1) ]],
                                     constant float &intensity [[buffer(0)]]
                                     ) {
-    float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
     float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height()));
+    #endif
+    float4 uCf = overlayTexture.sample(overlaySampler, textureCoordinate);
+    
     if (blend_filter_backdrop_has_premultiplied_alpha) {
         uCb = unpremultiply(uCb);
     }
@@ -1869,6 +2039,8 @@ namespace metalpetal {
 
 
 
+
+
 #ifndef TARGET_OS_SIMULATOR
     #error TARGET_OS_SIMULATOR not defined. Check <TargetConditionals.h>
 #endif
@@ -1878,16 +2050,17 @@ using namespace metalpetal;
 
 namespace metalpetal {
 
-vertex VertexOut multilayerCompositeVertexShader(
-                                        const device VertexIn * vertices [[ buffer(0) ]],
+vertex MTIMultilayerCompositingLayerVertexOut multilayerCompositeVertexShader(
+                                        const device MTIMultilayerCompositingLayerVertex * vertices [[ buffer(0) ]],
                                         constant float4x4 & transformMatrix [[ buffer(1) ]],
                                         constant float4x4 & orthographicMatrix [[ buffer(2) ]],
                                         uint vid [[ vertex_id ]]
                                         ) {
-    VertexOut outVertex;
-    VertexIn inVertex = vertices[vid];
+    MTIMultilayerCompositingLayerVertexOut outVertex;
+    MTIMultilayerCompositingLayerVertex inVertex = vertices[vid];
     outVertex.position = inVertex.position * transformMatrix * orthographicMatrix;
     outVertex.textureCoordinate = inVertex.textureCoordinate;
+    outVertex.positionInLayer = inVertex.positionInLayer;
     return outVertex;
 }
 
@@ -1895,24 +2068,36 @@ vertex VertexOut multilayerCompositeVertexShader(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeNormalBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return normalBlend(currentColor,textureColor);
@@ -1921,9 +2106,11 @@ fragment float4 multilayerCompositeNormalBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeNormalBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -1932,18 +2119,27 @@ fragment float4 multilayerCompositeNormalBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return normalBlend(backgroundColor,textureColor);
@@ -1953,24 +2149,36 @@ fragment float4 multilayerCompositeNormalBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeDarkenBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return darkenBlend(currentColor,textureColor);
@@ -1979,9 +2187,11 @@ fragment float4 multilayerCompositeDarkenBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeDarkenBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -1990,18 +2200,27 @@ fragment float4 multilayerCompositeDarkenBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return darkenBlend(backgroundColor,textureColor);
@@ -2011,24 +2230,36 @@ fragment float4 multilayerCompositeDarkenBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeMultiplyBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return multiplyBlend(currentColor,textureColor);
@@ -2037,9 +2268,11 @@ fragment float4 multilayerCompositeMultiplyBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeMultiplyBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -2048,18 +2281,27 @@ fragment float4 multilayerCompositeMultiplyBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return multiplyBlend(backgroundColor,textureColor);
@@ -2069,24 +2311,36 @@ fragment float4 multilayerCompositeMultiplyBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeColorBurnBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return colorBurnBlend(currentColor,textureColor);
@@ -2095,9 +2349,11 @@ fragment float4 multilayerCompositeColorBurnBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeColorBurnBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -2106,18 +2362,27 @@ fragment float4 multilayerCompositeColorBurnBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return colorBurnBlend(backgroundColor,textureColor);
@@ -2127,24 +2392,36 @@ fragment float4 multilayerCompositeColorBurnBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeLinearBurnBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return linearBurnBlend(currentColor,textureColor);
@@ -2153,9 +2430,11 @@ fragment float4 multilayerCompositeLinearBurnBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeLinearBurnBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -2164,18 +2443,27 @@ fragment float4 multilayerCompositeLinearBurnBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return linearBurnBlend(backgroundColor,textureColor);
@@ -2185,24 +2473,36 @@ fragment float4 multilayerCompositeLinearBurnBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeDarkerColorBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return darkerColorBlend(currentColor,textureColor);
@@ -2211,9 +2511,11 @@ fragment float4 multilayerCompositeDarkerColorBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeDarkerColorBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -2222,18 +2524,27 @@ fragment float4 multilayerCompositeDarkerColorBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return darkerColorBlend(backgroundColor,textureColor);
@@ -2243,24 +2554,36 @@ fragment float4 multilayerCompositeDarkerColorBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeLightenBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return lightenBlend(currentColor,textureColor);
@@ -2269,9 +2592,11 @@ fragment float4 multilayerCompositeLightenBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeLightenBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -2280,18 +2605,27 @@ fragment float4 multilayerCompositeLightenBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return lightenBlend(backgroundColor,textureColor);
@@ -2301,24 +2635,36 @@ fragment float4 multilayerCompositeLightenBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeScreenBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return screenBlend(currentColor,textureColor);
@@ -2327,9 +2673,11 @@ fragment float4 multilayerCompositeScreenBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeScreenBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -2338,18 +2686,27 @@ fragment float4 multilayerCompositeScreenBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return screenBlend(backgroundColor,textureColor);
@@ -2359,24 +2716,36 @@ fragment float4 multilayerCompositeScreenBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeColorDodgeBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return colorDodgeBlend(currentColor,textureColor);
@@ -2385,9 +2754,11 @@ fragment float4 multilayerCompositeColorDodgeBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeColorDodgeBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -2396,18 +2767,27 @@ fragment float4 multilayerCompositeColorDodgeBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return colorDodgeBlend(backgroundColor,textureColor);
@@ -2417,24 +2797,36 @@ fragment float4 multilayerCompositeColorDodgeBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeAddBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return addBlend(currentColor,textureColor);
@@ -2443,9 +2835,11 @@ fragment float4 multilayerCompositeAddBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeAddBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -2454,18 +2848,27 @@ fragment float4 multilayerCompositeAddBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return addBlend(backgroundColor,textureColor);
@@ -2475,24 +2878,36 @@ fragment float4 multilayerCompositeAddBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeLighterColorBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return lighterColorBlend(currentColor,textureColor);
@@ -2501,9 +2916,11 @@ fragment float4 multilayerCompositeLighterColorBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeLighterColorBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -2512,18 +2929,27 @@ fragment float4 multilayerCompositeLighterColorBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return lighterColorBlend(backgroundColor,textureColor);
@@ -2533,24 +2959,36 @@ fragment float4 multilayerCompositeLighterColorBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeOverlayBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return overlayBlend(currentColor,textureColor);
@@ -2559,9 +2997,11 @@ fragment float4 multilayerCompositeOverlayBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeOverlayBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -2570,18 +3010,27 @@ fragment float4 multilayerCompositeOverlayBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return overlayBlend(backgroundColor,textureColor);
@@ -2591,24 +3040,36 @@ fragment float4 multilayerCompositeOverlayBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeSoftLightBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return softLightBlend(currentColor,textureColor);
@@ -2617,9 +3078,11 @@ fragment float4 multilayerCompositeSoftLightBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeSoftLightBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -2628,18 +3091,27 @@ fragment float4 multilayerCompositeSoftLightBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return softLightBlend(backgroundColor,textureColor);
@@ -2649,24 +3121,36 @@ fragment float4 multilayerCompositeSoftLightBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeHardLightBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return hardLightBlend(currentColor,textureColor);
@@ -2675,9 +3159,11 @@ fragment float4 multilayerCompositeHardLightBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeHardLightBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -2686,18 +3172,27 @@ fragment float4 multilayerCompositeHardLightBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return hardLightBlend(backgroundColor,textureColor);
@@ -2707,24 +3202,36 @@ fragment float4 multilayerCompositeHardLightBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeVividLightBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return vividLightBlend(currentColor,textureColor);
@@ -2733,9 +3240,11 @@ fragment float4 multilayerCompositeVividLightBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeVividLightBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -2744,18 +3253,27 @@ fragment float4 multilayerCompositeVividLightBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return vividLightBlend(backgroundColor,textureColor);
@@ -2765,24 +3283,36 @@ fragment float4 multilayerCompositeVividLightBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeLinearLightBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return linearLightBlend(currentColor,textureColor);
@@ -2791,9 +3321,11 @@ fragment float4 multilayerCompositeLinearLightBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeLinearLightBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -2802,18 +3334,27 @@ fragment float4 multilayerCompositeLinearLightBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return linearLightBlend(backgroundColor,textureColor);
@@ -2823,24 +3364,36 @@ fragment float4 multilayerCompositeLinearLightBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositePinLightBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return pinLightBlend(currentColor,textureColor);
@@ -2849,9 +3402,11 @@ fragment float4 multilayerCompositePinLightBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositePinLightBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -2860,18 +3415,27 @@ fragment float4 multilayerCompositePinLightBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return pinLightBlend(backgroundColor,textureColor);
@@ -2881,24 +3445,36 @@ fragment float4 multilayerCompositePinLightBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeHardMixBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return hardMixBlend(currentColor,textureColor);
@@ -2907,9 +3483,11 @@ fragment float4 multilayerCompositeHardMixBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeHardMixBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -2918,18 +3496,27 @@ fragment float4 multilayerCompositeHardMixBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return hardMixBlend(backgroundColor,textureColor);
@@ -2939,24 +3526,36 @@ fragment float4 multilayerCompositeHardMixBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeDifferenceBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return differenceBlend(currentColor,textureColor);
@@ -2965,9 +3564,11 @@ fragment float4 multilayerCompositeDifferenceBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeDifferenceBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -2976,18 +3577,27 @@ fragment float4 multilayerCompositeDifferenceBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return differenceBlend(backgroundColor,textureColor);
@@ -2997,24 +3607,36 @@ fragment float4 multilayerCompositeDifferenceBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeExclusionBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return exclusionBlend(currentColor,textureColor);
@@ -3023,9 +3645,11 @@ fragment float4 multilayerCompositeExclusionBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeExclusionBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -3034,18 +3658,27 @@ fragment float4 multilayerCompositeExclusionBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return exclusionBlend(backgroundColor,textureColor);
@@ -3055,24 +3688,36 @@ fragment float4 multilayerCompositeExclusionBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeSubtractBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return subtractBlend(currentColor,textureColor);
@@ -3081,9 +3726,11 @@ fragment float4 multilayerCompositeSubtractBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeSubtractBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -3092,18 +3739,27 @@ fragment float4 multilayerCompositeSubtractBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return subtractBlend(backgroundColor,textureColor);
@@ -3113,24 +3769,36 @@ fragment float4 multilayerCompositeSubtractBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeDivideBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return divideBlend(currentColor,textureColor);
@@ -3139,9 +3807,11 @@ fragment float4 multilayerCompositeDivideBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeDivideBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -3150,18 +3820,27 @@ fragment float4 multilayerCompositeDivideBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return divideBlend(backgroundColor,textureColor);
@@ -3171,24 +3850,36 @@ fragment float4 multilayerCompositeDivideBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeHueBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return hueBlend(currentColor,textureColor);
@@ -3197,9 +3888,11 @@ fragment float4 multilayerCompositeHueBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeHueBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -3208,18 +3901,27 @@ fragment float4 multilayerCompositeHueBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return hueBlend(backgroundColor,textureColor);
@@ -3229,24 +3931,36 @@ fragment float4 multilayerCompositeHueBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeSaturationBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return saturationBlend(currentColor,textureColor);
@@ -3255,9 +3969,11 @@ fragment float4 multilayerCompositeSaturationBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeSaturationBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -3266,18 +3982,27 @@ fragment float4 multilayerCompositeSaturationBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return saturationBlend(backgroundColor,textureColor);
@@ -3287,24 +4012,36 @@ fragment float4 multilayerCompositeSaturationBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeColorBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return colorBlend(currentColor,textureColor);
@@ -3313,9 +4050,11 @@ fragment float4 multilayerCompositeColorBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeColorBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -3324,18 +4063,27 @@ fragment float4 multilayerCompositeColorBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return colorBlend(backgroundColor,textureColor);
@@ -3345,24 +4093,36 @@ fragment float4 multilayerCompositeColorBlend(
 #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
     
 fragment float4 multilayerCompositeLuminosityBlend_programmableBlending(
-                                                    VertexOut vertexIn [[ stage_in ]],
+                                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                                     float4 currentColor [[color(0)]],
-                                                    float4 maskColor [[color(1)]],
+                                                    float4 compositingMaskColor [[color(1)]],
                                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                    sampler colorSampler [[ sampler(0) ]]
+                                                    sampler colorSampler [[ sampler(0) ]],
+                                                    texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                    sampler maskSampler [[ sampler(1) ]]
                                                 ) {
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return luminosityBlend(currentColor,textureColor);
@@ -3371,9 +4131,11 @@ fragment float4 multilayerCompositeLuminosityBlend_programmableBlending(
 #endif
 
 fragment float4 multilayerCompositeLuminosityBlend(
-                                    VertexOut vertexIn [[ stage_in ]],
+                                    MTIMultilayerCompositingLayerVertexOut vertexIn [[ stage_in ]],
                                     texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                    texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                    texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                    sampler maskSampler [[ sampler(3) ]],
                                     constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                     texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                     sampler colorSampler [[ sampler(0) ]],
@@ -3382,18 +4144,27 @@ fragment float4 multilayerCompositeLuminosityBlend(
     constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
     float2 location = vertexIn.position.xy / viewportSize;
     float4 backgroundColor = backgroundTexture.sample(s, location);
-    float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-    if (parameters.contentHasPremultipliedAlpha) {
+    float2 textureCoordinate = vertexIn.textureCoordinate;
+    #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
+    textureCoordinate = modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height()));
+    #endif
+    float4 textureColor = colorTexture.sample(colorSampler, textureCoordinate);
+    if (multilayer_composite_content_premultiplied) {
         textureColor = unpremultiply(textureColor);
     }
-    if (parameters.tintColor.a != 0) {
+    if (multilayer_composite_has_mask) {
+        float4 maskColor = maskTexture.sample(maskSampler, vertexIn.positionInLayer);
+        float maskValue = maskColor[parameters.maskComponent];
+        textureColor.a *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_compositing_mask) {
+        float4 maskColor = compositingMaskTexture.sample(s, location);
+        float maskValue = maskColor[parameters.compositingMaskComponent];
+        textureColor.a *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
+    }
+    if (multilayer_composite_has_tint_color) {
         textureColor.rgb = parameters.tintColor.rgb;
         textureColor.a *= parameters.tintColor.a;
-    }
-    if (parameters.hasCompositingMask) {
-        float4 maskColor = maskTexture.sample(s, location);
-        float maskValue = maskColor[parameters.compositingMaskComponent];
-        textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
     }
     textureColor.a *= parameters.opacity;
     return luminosityBlend(backgroundColor,textureColor);
@@ -3409,6 +4180,8 @@ fragment float4 multilayerCompositeLuminosityBlend(
 //
 
 #include <metal_stdlib>
+
+
 
 
 
@@ -3596,14 +4369,21 @@ namespace metalpetal {
     fragment float4 multilayerCompositeColorLookup512x512Blend_programmableBlending(
                                                        VertexOut vertexIn [[ stage_in ]],
                                                        float4 currentColor [[color(0)]],
-                                                       float4 maskColor [[color(1)]],
+                                                       float4 compositingMaskColor [[color(1)]],
                                                        constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                        texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                       sampler colorSampler [[ sampler(0) ]]
-                                                       ) {
+                                                       sampler colorSampler [[ sampler(0) ]],
+                                                       texture2d<float, access::sample> maskTexture [[ texture(1) ]],
+                                                       sampler maskSampler [[ sampler(1) ]]) {
         float intensity = 1.0;
-        if (parameters.hasCompositingMask) {
-            intensity *= maskColor[parameters.compositingMaskComponent];
+        if (multilayer_composite_has_mask) {
+            float4 maskColor = maskTexture.sample(maskSampler, vertexIn.textureCoordinate);
+            float maskValue = maskColor[parameters.maskComponent];
+            intensity *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+        }
+        if (multilayer_composite_has_compositing_mask) {
+            float maskValue = compositingMaskColor[parameters.compositingMaskComponent];
+            intensity *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
         }
         intensity *= parameters.opacity;
         return colorLookup2DSquareLUT(currentColor,64,intensity,colorTexture,colorSampler);
@@ -3614,7 +4394,9 @@ namespace metalpetal {
     fragment float4 multilayerCompositeColorLookup512x512Blend(
                                                                VertexOut vertexIn [[ stage_in ]],
                                                                texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                                               texture2d<float, access::sample> maskTexture [[ texture(2) ]],
+                                                               texture2d<float, access::sample> compositingMaskTexture [[ texture(2) ]],
+                                                               texture2d<float, access::sample> maskTexture [[ texture(3) ]],
+                                                               sampler maskSampler [[ sampler(3) ]],
                                                                constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
                                                                texture2d<float, access::sample> colorTexture [[ texture(0) ]],
                                                                sampler colorSampler [[ sampler(0) ]],
@@ -3624,15 +4406,20 @@ namespace metalpetal {
         float2 location = vertexIn.position.xy / viewportSize;
         float4 backgroundColor = backgroundTexture.sample(s, location);
         float intensity = 1.0;
-        if (parameters.hasCompositingMask) {
-            float4 maskColor = maskTexture.sample(s, location);
+        if (multilayer_composite_has_mask) {
+            float4 maskColor = maskTexture.sample(maskSampler, vertexIn.textureCoordinate);
+            float maskValue = maskColor[parameters.maskComponent];
+            intensity *= multilayer_composite_mask_inverted ? (1.0 - maskValue) : maskValue;
+        }
+        if (multilayer_composite_has_compositing_mask) {
+            float4 maskColor = compositingMaskTexture.sample(s, location);
             float maskValue = maskColor[parameters.compositingMaskComponent];
-            intensity *= maskValue;
+            intensity *= multilayer_composite_compositing_mask_inverted ? (1.0 - maskValue) : maskValue;
         }
         intensity *= parameters.opacity;
         return colorLookup2DSquareLUT(backgroundColor,64,intensity,colorTexture,colorSampler);
     }
-        
+    
     fragment float4 colorLookup2DHorizontalStrip(
                                          VertexOut vertexIn [[stage_in]],
                                          texture2d<float, access::sample> sourceTexture [[texture(0)]],

--- a/Sources/MetalPetalObjectiveC/include/MTIShaderFunctionConstants.h
+++ b/Sources/MetalPetalObjectiveC/include/MTIShaderFunctionConstants.h
@@ -1,0 +1,1 @@
+../../../Frameworks/MetalPetal/Shaders/MTIShaderFunctionConstants.h

--- a/Tests/MetalPetalTestHelpers/CLUTGenerator.swift
+++ b/Tests/MetalPetalTestHelpers/CLUTGenerator.swift
@@ -1,0 +1,94 @@
+import CoreGraphics
+
+public struct CLUTImageLayout {
+    public var horizontalTileCount: UInt
+    public var verticalTileCount: UInt
+    public init(horizontalTileCount: UInt, verticalTileCount: UInt) {
+        self.verticalTileCount = verticalTileCount
+        self.horizontalTileCount = horizontalTileCount
+    }
+}
+
+public struct CLUTImageDescriptor {
+    public var dimension: UInt
+    public var layout: CLUTImageLayout
+    
+    public var isValid: Bool {
+        return dimension > 0 && dimension <= 256 && (layout.horizontalTileCount * layout.verticalTileCount == dimension)
+    }
+    
+    public var title: String {
+        return "CLUT_D\(self.dimension)_\(self.layout.horizontalTileCount * self.dimension)x\(self.layout.verticalTileCount * self.dimension)"
+    }
+    
+    public static let squareD16: CLUTImageDescriptor = CLUTImageDescriptor(dimension: 16, layout: CLUTImageLayout(horizontalTileCount: 4, verticalTileCount: 4))
+
+    public static let squareD64: CLUTImageDescriptor = CLUTImageDescriptor(dimension: 64, layout: CLUTImageLayout(horizontalTileCount: 8, verticalTileCount: 8))
+    
+    public static let squareD256: CLUTImageDescriptor = CLUTImageDescriptor(dimension: 256, layout: CLUTImageLayout(horizontalTileCount: 16, verticalTileCount: 16))
+    
+    public init(dimension: UInt, layout: CLUTImageLayout) {
+        self.dimension = dimension
+        self.layout = layout
+    }
+}
+
+public struct IdentityCLUTImageGenerator {
+    public static func generateIdentityCLUTImage(with descriptor: CLUTImageDescriptor) -> CGImage? {
+        assert(descriptor.isValid)
+        guard descriptor.isValid else {
+            return nil
+        }
+        
+        let imageWidth = Int(descriptor.dimension * descriptor.layout.horizontalTileCount)
+        let imageHeight = Int(descriptor.dimension * descriptor.layout.verticalTileCount)
+        
+        let bytesPerPixel = 4
+        let bytesPerRow = imageWidth * bytesPerPixel
+        
+        guard let buffer = malloc(imageHeight * bytesPerRow) else {
+            return nil
+        }
+        
+        struct Pixel {
+            var b: UInt8
+            var g: UInt8
+            var r: UInt8
+            var a: UInt8
+        }
+        
+        precondition(MemoryLayout<Pixel>.size == 4)
+        
+        let pixels = buffer.assumingMemoryBound(to: Pixel.self)
+        for y in 0..<imageHeight {
+            let lineOffset = y * imageWidth
+            for x in 0..<imageWidth {
+                var pixel = pixels.advanced(by: lineOffset + x).pointee
+                let tileX = x / Int(descriptor.dimension)
+                let tileY = y / Int(descriptor.dimension)
+                let tile = tileY * Int(descriptor.layout.horizontalTileCount) + tileX
+                let innerX = x - tileX * Int(descriptor.dimension)
+                let innerY = y - tileY * Int(descriptor.dimension)
+                pixel.b = UInt8(round(Double(tile) / Double(descriptor.dimension - 1) * 255))
+                pixel.r = UInt8(round(Double(innerX) / Double(descriptor.dimension - 1) * 255))
+                pixel.g = UInt8(round(Double(innerY) / Double(descriptor.dimension - 1) * 255))
+                pixel.a = 255
+                pixels.advanced(by: lineOffset + x).pointee = pixel
+            }
+        }
+        guard let dataProvider = CGDataProvider(data: CFDataCreate(kCFAllocatorDefault, buffer.assumingMemoryBound(to: UInt8.self), imageHeight * bytesPerRow)) else {
+            return nil
+        }
+        return CGImage(width: imageWidth,
+                       height: imageHeight,
+                       bitsPerComponent: 8,
+                       bitsPerPixel: bytesPerPixel * 8,
+                       bytesPerRow: bytesPerRow,
+                       space: CGColorSpaceCreateDeviceRGB(),
+                       bitmapInfo: CGBitmapInfo(rawValue: CGBitmapInfo.byteOrder32Little.rawValue | CGImageAlphaInfo.premultipliedFirst.rawValue),
+                       provider: dataProvider,
+                       decode: nil,
+                       shouldInterpolate: false,
+                       intent: .defaultIntent)
+    }
+}

--- a/Tests/MetalPetalTests/RenderTests.swift
+++ b/Tests/MetalPetalTests/RenderTests.swift
@@ -394,7 +394,7 @@ final class RenderTests: XCTestCase {
         filter.inputBackgroundImage = image
         filter.rasterSampleCount = 1
         filter.layers = [MultilayerCompositingFilter.Layer(content: MTIImage.white)
-                            .frame(center: CGPoint(x: 0.5, y: 0.5), size: CGSize(width: 1, height: 1), layoutUint: .pixel)
+                            .frame(center: CGPoint(x: 0.5, y: 0.5), size: CGSize(width: 1, height: 1), layoutUnit: .pixel)
                             .opacity(1)]
         let outputImage = try XCTUnwrap(filter.outputImage)
         let outputCGImage = try context.makeCGImage(from: outputImage)
@@ -419,7 +419,7 @@ final class RenderTests: XCTestCase {
         filter.inputBackgroundImage = image
         filter.rasterSampleCount = 1
         filter.layers = [MultilayerCompositingFilter.Layer(content: MTIImage.white)
-                            .frame(center: CGPoint(x: 0.5, y: 0.5), size: CGSize(width: 1, height: 1), layoutUint: .pixel)
+                            .frame(center: CGPoint(x: 0.5, y: 0.5), size: CGSize(width: 1, height: 1), layoutUnit: .pixel)
                             .opacity(0.5)]
         let outputImage = try XCTUnwrap(filter.outputImage)
         let outputCGImage = try context.makeCGImage(from: outputImage)
@@ -445,7 +445,7 @@ final class RenderTests: XCTestCase {
         filter.inputBackgroundImage = image
         filter.rasterSampleCount = 4
         filter.layers = [MultilayerCompositingFilter.Layer(content: MTIImage.white)
-                            .frame(center: CGPoint(x: 0.5, y: 0.5), size: CGSize(width: 1, height: 1), layoutUint: .pixel)
+                            .frame(center: CGPoint(x: 0.5, y: 0.5), size: CGSize(width: 1, height: 1), layoutUnit: .pixel)
                             .opacity(0.5)]
         let outputImage = try XCTUnwrap(filter.outputImage)
         let outputCGImage = try context.makeCGImage(from: outputImage)
@@ -470,7 +470,7 @@ final class RenderTests: XCTestCase {
         filter.inputBackgroundImage = image
         filter.rasterSampleCount = 1
         filter.layers = [MultilayerCompositingFilter.Layer(content: MTIImage.white)
-                            .frame(center: CGPoint(x: 0.5, y: 0.5), size: CGSize(width: 1, height: 1), layoutUint: .pixel)
+                            .frame(center: CGPoint(x: 0.5, y: 0.5), size: CGSize(width: 1, height: 1), layoutUnit: .pixel)
                             .opacity(1)
                             .tintColor(MTIColor(red: 1, green: 1, blue: 0, alpha: 1))]
         let outputImage = try XCTUnwrap(filter.outputImage)
@@ -497,7 +497,7 @@ final class RenderTests: XCTestCase {
         
         try autoreleasepool {
             filter.layers = [MultilayerCompositingFilter.Layer(content: MTIImage.white)
-                                .frame(center: CGPoint(x: 0.5, y: 0.5), size: CGSize(width: 1, height: 1), layoutUint: .pixel)
+                                .frame(center: CGPoint(x: 0.5, y: 0.5), size: CGSize(width: 1, height: 1), layoutUnit: .pixel)
                                 .opacity(1)
                                 .tintColor(MTIColor(red: 1, green: 1, blue: 0, alpha: 0.5))]
             let outputImage = try XCTUnwrap(filter.outputImage)
@@ -514,7 +514,7 @@ final class RenderTests: XCTestCase {
         
         try autoreleasepool {
             filter.layers = [MultilayerCompositingFilter.Layer(content: MTIImage.white)
-                                .frame(center: CGPoint(x: 0.5, y: 0.5), size: CGSize(width: 1, height: 1), layoutUint: .pixel)
+                                .frame(center: CGPoint(x: 0.5, y: 0.5), size: CGSize(width: 1, height: 1), layoutUnit: .pixel)
                                 .opacity(1)
                                 .tintColor(MTIColor(red: 1, green: 1, blue: 0, alpha: 0))]
             let outputImage = try XCTUnwrap(filter.outputImage)
@@ -547,7 +547,7 @@ final class RenderTests: XCTestCase {
         filter.inputBackgroundImage = image
         filter.rasterSampleCount = 1
         filter.layers = [MultilayerCompositingFilter.Layer(content: overlayImage)
-                            .frame(CGRect(x: 0, y: 0, width: 2, height: 2), layoutUint: .pixel)
+                            .frame(CGRect(x: 0, y: 0, width: 2, height: 2), layoutUnit: .pixel)
                             .rotation(.pi/2)
                             .opacity(1)]
         guard let outputImage = filter.outputImage else {
@@ -575,7 +575,7 @@ final class RenderTests: XCTestCase {
         let filter = MultilayerCompositingFilter()
         filter.inputBackgroundImage = MTIImage(color: MTIColor(red: 1, green: 0, blue: 0, alpha: 0.5), sRGB: false, size: CGSize(width: 1, height: 1))
         filter.layers = [MultilayerCompositingFilter.Layer(content:  MTIImage(color: MTIColor(red: 1, green: 0, blue: 0, alpha: 0.5), sRGB: false, size: CGSize(width: 1, height: 1)))
-                            .frame(CGRect(x: 0, y: 0, width: 1, height: 1), layoutUint: .pixel)
+                            .frame(CGRect(x: 0, y: 0, width: 1, height: 1), layoutUnit: .pixel)
                             .opacity(1)]
         filter.outputAlphaType = .alphaIsOne
         let outputImage = try XCTUnwrap(filter.outputImage?.withCachePolicy(.persistent))
@@ -592,7 +592,7 @@ final class RenderTests: XCTestCase {
         let filter = MultilayerCompositingFilter()
         filter.inputBackgroundImage = MTIImage(color: MTIColor(red: 1, green: 0, blue: 0, alpha: 0.5), sRGB: false, size: CGSize(width: 1, height: 1))
         filter.layers = [MultilayerCompositingFilter.Layer(content:  MTIImage(color: MTIColor(red: 1, green: 0, blue: 0, alpha: 0.5), sRGB: false, size: CGSize(width: 1, height: 1)))
-                            .frame(CGRect(x: 0, y: 0, width: 1, height: 1), layoutUint: .pixel)
+                            .frame(CGRect(x: 0, y: 0, width: 1, height: 1), layoutUnit: .pixel)
                             .opacity(1)]
         let outputImage = try XCTUnwrap(filter.outputImage?.withCachePolicy(.persistent))
         XCTAssert(outputImage.alphaType == .nonPremultiplied)
@@ -610,7 +610,7 @@ final class RenderTests: XCTestCase {
         let filter = MultilayerCompositingFilter()
         filter.inputBackgroundImage = MTIImage(color: MTIColor(red: 1, green: 0, blue: 0, alpha: 0.5), sRGB: false, size: CGSize(width: 1, height: 1))
         filter.layers = [MultilayerCompositingFilter.Layer(content:  MTIImage(color: MTIColor(red: 1, green: 0, blue: 0, alpha: 0.5), sRGB: false, size: CGSize(width: 1, height: 1)))
-                            .frame(CGRect(x: 0, y: 0, width: 1, height: 1), layoutUint: .pixel)
+                            .frame(CGRect(x: 0, y: 0, width: 1, height: 1), layoutUnit: .pixel)
                             .opacity(1)]
         filter.outputAlphaType = .premultiplied
         let outputImage = try XCTUnwrap(filter.outputImage?.withCachePolicy(.persistent))
@@ -630,7 +630,7 @@ final class RenderTests: XCTestCase {
         let filter = MultilayerCompositingFilter()
         filter.inputBackgroundImage = MTIImage(color: MTIColor(red: 1, green: 0, blue: 0, alpha: 0.5), sRGB: false, size: CGSize(width: 1, height: 1))
         filter.layers = [MultilayerCompositingFilter.Layer(content:  MTIImage(color: MTIColor(red: 1, green: 0, blue: 0, alpha: 0.5), sRGB: false, size: CGSize(width: 1, height: 1)))
-                            .frame(CGRect(x: 0, y: 0, width: 1, height: 1), layoutUint: .pixel)
+                            .frame(CGRect(x: 0, y: 0, width: 1, height: 1), layoutUnit: .pixel)
                             .opacity(1)]
         filter.outputAlphaType = .alphaIsOne
         let outputImage = try XCTUnwrap(filter.outputImage?.withCachePolicy(.persistent))
@@ -699,7 +699,7 @@ final class RenderTests: XCTestCase {
         let filter = MultilayerCompositingFilter()
         filter.inputBackgroundImage = MTIImage(color: MTIColor(red: 1, green: 0, blue: 0, alpha: 0.5), sRGB: false, size: CGSize(width: 1, height: 1))
         filter.layers = [MultilayerCompositingFilter.Layer(content:  MTIImage(color: MTIColor(red: 1, green: 0, blue: 0, alpha: 0.5), sRGB: false, size: CGSize(width: 1, height: 1)))
-                            .frame(CGRect(x: 0, y: 0, width: 1, height: 1), layoutUint: .pixel)
+                            .frame(CGRect(x: 0, y: 0, width: 1, height: 1), layoutUnit: .pixel)
                             .opacity(1)]
         filter.rasterSampleCount = 4
         filter.outputAlphaType = .premultiplied
@@ -727,7 +727,7 @@ final class RenderTests: XCTestCase {
         filter.inputBackgroundImage = image
         filter.rasterSampleCount = 1
         filter.layers = [MultilayerCompositingFilter.Layer(content: MTIImage.white)
-                            .frame(CGRect(x: 0, y: 0, width: 1.6, height: 1), layoutUint: .pixel)
+                            .frame(CGRect(x: 0, y: 0, width: 1.6, height: 1), layoutUnit: .pixel)
                             .opacity(1)]
         guard let outputImage = filter.outputImage else {
             XCTFail()
@@ -1050,7 +1050,7 @@ final class RenderTests: XCTestCase {
         let filter = MultilayerCompositingFilter()
         filter.inputBackgroundImage = image
         filter.layers = [MultilayerCompositingFilter.Layer(content: MTIImage(color: MTIColor(red: 64/255.0, green: 0, blue: 0, alpha: 0), sRGB: false, size: CGSize(width: 1, height: 1)))
-                            .frame(CGRect(x: 0, y: 0, width: 1, height: 1), layoutUint: .pixel)
+                            .frame(CGRect(x: 0, y: 0, width: 1, height: 1), layoutUnit: .pixel)
                             .opacity(1)
                             .blendMode(blendMode)]
         let outputImage = try XCTUnwrap(filter.outputImage)
@@ -1090,7 +1090,7 @@ final class RenderTests: XCTestCase {
         let filter = MultilayerCompositingFilter()
         filter.inputBackgroundImage = image
         filter.layers = [MultilayerCompositingFilter.Layer(content: overlay)
-                            .frame(CGRect(x: 0, y: 0, width: 2, height: 1), layoutUint: .pixel)
+                            .frame(CGRect(x: 0, y: 0, width: 2, height: 1), layoutUnit: .pixel)
                             .opacity(1)
                             .blendMode(blendMode)]
         let outputImage = try XCTUnwrap(filter.outputImage)
@@ -1119,16 +1119,11 @@ final class RenderTests: XCTestCase {
         let filter = MultilayerCompositingFilter()
         filter.inputBackgroundImage = image
         filter.layers = [MultilayerCompositingFilter.Layer(content: overlay)
-                            .frame(CGRect(x: 0, y: 0, width: 2, height: 1), layoutUint: .pixel)
+                            .frame(CGRect(x: 0, y: 0, width: 2, height: 1), layoutUnit: .pixel)
                             .opacity(1)
                             .blendMode(blendMode)]
         let outputImage = try XCTUnwrap(filter.outputImage)
-        do {
-            let _ = try context.makeCGImage(from: outputImage)
-            XCTFail()
-        } catch {
-            XCTAssert(error is MTIError && (error as! MTIError).code == .failedToFetchBlendRenderPipelineForMultilayerCompositing)
-        }
+        XCTAssertThrowsError(try context.makeCGImage(from: outputImage))
     }
     
     func testCustomBlending() throws {

--- a/Utilities/Sources/BoilerplateGenerator/BlendFormulaSupport.swift
+++ b/Utilities/Sources/BoilerplateGenerator/BlendFormulaSupport.swift
@@ -13,6 +13,9 @@ struct BlendFormulaSupport {
         let sourceHeaderFile = sourceDirectory.appendingPathComponent("Shaders/MTIShaderLib.h")
         let shaderHeaderContent = try! String(contentsOf: sourceHeaderFile, encoding: .utf8)
         
+        let functionConstantsHeaderFile = sourceDirectory.appendingPathComponent("Shaders/MTIShaderFunctionConstants.h")
+        let functionConstantsContent = try! String(contentsOf: functionConstantsHeaderFile, encoding: .utf8)
+        
         let header = """
         //
         // This is an auto-generated source file.
@@ -33,94 +36,16 @@ struct BlendFormulaSupport {
         
         static const char *MTIBlendFormulaSupportShaderTemplate = R"mtirawstring(
         \(shaderHeaderContent)
+        \(functionConstantsContent)
 
         using namespace metalpetal;
         
         {MTIBlendFormula}
-
-        fragment float4 customBlend(VertexOut vertexIn [[ stage_in ]],
-                                            texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                            sampler colorSampler [[ sampler(0) ]],
-                                            texture2d<float, access::sample> overlayTexture [[ texture(1) ]],
-                                            sampler overlaySampler [[ sampler(1) ]],
-                                            constant float &intensity [[buffer(0)]]
-                                            ) {
-            float4 uCb = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-            #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
-            float4 uCf = overlayTexture.sample(overlaySampler, modify_source_texture_coordinates(uCb, vertexIn.textureCoordinate, uint2(overlayTexture.get_width(), overlayTexture.get_height())));
-            #else
-            float4 uCf = overlayTexture.sample(overlaySampler, vertexIn.textureCoordinate);
-            #endif
-            float4 blendedColor = blend(uCb, uCf);
-            return mix(uCb,blendedColor,intensity);
-        }
-
-
-        #if __HAVE_COLOR_ARGUMENTS__ && !TARGET_OS_SIMULATOR
-            
-        fragment float4 multilayerCompositeCustomBlend_programmableBlending(
-                                                            VertexOut vertexIn [[ stage_in ]],
-                                                            float4 currentColor [[color(0)]],
-                                                            float4 maskColor [[color(1)]],
-                                                            constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
-                                                            texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                                            sampler colorSampler [[ sampler(0) ]]
-                                                        ) {
-            #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
-            float4 textureColor = colorTexture.sample(colorSampler, modify_source_texture_coordinates(currentColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height())));
-            #else
-            float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-            #endif
-            if (parameters.contentHasPremultipliedAlpha) {
-                textureColor = unpremultiply(textureColor);
-            }
-            if (parameters.tintColor.a != 0) {
-                textureColor.rgb = parameters.tintColor.rgb;
-                textureColor.a *= parameters.tintColor.a;
-            }
-            if (parameters.hasCompositingMask) {
-                float maskValue = maskColor[parameters.compositingMaskComponent];
-                textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
-            }
-            textureColor.a *= parameters.opacity;
-            return blend(currentColor,textureColor);
-        }
         
-        #endif
-
-        fragment float4 multilayerCompositeCustomBlend(
-                                            VertexOut vertexIn [[ stage_in ]],
-                                            texture2d<float, access::sample> backgroundTexture [[ texture(1) ]],
-                                            texture2d<float, access::sample> maskTexture [[ texture(2) ]],
-                                            constant MTIMultilayerCompositingLayerShadingParameters & parameters [[buffer(0)]],
-                                            texture2d<float, access::sample> colorTexture [[ texture(0) ]],
-                                            sampler colorSampler [[ sampler(0) ]],
-                                            constant float2 & viewportSize [[buffer(1)]]
-                                        ) {
-            constexpr sampler s(coord::normalized, address::clamp_to_zero, filter::linear);
-            float2 location = vertexIn.position.xy / viewportSize;
-            float4 backgroundColor = backgroundTexture.sample(s, location);
-            #if MTI_CUSTOM_BLEND_HAS_TEXTURE_COORDINATES_MODIFIER
-            float4 textureColor = colorTexture.sample(colorSampler, modify_source_texture_coordinates(backgroundColor, vertexIn.textureCoordinate, uint2(colorTexture.get_width(), colorTexture.get_height())));
-            #else
-            float4 textureColor = colorTexture.sample(colorSampler, vertexIn.textureCoordinate);
-            #endif
-            if (parameters.contentHasPremultipliedAlpha) {
-                textureColor = unpremultiply(textureColor);
-            }
-            if (parameters.tintColor.a != 0) {
-                textureColor.rgb = parameters.tintColor.rgb;
-                textureColor.a *= parameters.tintColor.a;
-            }
-            if (parameters.hasCompositingMask) {
-                float4 maskColor = maskTexture.sample(s, location);
-                float maskValue = maskColor[parameters.compositingMaskComponent];
-                textureColor.a *= parameters.usesOneMinusMaskValue ? (1.0 - maskValue) : maskValue;
-            }
-            textureColor.a *= parameters.opacity;
-            return blend(backgroundColor,textureColor);
-        }
-
+        \(MetalPetalBlendingShadersCodeGenerator.generateBlendFilterFragmentShader(shaderFunctionName: "customBlend", blendFunctionName: "blend"))
+        
+        \(MetalPetalBlendingShadersCodeGenerator.generateMultilayerCompositeFilterFragmentShader(shaderFunctionName: "multilayerCompositeCustomBlend", blendFunctionName: "blend"))
+        
         )mtirawstring";
 
         NSString * MTIBuildBlendFormulaShaderSource(NSString *formula) {

--- a/Utilities/Sources/SwiftPackageGenerator/SwiftPackageGenerator.swift
+++ b/Utilities/Sources/SwiftPackageGenerator/SwiftPackageGenerator.swift
@@ -93,14 +93,15 @@ public struct SwiftPackageGenerator: ParsableCommand {
     public func collectBuiltinMetalLibrarySource(shadersDirectory: URL) throws -> String {
         var librarySource = ""
         let sourceFileDirectory = shadersDirectory
-        let headerURL = sourceFileDirectory.appendingPathComponent("MTIShaderLib.h")
-        librarySource += try String(contentsOf: headerURL)
+        librarySource += try String(contentsOf: sourceFileDirectory.appendingPathComponent("MTIShaderLib.h"))
+        librarySource += try String(contentsOf: sourceFileDirectory.appendingPathComponent("MTIShaderFunctionConstants.h"))
         let fileManager = FileManager()
         for source in try fileManager.contentsOfDirectory(at: sourceFileDirectory, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]).sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
             if source.pathExtension == "metal" {
                 librarySource += "\n"
                 librarySource += try String(contentsOf: source)
                     .replacingOccurrences(of: "#include \"MTIShaderLib.h\"", with: "\n")
+                    .replacingOccurrences(of: "#include \"MTIShaderFunctionConstants.h\"", with: "\n")
                     .replacingOccurrences(of: "#include <TargetConditionals.h>", with: "\n")
             }
         }


### PR DESCRIPTION
- [x] Refactor the layer's render pipeline creation, from "All at once" to  "on-demand". Considering that we do not need to use all the blend modes at most times.
- [x] Use function constants to control composting mask, alpha type conversion, tint operation instead of using uniforms. This improve the performance of the shader, however we may need to create more PSOs(Pipeline State Object). Considering that PSOs are cached, this seems to be a fair trade.
- [x] Add a mask property to `MTILayer` and its Swift counterpart `MultilayerCompositingFilter.Layer`
- [x] Modify the vertices of layer compositing shader to include a `positionInLayer` attribute. Use `positionInLayer` in shader to sample the mask.
- [x] `layoutUnit` typo fix.
- [x] Handle the mask's alpha type.
- [x] Add tests.