### PR TITLE
Fix MTIAsyncVideoCompositionRequestHandler crash

### DIFF
--- a/Frameworks/MetalPetal/MTIVideoComposition.swift
+++ b/Frameworks/MetalPetal/MTIVideoComposition.swift
@@ -73,8 +73,8 @@ public class MTIAsyncVideoCompositionRequestHandler {
         public let compositionTime: CMTime
         public let renderSize: CGSize
         
-        public var anySourceImage: MTIImage {
-            return sourceImages.first!.value
+        public var anySourceImage: MTIImage? {
+            return sourceImages.first?.value
         }
     }
     

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ let context = try MTIContext(device: device)
 let asset = AVAsset(url: videoURL)
 let composition = MTIVideoComposition(asset: asset, context: context, queue: DispatchQueue.main, filter: { request in
     return FilterGraph.makeImage { output in
-        request.anySourceImage => filterA => filterB => output
+        request.anySourceImage! => filterA => filterB => output
     }!
 }
 


### PR DESCRIPTION
Crash when sourceImages will return no images for track, or when sourceImages is empty

This fixes #255