### PR TITLE
Refine swift interfaces

### DIFF
--- a/Frameworks/MetalPetal/Kernels/MTIRenderPipelineKernel.h
+++ b/Frameworks/MetalPetal/Kernels/MTIRenderPipelineKernel.h
@@ -81,11 +81,11 @@ __attribute__((objc_subclassing_restricted))
 - (MTIImage *)applyToInputImages:(NSArray<MTIImage *> *)images
                       parameters:(NSDictionary<NSString *,id> *)parameters
          outputTextureDimensions:(MTITextureDimensions)outputTextureDimensions
-               outputPixelFormat:(MTLPixelFormat)outputPixelFormat;
+               outputPixelFormat:(MTLPixelFormat)outputPixelFormat NS_REFINED_FOR_SWIFT;
 
 - (NSArray<MTIImage *> *)applyToInputImages:(NSArray<MTIImage *> *)images
                                  parameters:(NSDictionary<NSString *,id> *)parameters
-                          outputDescriptors:(NSArray<MTIRenderPassOutputDescriptor *> *)outputDescriptors;
+                          outputDescriptors:(NSArray<MTIRenderPassOutputDescriptor *> *)outputDescriptors NS_REFINED_FOR_SWIFT;
 
 @end
 

--- a/Frameworks/MetalPetal/Kernels/MTIRenderPipelineKernel.m
+++ b/Frameworks/MetalPetal/Kernels/MTIRenderPipelineKernel.m
@@ -515,6 +515,7 @@ __attribute__((objc_subclassing_restricted))
 }
 
 - (NSArray<MTIImage *> *)applyToInputImages:(NSArray<MTIImage *> *)images parameters:(NSDictionary<NSString *,id> *)parameters outputDescriptors:(NSArray<MTIRenderPassOutputDescriptor *> *)outputDescriptors {
+    NSParameterAssert(outputDescriptors.count == _colorAttachmentCount);
     MTIRenderCommand *command = [[MTIRenderCommand alloc] initWithKernel:self geometry:MTIVertices.fullViewportSquareVertices images:images parameters:parameters];
     return [MTIRenderCommand imagesByPerformingRenderCommands:@[command]
                                             outputDescriptors:outputDescriptors];

--- a/Frameworks/MetalPetal/Kernels/MTIRenderPipelineKernel.swift
+++ b/Frameworks/MetalPetal/Kernels/MTIRenderPipelineKernel.swift
@@ -1,0 +1,57 @@
+//
+//  MTIRenderPipelineKernel.swift
+//  Pods
+//
+//  Created by YuAo on 2021/11/30.
+//
+
+import Foundation
+import Metal
+
+#if SWIFT_PACKAGE
+import MetalPetalObjectiveC.Core
+#endif
+
+extension MTIRenderPipelineKernel {
+    
+    public func makeImage(parameters: [String: Any] = [:], dimensions: MTITextureDimensions, pixelFormat: MTLPixelFormat = .unspecified) -> MTIImage {
+        apply(to: [], parameters: parameters, outputDimensions: dimensions, outputPixelFormat: pixelFormat)
+    }
+    
+    public func apply(to image: MTIImage, parameters: [String: Any] = [:], outputPixelFormat: MTLPixelFormat = .unspecified) -> MTIImage {
+        __apply(toInputImages: [image], parameters: parameters, outputTextureDimensions: image.dimensions, outputPixelFormat: outputPixelFormat)
+    }
+    
+    public func apply(to image: MTIImage, parameters: [String: Any] = [:], outputDimensions: MTITextureDimensions, outputPixelFormat: MTLPixelFormat = .unspecified) -> MTIImage {
+        __apply(toInputImages: [image], parameters: parameters, outputTextureDimensions: outputDimensions, outputPixelFormat: outputPixelFormat)
+    }
+    
+    public func apply(to images: [MTIImage], parameters: [String: Any] = [:], outputDimensions: MTITextureDimensions, outputPixelFormat: MTLPixelFormat = .unspecified) -> MTIImage {
+        __apply(toInputImages: images, parameters: parameters, outputTextureDimensions: outputDimensions, outputPixelFormat: outputPixelFormat)
+    }
+    
+    public func apply(to images: [MTIImage], parameters: [String: Any] = [:], outputDescriptors: [MTIRenderPassOutputDescriptor]) -> [MTIImage] {
+        __apply(toInputImages: images, parameters: parameters, outputDescriptors: outputDescriptors)
+    }
+    
+    @available(*, deprecated, renamed: "apply(to:parameters:outputDescriptors:)")
+    public func apply(toInputImages: [MTIImage], parameters: [String: Any], outputDescriptors: [MTIRenderPassOutputDescriptor]) -> [MTIImage] {
+        __apply(toInputImages: toInputImages, parameters: parameters, outputDescriptors: outputDescriptors)
+    }
+    
+    @available(*, deprecated, renamed: "apply(to:parameters:outputDimensions:outputPixelFormat:)")
+    public func apply(toInputImages: [MTIImage], parameters: [String: Any], outputTextureDimensions: MTITextureDimensions, outputPixelFormat: MTLPixelFormat) -> MTIImage {
+        __apply(toInputImages: toInputImages, parameters: parameters, outputTextureDimensions: outputTextureDimensions, outputPixelFormat: outputPixelFormat)
+    }
+}
+
+extension Array where Element == MTIRenderCommand {
+    
+    public func makeImage(rasterSampleCount: Int = 1, dimension: MTITextureDimensions, pixelFormat: MTLPixelFormat = .unspecified) -> MTIImage {
+        MTIRenderCommand.images(byPerforming: self, rasterSampleCount: UInt(rasterSampleCount), outputDescriptors: [MTIRenderPassOutputDescriptor(dimensions: dimension, pixelFormat: pixelFormat)]).first!
+    }
+    
+    public func makeImages(rasterSampleCount: Int = 1, outputDescriptors: [MTIRenderPassOutputDescriptor]) -> [MTIImage] {
+        MTIRenderCommand.images(byPerforming: self, rasterSampleCount: UInt(rasterSampleCount), outputDescriptors: outputDescriptors)
+    }
+}

--- a/MetalPetalExamples/Shared/BokehEffectView.swift
+++ b/MetalPetalExamples/Shared/BokehEffectView.swift
@@ -177,11 +177,11 @@ struct BokehEffectView: View {
 struct CustomShapeBokehWithMask {
     private static let powKernel = MTIRenderPipelineKernel(vertexFunctionDescriptor: .passthroughVertex, fragmentFunctionDescriptor: MTIFunctionDescriptor(name: "imagePow", in: .main))
     private static func pow(_ image: MTIImage, _ value: Float) -> MTIImage {
-        powKernel.apply(toInputImages: [image], parameters: ["value": value], outputTextureDimensions: image.dimensions, outputPixelFormat: .rgba32Float)
+        powKernel.apply(to: [image], parameters: ["value": value], outputDimensions: image.dimensions, outputPixelFormat: .rgba32Float)
     }
     private static let convolutionKernel = MTIRenderPipelineKernel(vertexFunctionDescriptor: .passthroughVertex, fragmentFunctionDescriptor: MTIFunctionDescriptor(name: "imageConvolution", in: .main))
     private static func applyImageConvolution(to image: MTIImage, mask: MTIImage, kernelSize: Int, kernelImage: MTIImage, brightness: Float = 1.0) -> MTIImage {
-        return convolutionKernel.apply(toInputImages: [image, mask, kernelImage], parameters: ["radius": kernelSize/2, "brightness": brightness], outputTextureDimensions: image.dimensions, outputPixelFormat: .rgba32Float)
+        return convolutionKernel.apply(to: [image, mask, kernelImage], parameters: ["radius": kernelSize/2, "brightness": brightness], outputDimensions: image.dimensions, outputPixelFormat: .rgba32Float)
     }
     static func bokeh(image: MTIImage, mask: MTIImage, kernelImage: MTIImage, kernelSize: Int, power: Float, brightness: Float) -> MTIImage {
         let powered = pow(image, power)

--- a/MetalPetalExamples/Shared/Supporting Types/DemoImages.swift
+++ b/MetalPetalExamples/Shared/Supporting Types/DemoImages.swift
@@ -98,14 +98,14 @@ struct DemoImages {
 struct RGUVGradientImage {
     private static let kernel = MTIRenderPipelineKernel(vertexFunctionDescriptor: .passthroughVertex, fragmentFunctionDescriptor: MTIFunctionDescriptor(name: "rgUVGradient", in: Bundle.main))
     static func makeImage(size: CGSize) -> MTIImage {
-        kernel.apply(toInputImages: [], parameters: [:], outputTextureDimensions: MTITextureDimensions(cgSize: size), outputPixelFormat: .unspecified)
+        kernel.makeImage(dimensions: MTITextureDimensions(cgSize: size))
     }
 }
 
 struct RGUVB1GradientImage {
     private static let kernel = MTIRenderPipelineKernel(vertexFunctionDescriptor: .passthroughVertex, fragmentFunctionDescriptor: MTIFunctionDescriptor(name: "rgUVB1Gradient", in: Bundle.main))
     static func makeImage(size: CGSize) -> MTIImage {
-        kernel.apply(toInputImages: [], parameters: [:], outputTextureDimensions: MTITextureDimensions(cgSize: size), outputPixelFormat: .unspecified)
+        kernel.makeImage(dimensions: MTITextureDimensions(cgSize: size))
     }
     static func makeCGImage(size: CGSize) -> CGImage {
         let context = try! MTIContext(device: MTLCreateSystemDefaultDevice()!)
@@ -116,7 +116,7 @@ struct RGUVB1GradientImage {
 struct RadialGradientImage {
     private static let kernel = MTIRenderPipelineKernel(vertexFunctionDescriptor: .passthroughVertex, fragmentFunctionDescriptor: MTIFunctionDescriptor(name: "radialGradient", in: Bundle.main))
     static func makeImage(size: CGSize) -> MTIImage {
-        kernel.apply(toInputImages: [], parameters: [:], outputTextureDimensions: MTITextureDimensions(cgSize: size), outputPixelFormat: .unspecified)
+        kernel.makeImage(dimensions: MTITextureDimensions(cgSize: size))
     }
 }
 

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,462 +7,464 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		00235F0491A9259D4512D48CC0463031 /* MTIBlendFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = DE8E1F388170A671FCF62664F42CCF25 /* MTIBlendFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		006C2144D5BAA26883511F622BB9E79D /* MTIError.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F7FCE08EC324401B150214C649B0C0C /* MTIError.m */; };
-		015710863A6B5BF7E3A3DD1501EFFAD5 /* MTIBulgeDistortionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E49E9EF077B9155BAAAC3B46EF97BB5 /* MTIBulgeDistortionFilter.m */; };
-		0190647FF3989CF9F1C2CDD7D778BAE9 /* MTIRGBToneCurveFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0911B26BFD8E1F38ADA0E35009DC0F7F /* MTIRGBToneCurveFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		01A9404BF6EB829608DCD93C325838AC /* MTIRGBColorSpaceConversionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B1820B839CA4B878B9DA024AE1350DE /* MTIRGBColorSpaceConversionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		01AEEC95D70894F877BAF5C6105EBA42 /* MTIChromaKeyBlendFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DACF8FE6128C086A380E2ABC956120C /* MTIChromaKeyBlendFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		02419DA36EC317F9E2994D564B22319F /* MTIRGBToneCurveFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 75F8C0942B51125AD7896B3A1F810DBB /* MTIRGBToneCurveFilter.m */; };
-		02E1F1D589E91C0A814EE935D8DAE9C5 /* MTIRenderPassOutputDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 43358EE79231F2E49FDDB8F9707CD707 /* MTIRenderPassOutputDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0534E035455A8EA6447B6BC91DAFF13A /* MTICVMetalTextureCache.m in Sources */ = {isa = PBXBuildFile; fileRef = C7905C9FDAA58B78BC083B0E2854C505 /* MTICVMetalTextureCache.m */; };
-		058E45FC1961F60910E986559DE49023 /* MTIHasher.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BDF177600159053D248158B2F1CF945 /* MTIHasher.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		05AD893CE9887703CF011EE1E1D51595 /* MTIMPSConvolutionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = CDC6174B55D968D88043CD874E26FE76 /* MTIMPSConvolutionFilter.m */; };
-		064CBE9EBB8B994BB45D3A39F8C38EFD /* MTILock.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E2FD4A1B19B7040FFE209F3041D729A /* MTILock.m */; };
-		064D621013E15A47E35779EE561F5CCD /* MTIFunctionArgumentsEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B74E8D6ABC0443FEED3026CD1E7B0D8 /* MTIFunctionArgumentsEncoder.m */; };
-		067245457876A1EFC0030E825A478448 /* MTISKSceneRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0BBA4BBFCB7CB5A42A63C64276CD04F3 /* MTISKSceneRenderer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		074EB089446469E2C2F6147950D74251 /* MTICLAHEFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = D6BB01559B627146085BCF1144C2DA26 /* MTICLAHEFilter.m */; };
-		07C3922298947352F06631DF450F1BC6 /* MTIDrawableRendering.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B4FEB15A3332424BCC298AE3FE9BA /* MTIDrawableRendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		001362E589693207CF42E87A39808CC2 /* MTIImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 98A870F833375207F89B2FB480B7D9B4 /* MTIImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		003B64A419DA9E091AC7DC25080FBCF7 /* MTIRenderCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 87CF9D85C1CDA7AB97AE28528E55DAD4 /* MTIRenderCommand.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		014006CFCFDD8D98911D73A314EFFA25 /* MTIPixelFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F7446D805364BCB7BCEFA4F29618902 /* MTIPixelFormat.m */; };
+		019FEA72FDAEF4DA137CA0AB7F882E1F /* MultilayerCompositingFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19BB95D6F52A8B62151B3742655637A0 /* MultilayerCompositingFilter.swift */; };
+		026FBC14CC0957D963925C9429AAAF1F /* MTIUnaryImageRenderingFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B42F783C6EA56E16971626EC3EC1356 /* MTIUnaryImageRenderingFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		03305132F86EBB8DDCA217239DBC267A /* MTIImagePromiseDebug.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E7E883A98F26CDC01465914462E3B45 /* MTIImagePromiseDebug.m */; };
+		0369DB0CC9DB687034464E21027D3177 /* MTIFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 83E81065F318F10E0C0C2A9BBD0812CD /* MTIFilter.m */; };
+		03A604A78E19D95BBE58D3170A0DED4B /* MTICVPixelBufferRendering.m in Sources */ = {isa = PBXBuildFile; fileRef = DB272E5AE4E21F25DB8255891881926F /* MTICVPixelBufferRendering.m */; };
+		041FE793D0C8BC9A30CE9B47B6AE9030 /* MTICropRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77C19153B5BDAEEAECA3BE20650B76F7 /* MTICropRegion.swift */; };
+		04B17D1FD7EB0779AB6372AF208D0486 /* MTIVibranceFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FDC1CD26C35E90E7FBAB6D25EFCA072 /* MTIVibranceFilter.m */; };
+		05D05D673BB26DBB62CE7E7D710B38C5 /* MTIMPSConvolutionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = CDC6174B55D968D88043CD874E26FE76 /* MTIMPSConvolutionFilter.m */; };
+		063F1A6F923D206B18BA799722A4ECD6 /* MetalPetal-Core-Swift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 26B549968261A5B414B775D3424FD0DC /* MetalPetal-Core-Swift-dummy.m */; };
+		06BC8D5C5111208A01C0F85BE05DCA66 /* MTIVector+SIMD.m in Sources */ = {isa = PBXBuildFile; fileRef = C33CAEF97463167982B0D85B4A6F40C0 /* MTIVector+SIMD.m */; };
+		0799F95A8E0DC24A884B7F17FC0F7D7A /* MTICLAHEFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = D6BB01559B627146085BCF1144C2DA26 /* MTICLAHEFilter.m */; };
+		07A619C1778D0121F79B699EF4AA186F /* MTICropFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 39F1000E921A9281C763EDA10723C95D /* MTICropFilter.m */; };
 		07D00F6A1075F181012D4EA04018B364 /* Pods-MetalPetalExamples-MetalPetalExamples (macOS)-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D47A3A6BBB5BC63F774948BED29F508 /* Pods-MetalPetalExamples-MetalPetalExamples (macOS)-dummy.m */; };
-		0AC064CF0CB95E93A87BB770BCA2815C /* MTIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E63002E575273A6B29BAAFD639A807 /* MTIImage.swift */; };
-		0B41B0EC7E50016A72D0106AFF2AC3F8 /* MTIFunctionDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C6A19F5CDB52E0EDA8D1B3220F0E81 /* MTIFunctionDescriptor.m */; };
-		0B92F78362327F440FC48BF542B62545 /* MTIBlendFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = FEBC1D778C54B5F25FF83E52DEB4AB69 /* MTIBlendFilter.m */; };
-		0C0A939767611A000FCC342947524B0D /* MTITextureDimensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158A8EFE6110E8196D7C6469EDC15E63 /* MTITextureDimensions.swift */; };
-		0C39A08D382E5F0FC919E54347EBAB09 /* MTIDrawableRendering.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B4FEB15A3332424BCC298AE3FE9BA /* MTIDrawableRendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0D578AD22DF5005B83AAD38DB021C870 /* MTIMPSUnsharpMaskFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = D9DCB3600E15951DE046C97C55F5BE54 /* MTIMPSUnsharpMaskFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0D7187D1C699890A1EE5FE6BA63DCE88 /* MTILibrarySource.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A5A91B6B2C1086D66D70D0EC1A15246 /* MTILibrarySource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0DFEE533BE7709A5B2BD5D408903C755 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89E166384417C93EEEB709D6E4A9DE1 /* Filter.swift */; };
-		0E94F2157BE15060EF8F133FFEB8FEB5 /* MTIBulgeDistortionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = E4CA643AFD489837BDA5B07F9AEF20D8 /* MTIBulgeDistortionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0EBA5AD4DD5C1739ECDB5A6F786A1F7B /* MTIBlendModes.h in Headers */ = {isa = PBXBuildFile; fileRef = C17A0628178212F76DCE9680877FA412 /* MTIBlendModes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0F32341ABFBA2A611C6781C2A08072AA /* Shaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = F25E83F831680F6F145FF5803FA16038 /* Shaders.metal */; };
-		0F50B431D306F22004B9B1F235B20E28 /* MTITexturePool.h in Headers */ = {isa = PBXBuildFile; fileRef = 78F7F132405D51C8039F8F0F247675DB /* MTITexturePool.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0F6CAA934DD9F39020105D7214F6BEB8 /* MTIColorMatrixFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 64B2FA89E379A1E21599B10A8112AC5D /* MTIColorMatrixFilter.m */; };
-		102018F6FE0B34F3A09B2698A59008E7 /* MTIMPSUnsharpMaskFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CA228D8091B478FDDCEC8727EA8F208 /* MTIMPSUnsharpMaskFilter.m */; };
-		10964BEE67B2E23C32E6F759A37EB317 /* BlendingShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 6523B084669CA8E9CDA5E2EDF1011A04 /* BlendingShaders.metal */; };
-		11BCB443600343EEBFE0852A6C9A1115 /* MetalPetal-AppleSilicon-Core-Swift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EFB44E333AB6E7F988772EB608C1B10 /* MetalPetal-AppleSilicon-Core-Swift-dummy.m */; };
-		11D97F98169CF75F50EE244326EE41A6 /* MTIAlphaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 309CD50F9862DED7227D1567139AA70F /* MTIAlphaType.swift */; };
-		11E75D2FE1FDA360549888B70E276B87 /* MTISCNSceneRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9746B08D8D3984B3A8E04ABC1C79A6EC /* MTISCNSceneRenderer.m */; };
-		11F66110D506FB2ED6A0DB9E7AC0A028 /* MTIImageRenderingContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5FEB9053B35ED8C2EAF431B02BA985E3 /* MTIImageRenderingContext.mm */; };
-		122BEFA0BF053D9CF1E800534C97BE61 /* MTIVector+SIMD.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D8CE33BBFC5E37449CFD2579DAAA426 /* MTIVector+SIMD.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		125FC8D28B6E83A5B5E367B5C5603FDF /* MTIPixelFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F7446D805364BCB7BCEFA4F29618902 /* MTIPixelFormat.m */; };
-		130D583C45D8796EBE76B00E52A7212F /* MTIImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 98A870F833375207F89B2FB480B7D9B4 /* MTIImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		13D160628C5A4B863D0775243971E619 /* MTIRenderPassOutputDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 74B6B717A8E378D75CBA474EFD8C90F3 /* MTIRenderPassOutputDescriptor.m */; };
-		153EE663866DE85B3C3EFF3A096B1947 /* MTIImageRenderingContext.h in Headers */ = {isa = PBXBuildFile; fileRef = A414EC6DE34C402428AE493B9822B9C8 /* MTIImageRenderingContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		155B8DA3CB30DB553D649FA6517A70D0 /* MTIMPSSobelFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = DCAFD03727F6E904E3AEEAAC1CC1BE97 /* MTIMPSSobelFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		159CE0D1FD59ECA6EBFF56353F2B36DD /* MTIRenderGraphOptimization.m in Sources */ = {isa = PBXBuildFile; fileRef = B24021FF880799F5045E921C14BF0CC6 /* MTIRenderGraphOptimization.m */; };
-		16EAE26EC8D347AF57A233F39A56308C /* MTIPrint.h in Headers */ = {isa = PBXBuildFile; fileRef = DDAE8FEA0BDC7BF6466286F2E1FC3B99 /* MTIPrint.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		16ED7C4D298BF1B4D334D919A3D6677F /* MTIError.h in Headers */ = {isa = PBXBuildFile; fileRef = 051D63EB3BDF7FD714F71DC83B48597F /* MTIError.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		173F1FCE6E6E59ADFEEA818285BFF31E /* MTIVector.h in Headers */ = {isa = PBXBuildFile; fileRef = 080D39D554DC6A497F3CB775865C8E8A /* MTIVector.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1779CC837B4F250D79443B3D8B198032 /* MTILibrarySource.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A4F479B562C11E2F3621E63CEB019D3 /* MTILibrarySource.m */; };
-		179DDECC0EB2E0F7C204B35B16E53207 /* MTIGeometryUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = DCA6512368E6D9B20E3784A213050F9F /* MTIGeometryUtilities.m */; };
-		189A43D6FC85FB7294B27B884902A5ED /* MTIImage.m in Sources */ = {isa = PBXBuildFile; fileRef = DEE8949D1E9AB7CB65D47C5DFC0E7B47 /* MTIImage.m */; };
-		1948FA7423818BCA9EDC3729827B5E16 /* MTIVector.m in Sources */ = {isa = PBXBuildFile; fileRef = A0A2ED91C6BEFCCFAF239EE61BD05996 /* MTIVector.m */; };
-		19739045AA3ED655D90577B8DBCEEE30 /* MTIColorLookupFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6255D81F38B30694A9DB957329C7108F /* MTIColorLookupFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1A65FE65FCDE0ADD61E46D6E779DCED8 /* MTICVPixelBufferRendering.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EDC14FDCB24D11544B66C19CFC9601D /* MTICVPixelBufferRendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1AF5316B29366ECF5CA60C62D91E5E2C /* MTIAlphaType.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A2A655423DC9C5706746A359AD4E0CF /* MTIAlphaType.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1B4D322E613865672E3731795B56635A /* MTICVPixelBufferPool.m in Sources */ = {isa = PBXBuildFile; fileRef = A1425DC453E2AB8FC117D4C8E1B3F5B2 /* MTICVPixelBufferPool.m */; };
-		1BD63595B54D57B8B569D38FBADEE083 /* MTIMPSKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BB4C749C706E442C8638B3D5C60A200 /* MTIMPSKernel.m */; };
-		1D65BF7C4ACAC6C966EC864D4CADA09C /* MTIPixellateFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 24A7D70F51687F71F429BB6A04EF89BA /* MTIPixellateFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1DC7B047407B3CD9D678B43D22DAD310 /* MTILayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BA3FB75D4EDB0260464604294862462 /* MTILayer.m */; };
-		1E87143D632E6ED44E33A51FF5119EFE /* MTIMultilayerCompositingFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 73170EF91BB7AC39B8E7F1C4DB9B266F /* MTIMultilayerCompositingFilter.m */; };
-		1FD1656C7673AD4D078E2F5E8146505D /* MTIUnaryImageRenderingFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 37F59A9ECCBB13D1DA569B26EC63E5D4 /* MTIUnaryImageRenderingFilter.m */; };
-		20E86D9B075E0A9D84AF4BA891FC5BA5 /* MTIVertex.m in Sources */ = {isa = PBXBuildFile; fileRef = F2CC0881E4DEACE9488067D24EC8211C /* MTIVertex.m */; };
-		216BF36CCABD68DF6ED62EC205526AA0 /* MTITextureDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FA804CE45886D4C18673E137C1AF913 /* MTITextureDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		21BC465115AEEE25563B970628136C6A /* MTISamplerDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 840B7117FC626722A3F57ECB3DF7D3EF /* MTISamplerDescriptor.m */; };
-		21C632305A0211E88823333D9ACF0A58 /* MTIMemoryWarningObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C9B4C7F349CB63D814E673B0385E152 /* MTIMemoryWarningObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2267FB9F7A1B79D732803253D1F020C1 /* LensBlur.metal in Sources */ = {isa = PBXBuildFile; fileRef = 0C1080D7E7CFD3D7141B80C5FDDCCBD1 /* LensBlur.metal */; };
-		22BD36FB9F82D896D0C9F04384C140D2 /* MTIGeometry.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F14CB019480676EAFA71875A8646E37 /* MTIGeometry.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2553A3190093084041E60F34CEE61343 /* MTICorner.h in Headers */ = {isa = PBXBuildFile; fileRef = A89557483FFF8499123C3673D7734812 /* MTICorner.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		259D5E73986871205C97D2FB06166A65 /* MTIComputePipelineKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 636D0E86122B800AC26534C969A4B20C /* MTIComputePipelineKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		26AE971F328604F57179C3DCB459B7DC /* MTITextureDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = F717F5873FADD7511C4883FB7FE39261 /* MTITextureDescriptor.m */; };
-		2710A66105F1B6F40437D928E59AD897 /* MTIRenderGraphOptimization.m in Sources */ = {isa = PBXBuildFile; fileRef = B24021FF880799F5045E921C14BF0CC6 /* MTIRenderGraphOptimization.m */; };
-		27C3A188EB3D223366FC737DF884D4B5 /* MTIWeakToStrongObjectsMapTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 77AB69D212A357773556E7A6D43B49F0 /* MTIWeakToStrongObjectsMapTable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2835BDB54C161BA078F3F1E9609BCFC8 /* MTICVMetalIOSurfaceBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 59DB6169E28AC4E89FD4E28C17D075A1 /* MTICVMetalIOSurfaceBridge.m */; };
-		2884C75DF7774C040518A354329AE71F /* MTIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E63002E575273A6B29BAAFD639A807 /* MTIImage.swift */; };
-		288EEE25DB081E4B815A0D0A24F2F12C /* MTITextureLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C7B79C1EF70120069525973A373B5B0 /* MTITextureLoader.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		28A29688291A102408C75B1A527F41FD /* MTISCNSceneRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = D4594ED8316E9485C8D047368DF9F011 /* MTISCNSceneRenderer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		07FFCFA9266BB74C237466B1925FC75E /* MTIBlendWithMaskFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 10E2160AEA61ADA3331B92DDF59AE34A /* MTIBlendWithMaskFilter.m */; };
+		0922437ED2C409ADC150F2130F827473 /* MTIHighPassSkinSmoothingFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 10D221A98BB3A4F75B78622BF5C6AD31 /* MTIHighPassSkinSmoothingFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0968F5C611F48AF648768E38C70736AB /* MTIMemoryWarningObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 07AD86FA01273A5DF7B6F27A8378DEE9 /* MTIMemoryWarningObserver.m */; };
+		09CF02C00484BC81DF5C3B06CB4CDD38 /* MTITextureDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FA804CE45886D4C18673E137C1AF913 /* MTITextureDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0A36CAC0445EE1EBC783A1010A1F00FA /* MTIContext+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ED6E8A8BF705A94647F4A0253AC81DB /* MTIContext+Internal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0B99ABB700B1A2C1E4927F77CEB0C056 /* MTIComputePipelineKernel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F42FFF4671ABF7D97023F18B62349C2 /* MTIComputePipelineKernel.swift */; };
+		0C94FE1E604101D2B01164ECF6D48FFE /* MTIUnaryImageRenderingFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 37F59A9ECCBB13D1DA569B26EC63E5D4 /* MTIUnaryImageRenderingFilter.m */; };
+		0D1BB1456AB76A8D5519350779C9B5E2 /* MTIVector.h in Headers */ = {isa = PBXBuildFile; fileRef = 080D39D554DC6A497F3CB775865C8E8A /* MTIVector.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0D4BD6C4DF7B4CF3AC0437E12A7814F8 /* MTIBlendModes.m in Sources */ = {isa = PBXBuildFile; fileRef = AD7A7B5562D417F4DBED87CE99A5636A /* MTIBlendModes.m */; };
+		0D98D2D0849CD47D89D4CE118B390D7E /* MTIThreadSafeImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 4524341A2AE33300382F4F452296942C /* MTIThreadSafeImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0D9A36D7192C0E036999E9C22AE35C7D /* MTIColor.h in Headers */ = {isa = PBXBuildFile; fileRef = 1007E23586C26A5AC21D8EE48B9DD4E2 /* MTIColor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0DBDED79254435922C67C4469B392BF9 /* MTILibrarySource.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A4F479B562C11E2F3621E63CEB019D3 /* MTILibrarySource.m */; };
+		0E57568947636C90EC298AF9C10478EE /* MTITextureLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 5382AA7FFB422306848695FF7CD61737 /* MTITextureLoader.m */; };
+		0EA69462B28F12D66728C72FADBFC317 /* MTILock.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E2FD4A1B19B7040FFE209F3041D729A /* MTILock.m */; };
+		0EFB04322B15DAE03B9921170BE7539F /* MTIColor.h in Headers */ = {isa = PBXBuildFile; fileRef = 1007E23586C26A5AC21D8EE48B9DD4E2 /* MTIColor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		10B6C2018B13F1F150781552E1BB91AE /* MTIRenderGraphOptimization.h in Headers */ = {isa = PBXBuildFile; fileRef = D24DDF832828EE4F31C7C3EDC8501387 /* MTIRenderGraphOptimization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		10F4ABC5C5B969B92C6D5241F5A51021 /* MTIVector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7943BF975882151B9BD025A7A616607 /* MTIVector.swift */; };
+		1155599DF3114E47D2BBC095AB696734 /* MTIColor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BC89A2032F2F966D1A77702264B23EA /* MTIColor.m */; };
+		118FA4A4D35F7A141EDD57788BBC195F /* MTIColor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BC89A2032F2F966D1A77702264B23EA /* MTIColor.m */; };
+		1322F21B578EC30CD87A87E8BC72173E /* MTIMPSSobelFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = DCAFD03727F6E904E3AEEAAC1CC1BE97 /* MTIMPSSobelFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		133D19E0496AC5BEEFF94A2D71BE684A /* MTILock.h in Headers */ = {isa = PBXBuildFile; fileRef = DE4504BC5F4A6A410885244736A7FAE4 /* MTILock.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1476BB1C60E4F071865750854430D982 /* MTIMultilayerCompositeKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9BAFF05C5720FC8E639F84631D8A92 /* MTIMultilayerCompositeKernel.m */; };
+		14EA54D62411CEDD28176E6AD04776CA /* MetalPetal.h in Headers */ = {isa = PBXBuildFile; fileRef = 668F9CB3802E4923A02CBE9E39CE5697 /* MetalPetal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		15F9BA9BDE2370D1558E39F411B01481 /* MTIMPSHistogramFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 24687AF624C1F2D905A5319C44B27222 /* MTIMPSHistogramFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		161E572D54EF23A8B1CC314ACCA79E44 /* MTIFunctionDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EAC8394FB0E80CCE2A97F4AB4B56113 /* MTIFunctionDescriptor.swift */; };
+		16DE1A54C75B724849D7E8A4B5185CEB /* CLAHE.metal in Sources */ = {isa = PBXBuildFile; fileRef = D923AAD0CB084596522F9F1B4789B175 /* CLAHE.metal */; };
+		16EB001C607C9651255A47F663E04889 /* MTIMPSKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = B16EBC2392F758D3E1790251BD64BC71 /* MTIMPSKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		189331A12A1F294A4EE7F87798C2AE06 /* MTIBlendWithMaskFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 715856E3A7AC731446F51596360D7131 /* MTIBlendWithMaskFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		18A55001E60BF594529E4559C157510C /* MTICropRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77C19153B5BDAEEAECA3BE20650B76F7 /* MTICropRegion.swift */; };
+		19DA514A66BA91BCD92E4D9DB9E5B6DC /* MTIComputePipelineKernel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F42FFF4671ABF7D97023F18B62349C2 /* MTIComputePipelineKernel.swift */; };
+		19E9675F764F36ADD522206CFCEE2926 /* MTIColorMatrix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D2796D5C6FDC685BEFA6996CC75C4B /* MTIColorMatrix.swift */; };
+		1A53C6E28652DAA9775AFA37CA77EA19 /* MTICVPixelBufferPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = A0851268EA397439AA5B729FB3DC633F /* MTICVPixelBufferPromise.m */; };
+		1AD2250FCB18FACC4F430D9E33180F5C /* MTICorner.h in Headers */ = {isa = PBXBuildFile; fileRef = A89557483FFF8499123C3673D7734812 /* MTICorner.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BC25998ECFDAC38CDC45F0E20996476 /* MTIVector+SIMD.m in Sources */ = {isa = PBXBuildFile; fileRef = C33CAEF97463167982B0D85B4A6F40C0 /* MTIVector+SIMD.m */; };
+		1CC7BBCDD47A9245566798BA843EBF1D /* MTIPixellateFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 24A7D70F51687F71F429BB6A04EF89BA /* MTIPixellateFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1CE253FE94CDD4233F7BFFB13277C5C6 /* MTIBlendModes.h in Headers */ = {isa = PBXBuildFile; fileRef = C17A0628178212F76DCE9680877FA412 /* MTIBlendModes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D4F410643339F5CBBC6DAFB865ADF7A /* MTIVibranceFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = C5D59DAF4CB77D4E67FB427915F52D4A /* MTIVibranceFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1E7A7D0CC793F3889542B8B9C81A9D1E /* MTIDotScreenFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = ADDCA587F2C14BD86B32D7A835B19518 /* MTIDotScreenFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1E8E88C16D52E202DD5C921E0BF9B88F /* MTITextureDimensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 794AD47DC7253C8C95184268C61F021D /* MTITextureDimensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F8420B1C4516C9DEE224D8FDD1877D9 /* MetalPetal.h in Headers */ = {isa = PBXBuildFile; fileRef = 668F9CB3802E4923A02CBE9E39CE5697 /* MetalPetal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2061A892EA38A2E047BCC5CC96E55084 /* MTISKSceneRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0BBA4BBFCB7CB5A42A63C64276CD04F3 /* MTISKSceneRenderer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		20C757107CEB0E667E30E93343E89D61 /* MTISKSceneRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 2143036CABE393784D025D87644A92CB /* MTISKSceneRenderer.m */; };
+		22D638F1118FDC05D8A3D52530740291 /* MTICLAHEFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F5D6306B41724303B8CD05276822338 /* MTICLAHEFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2344975842F430D8464688366E68DB8A /* MTIRenderPipeline.h in Headers */ = {isa = PBXBuildFile; fileRef = 51A388571970F41F8AF173376B80987D /* MTIRenderPipeline.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		23E1ADB154ABEAFAEA426E1A0D6124F3 /* MTIFunctionDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = B365A4039426EBFD0913D8C930F7BC1B /* MTIFunctionDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		245763C99C0CF86A8EBC71AE05FE713F /* MTIImageOrientation.m in Sources */ = {isa = PBXBuildFile; fileRef = 2482C3A8BFCD7A98D3CE458A5031A11C /* MTIImageOrientation.m */; };
+		245FE5FA7D7DD7B639080073BC18DA83 /* BlendingShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 6523B084669CA8E9CDA5E2EDF1011A04 /* BlendingShaders.metal */; };
+		248985CBCC0B8D3355F322DA7BCE0CC8 /* MTIChromaKeyBlendFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 629081B3EE1DF76DB7BFBD81E70EF266 /* MTIChromaKeyBlendFilter.m */; };
+		251445AECEF1EA98684F626949808502 /* MTIBlendFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = DE8E1F388170A671FCF62664F42CCF25 /* MTIBlendFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25EF820E5001C851B0DEB57FD633146D /* MTIImage.m in Sources */ = {isa = PBXBuildFile; fileRef = DEE8949D1E9AB7CB65D47C5DFC0E7B47 /* MTIImage.m */; };
+		261A1F8C38BB1E71529AEC471A61DC75 /* MTIMPSKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = B16EBC2392F758D3E1790251BD64BC71 /* MTIMPSKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2649EC58DC80DFF70B4FADA70FE1240B /* MTIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B14DABA285F792CC3CFDDC37979BC71 /* MTIImage.swift */; };
+		265C602D6A5078FB18A166EFBC44B6F6 /* MTITransformFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F35D202C320154242070FF675337283 /* MTITransformFilter.m */; };
+		26814C5EFFE7BAF4CA261CA925EC73A7 /* MTIRGBColorSpaceConversionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B1820B839CA4B878B9DA024AE1350DE /* MTIRGBColorSpaceConversionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		26E62FB3A9327FB43DD3894CA2FB9B3B /* MTICLAHEFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = D6BB01559B627146085BCF1144C2DA26 /* MTICLAHEFilter.m */; };
+		27E276CE7E4B60C9D2CA022D606E8889 /* MTIGeometryUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = C9517BE2D20FDC257C0E979C3D005ABD /* MTIGeometryUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		284FA298476286A17D2DA68322971332 /* MTIRenderGraphOptimization.h in Headers */ = {isa = PBXBuildFile; fileRef = D24DDF832828EE4F31C7C3EDC8501387 /* MTIRenderGraphOptimization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2858B78549AFB39CC543180D1A3B75F4 /* MTIDefer.h in Headers */ = {isa = PBXBuildFile; fileRef = F3127DA534F8DF0893392C62B3969338 /* MTIDefer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		28C621B479F804857E11AA77B8EB1D61 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D96B6F02A66345DED9C856D1BD504B40 /* Foundation.framework */; };
-		29D6C4953E04FD4BC82BF6595321BA3F /* MTIColorMatrix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552422256A92E5B0BD669E908CE3895A /* MTIColorMatrix.swift */; };
-		2A1C57E38632E67D5694C4BA04F72A07 /* MTIMPSBoxBlurFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 81F9877F1AED144A6E2A911FF7013E1F /* MTIMPSBoxBlurFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2ADA939A3839B6C97C5C9CDA0EA4889C /* MTISKSceneRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 2143036CABE393784D025D87644A92CB /* MTISKSceneRenderer.m */; };
-		2B52D17A1D9E5ECB1099D8E63E65D002 /* MTIMPSConvolutionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 07A8FE33257602CA9AF1A0401B917E72 /* MTIMPSConvolutionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2B64207A54CB0958341FA531F4968F8D /* MTIThreadSafeImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 994294A7C1F35F53E1FECEC65BB8E8C3 /* MTIThreadSafeImageView.m */; };
-		2B655844FC2B11D0257FDF6B69C8C411 /* MTIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276AB8C54378AD1A6E1305BBF8866223 /* MTIError.swift */; };
-		2C034A8EAE9426828151A9043971FF95 /* MTIRenderCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 87CF9D85C1CDA7AB97AE28528E55DAD4 /* MTIRenderCommand.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2CC3F9E6FC9D667772ED151EC3407445 /* MTIRGBToneCurveFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 75F8C0942B51125AD7896B3A1F810DBB /* MTIRGBToneCurveFilter.m */; };
-		2CD6C8FB6F10D47D6F03865EDF46286D /* MTIImageOrientation.h in Headers */ = {isa = PBXBuildFile; fileRef = 37246B9D8C729D40CDA3AB0967DD05D6 /* MTIImageOrientation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		30EADE84841C2FB99365DDDF8EE0206E /* MTIMPSBoxBlurFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 81F9877F1AED144A6E2A911FF7013E1F /* MTIMPSBoxBlurFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		320CF4E92E751D32ED4ED998A8A5C313 /* MTIMPSDefinitionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = BEAFE3992F336768B1CEEBB0A76790B4 /* MTIMPSDefinitionFilter.m */; };
-		321FE7551030F8DA4F55F3FC68DB365C /* MTIAlphaType.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A2A655423DC9C5706746A359AD4E0CF /* MTIAlphaType.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3224ECCA420E4C101496CE2097023135 /* MTIPixelFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDC220791823F8B8EDCC75DEEFE5AE2 /* MTIPixelFormat.swift */; };
-		331C7B01BE2023F50C54BB0DD652C319 /* MTIImageRenderingContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5FEB9053B35ED8C2EAF431B02BA985E3 /* MTIImageRenderingContext.mm */; };
-		333EE6D72940A5EAB203DDA0BE25CB2F /* MTISamplerDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A140A5542FB46FDEC00FF8D7BC0929E /* MTISamplerDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		336AEA2AC2DC753940F831D7EF979873 /* MTIImageRenderingContext.h in Headers */ = {isa = PBXBuildFile; fileRef = A414EC6DE34C402428AE493B9822B9C8 /* MTIImageRenderingContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		342EDE24E2BE32D7B7C8F1A2C71A900D /* MTIAlphaPremultiplicationFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 22EFDD084C13F0A0946FC47579BEA725 /* MTIAlphaPremultiplicationFilter.m */; };
-		35245C218B84572B71704764EE4F6C16 /* MTIColorHalftoneFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B8619AA152D6BA49379AF7C071D3764 /* MTIColorHalftoneFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		35B442C2FAEC027B79034BC2EA639DB3 /* MTIPixelFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 42FDD1B7319AB7FB6CD09EF5EA835EFD /* MTIPixelFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		35EEB23D8BE6BB1821F9578D2D495A7A /* MTILayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BA3FB75D4EDB0260464604294862462 /* MTILayer.m */; };
-		368C2A24B2BDAC44F6434B7BD4F12412 /* MTIMask.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F7A4CF15A9842965A2F34D52E517483 /* MTIMask.m */; };
-		36A57667E8B1324E6B73E74A7621C8B3 /* MTIImageRenderingContext+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 6721C9D18C1B9F4B79F48A614D6073B3 /* MTIImageRenderingContext+Internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		3753DD6BF4B567A9848D18C862C2EABF /* MTITextureDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = F717F5873FADD7511C4883FB7FE39261 /* MTITextureDescriptor.m */; };
-		37CD99098AFC9672B7289F7463D00CDE /* MTIRGBColorSpaceConversionFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC32955D75E51A051F78B9406DD9746 /* MTIRGBColorSpaceConversionFilter.swift */; };
-		37D2BEB5C25F4451696B0E3527FC3C8E /* MTIColorMatrix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552422256A92E5B0BD669E908CE3895A /* MTIColorMatrix.swift */; };
-		38230EB4E35D71E0B7C923D4649D5E0A /* MTIAlphaType.m in Sources */ = {isa = PBXBuildFile; fileRef = C34ED5A0B8F0040BCA7FF07F063F4AA6 /* MTIAlphaType.m */; };
-		3867631C1634FAE24EEE6F5C3BEE5340 /* MTIVector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0243A423BEFA91D847C05973AF6C95 /* MTIVector.swift */; };
-		3987ACA16772306AFA479B5771641068 /* MTIImagePromiseDebug.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E7E883A98F26CDC01465914462E3B45 /* MTIImagePromiseDebug.m */; };
-		398DA92AAD713C594A433ED23F72A904 /* MTIRenderPipelineKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = 440BA8D18A570D93B7ECDDA1AD4DDFFE /* MTIRenderPipelineKernel.m */; };
-		3A1434CAE3289CD23BB0844C38412228 /* MTIFunctionDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = B365A4039426EBFD0913D8C930F7BC1B /* MTIFunctionDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3BABA99F6FE83B9C2731C75D9AF86396 /* MTIBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AA4B41672F25730E0F1CBA46DD85880 /* MTIBuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3CBF9762DAAEFD882E8DCFEF77A0AFBE /* MTIUnaryImageRenderingFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B42F783C6EA56E16971626EC3EC1356 /* MTIUnaryImageRenderingFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3D0361DD2645DB3F321FD7663C16D5D6 /* Halftone.metal in Sources */ = {isa = PBXBuildFile; fileRef = 28368807F05E87E2C5E561378AC64D64 /* Halftone.metal */; };
-		3E1A72F2CC20C7E913AF1294CA0B4195 /* MTIMPSConvolutionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = CDC6174B55D968D88043CD874E26FE76 /* MTIMPSConvolutionFilter.m */; };
-		3EFED067898AC6B94F776D4F135EB623 /* MTITransformFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 122D351C6553FCA95C13D8901DDBFE9C /* MTITransformFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3F5ADCFFE30F94A6DC8286B0E4DC5F9C /* MTIBulgeDistortionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = E4CA643AFD489837BDA5B07F9AEF20D8 /* MTIBulgeDistortionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		40463437E0FA47121CCFF4A2A9E66390 /* MTICVPixelBufferPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = A0851268EA397439AA5B729FB3DC633F /* MTICVPixelBufferPromise.m */; };
-		415A281074BAB281FE46BE97939EFF83 /* MTICropFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 39F1000E921A9281C763EDA10723C95D /* MTICropFilter.m */; };
-		4198A11BAF4CDF95EEBBC168D2AD6643 /* MTIImageOrientation.m in Sources */ = {isa = PBXBuildFile; fileRef = 2482C3A8BFCD7A98D3CE458A5031A11C /* MTIImageOrientation.m */; };
-		41E1AAF1BA9D9E64F8738DA5119F615C /* Halftone.metal in Sources */ = {isa = PBXBuildFile; fileRef = 28368807F05E87E2C5E561378AC64D64 /* Halftone.metal */; };
-		42033C3DF83595C9D6014BBB04D94BE2 /* MTICropRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3F1D22604D4CE74FD6D91A6A00126F /* MTICropRegion.swift */; };
-		42C9D2B27632B7AD8A88DD41C2A20EE6 /* MTIMPSDefinitionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = BEAFE3992F336768B1CEEBB0A76790B4 /* MTIMPSDefinitionFilter.m */; };
-		43871131954C0206C614FD97623D183B /* MTIBlendWithMaskFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 10E2160AEA61ADA3331B92DDF59AE34A /* MTIBlendWithMaskFilter.m */; };
-		454425F8DDF617C11A3AEF04B6C94BAB /* MTIChromaKeyBlendFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 629081B3EE1DF76DB7BFBD81E70EF266 /* MTIChromaKeyBlendFilter.m */; };
-		4584CF4DA4DEE9E41C453638155F96D7 /* MTIThreadSafeImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 4524341A2AE33300382F4F452296942C /* MTIThreadSafeImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4634E84E2983621AB44C3CB428E84935 /* MTIVertex.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F4F8A8596485C0273B699F1E2BF14C3 /* MTIVertex.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		467DA02A9B44F7A9B16FC2A2494094BC /* MTIRenderPipeline.h in Headers */ = {isa = PBXBuildFile; fileRef = 51A388571970F41F8AF173376B80987D /* MTIRenderPipeline.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4699E6C436AEE62AF2E0D7473ABF0613 /* MTIMPSHistogramFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = B334145EDBF0EAC80F861216049C7A07 /* MTIMPSHistogramFilter.m */; };
-		469B31B6032959FA3F7BB836E3F95EB3 /* MTIColorHalftoneFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B8619AA152D6BA49379AF7C071D3764 /* MTIColorHalftoneFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		46AE830885D7C4520ED11B4418AFE3C0 /* MTITexturePool.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7ABCB697CFDD9B0CA7CBE2DEB6EECC99 /* MTITexturePool.mm */; };
-		475F26BF11553F5CB9C8D0D93CA5DDA8 /* MTICoreImageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1A4E83423BA248CF37F5CA880CFC73 /* MTICoreImageExtension.swift */; };
-		47A3C30D260E06CF2FF0B806899AE21A /* MTIError.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F7FCE08EC324401B150214C649B0C0C /* MTIError.m */; };
-		47DF07B897952BFED77C18A2412693BB /* MTICVMetalIOSurfaceBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D06881FE11756F8FCEE425B28617CAB /* MTICVMetalIOSurfaceBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		48567A3B459C02145D42E6B18E910DF4 /* MTIImagePromise.m in Sources */ = {isa = PBXBuildFile; fileRef = E6ADA49B609B3FAFADA6A2D39E688717 /* MTIImagePromise.m */; };
-		48985AB97BAB8E9FB41D133CAB8D30C7 /* MTIGeometry.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F14CB019480676EAFA71875A8646E37 /* MTIGeometry.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		48A95C67B1DA4A98DA0E53027614997C /* MTIColorHalftoneFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 46979D946C597284368024105C6667E2 /* MTIColorHalftoneFilter.m */; };
-		499651A8E2A9465075F1378B2195AB75 /* MTICorner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE571E8CB85DCF6F357CD8DAA3AE487 /* MTICorner.swift */; };
-		49EC910DC164112886D58B0547290F63 /* MTITexturePool.h in Headers */ = {isa = PBXBuildFile; fileRef = 78F7F132405D51C8039F8F0F247675DB /* MTITexturePool.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4A19FA56D86AD2B4CCD4737B7CE75C30 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89E166384417C93EEEB709D6E4A9DE1 /* Filter.swift */; };
-		4A24FEAF10E281525CEEEE31817AA91A /* MTIPixellateFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 992934579D2CE8D49CDF3DB722D326EE /* MTIPixellateFilter.m */; };
-		4A69B59CCCF6C310B96CD15C3FF4F8CB /* MTIMemoryWarningObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 07AD86FA01273A5DF7B6F27A8378DEE9 /* MTIMemoryWarningObserver.m */; };
-		4A6C1B7BDA6ECDFD2CF80A96279B0AF8 /* MTIDrawableRendering.m in Sources */ = {isa = PBXBuildFile; fileRef = A6C55D2839E2E9BDCBC98E9FDBECDE3F /* MTIDrawableRendering.m */; };
-		4C102891C499D765EEB0BF18CEBB4864 /* MTICVPixelBufferPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = EC826C41089341DF8216FEEABA77CEF1 /* MTICVPixelBufferPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4DC0E85B28F6A92B7A43863E8E4B3DF2 /* MTIRoundCornerFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = CD942E3C1820E839A9B4B01AFB277259 /* MTIRoundCornerFilter.m */; };
-		4EAAF7D56633A2FA01DC8AF8B3A3CF8F /* MTIMPSKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BB4C749C706E442C8638B3D5C60A200 /* MTIMPSKernel.m */; };
-		4F99AC101C7FC2444B557BE52FC9C187 /* MTIRGBColorSpaceConversionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B1820B839CA4B878B9DA024AE1350DE /* MTIRGBColorSpaceConversionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5056959258D5D43AEB6D2D069AF50E5B /* MTISCNSceneRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9746B08D8D3984B3A8E04ABC1C79A6EC /* MTISCNSceneRenderer.m */; };
-		50642D0BC3CCD36A27675F847C01EFFA /* MTIUnaryImageRenderingFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 37F59A9ECCBB13D1DA569B26EC63E5D4 /* MTIUnaryImageRenderingFilter.m */; };
-		5078A57645E04D88FD0AA5AC9EBA305B /* MTIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 280BBD2FFA2096DEB29F65AA3A746F97 /* MTIColor.swift */; };
-		507A62AF045B7CFA3B4135BEBAC18A6D /* MTIWeakToStrongObjectsMapTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 77AB69D212A357773556E7A6D43B49F0 /* MTIWeakToStrongObjectsMapTable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5101829E6F5E4DCDAF299CB4048D6B5B /* MTIImagePromise.m in Sources */ = {isa = PBXBuildFile; fileRef = E6ADA49B609B3FAFADA6A2D39E688717 /* MTIImagePromise.m */; };
-		512FC088C712346837D7749838950EE9 /* MTIDataBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 556074EB4DCE458E9FFDA0303F008462 /* MTIDataBuffer.swift */; };
-		5156A16D10AAE8BA3D835F220079AF84 /* MTITransformFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F35D202C320154242070FF675337283 /* MTITransformFilter.m */; };
-		5190745568E814356FFFEBE75A83CD2D /* MTIMPSHistogramFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 24687AF624C1F2D905A5319C44B27222 /* MTIMPSHistogramFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		52A6DA45AA8ACF95731D7F937017DE5B /* MTIRenderGraphOptimization.h in Headers */ = {isa = PBXBuildFile; fileRef = D24DDF832828EE4F31C7C3EDC8501387 /* MTIRenderGraphOptimization.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		53FD27529F5A2D539711FF11F6E4DBF2 /* MTICoreImageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1A4E83423BA248CF37F5CA880CFC73 /* MTICoreImageExtension.swift */; };
-		54121B89BE1470C25A47765D2D4AF933 /* CLAHE.metal in Sources */ = {isa = PBXBuildFile; fileRef = D923AAD0CB084596522F9F1B4789B175 /* CLAHE.metal */; };
-		5435874B16422A94A7610712CA0D6D0E /* MTIRenderPipeline.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E324DCB3CD1BE72BB6EE47DFDBA470 /* MTIRenderPipeline.m */; };
-		5568EDE85B6BE0A193AB1F88C5B4B9D4 /* MTIMPSHistogramFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = B334145EDBF0EAC80F861216049C7A07 /* MTIMPSHistogramFilter.m */; };
-		576633A3DB59A02E86CCF716EA671054 /* MTIHighPassSkinSmoothingFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 10D221A98BB3A4F75B78622BF5C6AD31 /* MTIHighPassSkinSmoothingFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		582243E1725B2AA81CF832FDA7DCDB5D /* MTIHasher.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BDF177600159053D248158B2F1CF945 /* MTIHasher.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5852A7C9051F13D03651D2A9D5C2A183 /* MTIBlendModes.m in Sources */ = {isa = PBXBuildFile; fileRef = AD7A7B5562D417F4DBED87CE99A5636A /* MTIBlendModes.m */; };
-		593AB10A059003F0A0D8FD5BDD8CE325 /* MTIUnaryImageRenderingFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B42F783C6EA56E16971626EC3EC1356 /* MTIUnaryImageRenderingFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		59E82117CD951017897E9A6F7AF96466 /* MTIShaderFunctionConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C04E14334C83E8E5F89CB3DA2D0346 /* MTIShaderFunctionConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5A0EC99D78A3D501AB62370246E5CC03 /* MTICoreImageRendering.h in Headers */ = {isa = PBXBuildFile; fileRef = 87D681EED87BC4A7557906E1F8707BA6 /* MTICoreImageRendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5AB1031301EFAF70FDA74D8A65826305 /* MTILock.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E2FD4A1B19B7040FFE209F3041D729A /* MTILock.m */; };
-		5B082992674DF3431999F3DE312BBF9E /* MTIAlphaType.m in Sources */ = {isa = PBXBuildFile; fileRef = C34ED5A0B8F0040BCA7FF07F063F4AA6 /* MTIAlphaType.m */; };
-		5E1CF22E49BF171ABA368CA2F010E01D /* MTIContext.m in Sources */ = {isa = PBXBuildFile; fileRef = BB25E2412ACAF0CD6ADE8C60161DC127 /* MTIContext.m */; };
-		5F3511FAC419BB2093D6980CF75405F5 /* MTITransformFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F35D202C320154242070FF675337283 /* MTITransformFilter.m */; };
-		60A40C54F8FD2581C201CA36A09CE175 /* MTIColor.h in Headers */ = {isa = PBXBuildFile; fileRef = 1007E23586C26A5AC21D8EE48B9DD4E2 /* MTIColor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		60B72AA53E8832E275DF28A7C978E84A /* MTIAlphaPremultiplicationFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 19530138A14BA035658FDA26478FA30C /* MTIAlphaPremultiplicationFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		612B8BF91EECAD9FB61272510C3986E3 /* MTIKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 213784EC8936904929EA1A3380E503CB /* MTIKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		625E0C00F2AC62084323EBDD933F89A4 /* MTIImage.h in Headers */ = {isa = PBXBuildFile; fileRef = BFE0E806B256BB3A9700DB5FD424B6A9 /* MTIImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		638318991CF13F5F123C35B05F62EB32 /* MTIRenderPipelineKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = 440BA8D18A570D93B7ECDDA1AD4DDFFE /* MTIRenderPipelineKernel.m */; };
-		647F4331B40BAC5B1061A99FF549B75F /* MetalPetal.swift in Sources */ = {isa = PBXBuildFile; fileRef = F575DD21FD663D8B548ED1F872590F12 /* MetalPetal.swift */; };
-		64E50A879993E3E698EC3C3FB9946B28 /* MTIBlendFormulaSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = B49289A3A6CD192DB7537DE4D733EB0F /* MTIBlendFormulaSupport.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		6557BD226D6C45867932A8854927EDCB /* MultilayerCompositingFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 180993A2787EFF3A8DBAA3D002CC937C /* MultilayerCompositingFilter.swift */; };
-		659C58572C899D571AFC2967461079C2 /* MTIBlendModes.m in Sources */ = {isa = PBXBuildFile; fileRef = AD7A7B5562D417F4DBED87CE99A5636A /* MTIBlendModes.m */; };
-		66148B7E5F1AC04045DB055876411EB9 /* MTIVertex.m in Sources */ = {isa = PBXBuildFile; fileRef = F2CC0881E4DEACE9488067D24EC8211C /* MTIVertex.m */; };
-		665450C77CC799B2D3156DBB4BBC1AE6 /* MTIMPSDefinitionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 95749359434BE4A174EA5690D86A960B /* MTIMPSDefinitionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66C0F39A6EBC8BACE13A6104F961ECDC /* MTICVPixelBufferPool.h in Headers */ = {isa = PBXBuildFile; fileRef = B3453C3DF38A3143DE7CABCE3235B93E /* MTICVPixelBufferPool.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66F3E571043AF76E01EFF74EBE9668E8 /* MTIDefer.m in Sources */ = {isa = PBXBuildFile; fileRef = 89933E584BCEDC968272B351AC127B46 /* MTIDefer.m */; };
-		6728C3B58C0CB6311E997E91EA8E5C2B /* MTIRenderTask.m in Sources */ = {isa = PBXBuildFile; fileRef = A76A116553C936D5987440E70163392C /* MTIRenderTask.m */; };
-		6728FD117837B15975E55B40BAF73B13 /* MTISamplerDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 840B7117FC626722A3F57ECB3DF7D3EF /* MTISamplerDescriptor.m */; };
-		67A5D60A676BDE3DA0EA6D06B9C2FF2C /* MTICVPixelBufferPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = A0851268EA397439AA5B729FB3DC633F /* MTICVPixelBufferPromise.m */; };
-		686249B00AED228CBBF3A38C593DB45D /* MTIWeakToStrongObjectsMapTable.m in Sources */ = {isa = PBXBuildFile; fileRef = 34C98F4575D79C98DB8181EAB01C2291 /* MTIWeakToStrongObjectsMapTable.m */; };
-		68B586497951C0460308F4675C116B41 /* MTILayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EE1C40E9FA9CD4E24E8A3A05645EC86 /* MTILayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		69104B8C914B8B7CB5FDE03FEDB6C490 /* MTIFunctionDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = B365A4039426EBFD0913D8C930F7BC1B /* MTIFunctionDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		69A68C401C6F02568AB6A7A1F7094E3C /* MTICVMetalTextureBridging.h in Headers */ = {isa = PBXBuildFile; fileRef = A57C7A26933829A8FF6546DB7B9E5E05 /* MTICVMetalTextureBridging.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6A279C3035413444801E01993974A5AC /* MTIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 280BBD2FFA2096DEB29F65AA3A746F97 /* MTIColor.swift */; };
-		6BC177AB439C12E7110E5E7E6445D1B4 /* MTIMPSGaussianBlurFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8DE0D3B0E0C70FD0B6DE5895132A966F /* MTIMPSGaussianBlurFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6C37EB742B0A74800A1AF4970748A179 /* MTITexturePool.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7ABCB697CFDD9B0CA7CBE2DEB6EECC99 /* MTITexturePool.mm */; };
-		6CA036A7572C9050E2F9BFF148E0CFA3 /* MTIImageViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CD698896E6D092584FCA5BD38B1C9B8 /* MTIImageViewProtocol.swift */; };
-		6D85117AD4E195D1FCA10C53D3500394 /* MTIVector.m in Sources */ = {isa = PBXBuildFile; fileRef = A0A2ED91C6BEFCCFAF239EE61BD05996 /* MTIVector.m */; };
-		6DAD76239DEDE4646762B079912969A7 /* MTIRenderPipeline.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E324DCB3CD1BE72BB6EE47DFDBA470 /* MTIRenderPipeline.m */; };
-		6E917648AB6B7E6812C01D1FBD96E5B9 /* MTIImageOrientation.h in Headers */ = {isa = PBXBuildFile; fileRef = 37246B9D8C729D40CDA3AB0967DD05D6 /* MTIImageOrientation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6F26D473E61ECD3E9F3ED9177B79CF46 /* MetalPetal-Core-Swift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 26B549968261A5B414B775D3424FD0DC /* MetalPetal-Core-Swift-dummy.m */; };
-		6F845D308972C21F984332D0320BFFA9 /* MTIContext.h in Headers */ = {isa = PBXBuildFile; fileRef = CFA4B1342272CDFC056C4CDA57558A5C /* MTIContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6FF6348699E19D6CE0DDB6C300B6A548 /* MTIComputePipeline.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B4973445B351C5ABB6B85FFF825EA3E /* MTIComputePipeline.m */; };
-		71843C09630B70FEEE6B64744D1814B9 /* MTIBlendFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = DE8E1F388170A671FCF62664F42CCF25 /* MTIBlendFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		718CBF45818689C4ABF19BB2FAF8C777 /* MTICropFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 39F1000E921A9281C763EDA10723C95D /* MTICropFilter.m */; };
-		728B6F33F0F24380939D3F1821212FF9 /* MTIContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = E89795823431E721A98D88072DB54991 /* MTIContext.swift */; };
-		72A4445A5F255BBFDA971F3C844CFDA0 /* MTIComputePipeline.h in Headers */ = {isa = PBXBuildFile; fileRef = EA170FD883EA613973ED2B16D80C1EBC /* MTIComputePipeline.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		72B4635DBD62C443BA0EA74729C93CB2 /* MTIDrawableRendering.m in Sources */ = {isa = PBXBuildFile; fileRef = A6C55D2839E2E9BDCBC98E9FDBECDE3F /* MTIDrawableRendering.m */; };
-		72C323C1C5DA6F97F0B84138F84813FD /* MTIImageOrientation.m in Sources */ = {isa = PBXBuildFile; fileRef = 2482C3A8BFCD7A98D3CE458A5031A11C /* MTIImageOrientation.m */; };
+		28D2B926C78CD346BB36BC8F067C12E2 /* MTIMPSUnsharpMaskFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CA228D8091B478FDDCEC8727EA8F208 /* MTIMPSUnsharpMaskFilter.m */; };
+		290691A3D0EF0FD535FE38899EE9A5AE /* MTIShaderFunctionConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C04E14334C83E8E5F89CB3DA2D0346 /* MTIShaderFunctionConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2A26F9F487DA48E51CDD1F5BFF167F4B /* MTIImageOrientation.h in Headers */ = {isa = PBXBuildFile; fileRef = 37246B9D8C729D40CDA3AB0967DD05D6 /* MTIImageOrientation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2AD2BFD04531BF82EC6767B160B9E864 /* MTIContext.h in Headers */ = {isa = PBXBuildFile; fileRef = CFA4B1342272CDFC056C4CDA57558A5C /* MTIContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2AEBAE803B152A5446841939B00F9AD5 /* MTIRoundCornerFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = A3D9326B2142633F71EA01F126995043 /* MTIRoundCornerFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2B517B58B69223F713E5C29C4E195D73 /* Halftone.metal in Sources */ = {isa = PBXBuildFile; fileRef = 28368807F05E87E2C5E561378AC64D64 /* Halftone.metal */; };
+		2BD8587D0E229DCA20ABAAAAF6C89B05 /* MTIPixelFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F7446D805364BCB7BCEFA4F29618902 /* MTIPixelFormat.m */; };
+		2C26F2DED7CDDBA6B89EC8BD93284F58 /* MTIAlphaPremultiplicationFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 22EFDD084C13F0A0946FC47579BEA725 /* MTIAlphaPremultiplicationFilter.m */; };
+		2C4F6CFC2325E5714C7AD50FF85634D6 /* MTIComputePipeline.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B4973445B351C5ABB6B85FFF825EA3E /* MTIComputePipeline.m */; };
+		2D52C61CC68D2FAC3042EEEFE03250AE /* MTIRenderTask.m in Sources */ = {isa = PBXBuildFile; fileRef = A76A116553C936D5987440E70163392C /* MTIRenderTask.m */; };
+		2EDA4CC820A9D263897D3392C8BF2102 /* MTIImageOrientation.m in Sources */ = {isa = PBXBuildFile; fileRef = 2482C3A8BFCD7A98D3CE458A5031A11C /* MTIImageOrientation.m */; };
+		2F0E1BD8047D575AB2CC95C353519333 /* MTICVMetalIOSurfaceBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 59DB6169E28AC4E89FD4E28C17D075A1 /* MTICVMetalIOSurfaceBridge.m */; };
+		2FEFAEC5862FCBDC6A750725F29C6ABC /* MTIImageProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F03CAE7F13EF0B0CBC49493F795676C /* MTIImageProperties.m */; };
+		30BE829A942C705C13C4E7A5205B5D23 /* MTIFunctionDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C6A19F5CDB52E0EDA8D1B3220F0E81 /* MTIFunctionDescriptor.m */; };
+		30E6AF38938075389E245216A5924EBC /* MTIMPSHistogramFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = B334145EDBF0EAC80F861216049C7A07 /* MTIMPSHistogramFilter.m */; };
+		30ED9652958E4F99C6C749064FB711DD /* MultilayerCompositeShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = ADF6D517190D4C74DE44CB5CBB62F3F4 /* MultilayerCompositeShaders.metal */; };
+		3109C58A14168F1B53391139C604A7E7 /* MTIVector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7943BF975882151B9BD025A7A616607 /* MTIVector.swift */; };
+		31DF76FE5FE8FF4F0534C946B8AC7C82 /* MTIGeometry.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F14CB019480676EAFA71875A8646E37 /* MTIGeometry.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32E419761A5275222374E6C4E9499B2E /* MTIImagePromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 43476F2131AD4026877FB1245806E517 /* MTIImagePromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		338B52C22DDF20527FDE83CC5C612C1A /* MTIFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = C870EA46C8220E8CFCCD47429DC0937A /* MTIFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		33AD45FC0411FFA4182D04E5758E20D0 /* MTIRoundCornerFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = CD942E3C1820E839A9B4B01AFB277259 /* MTIRoundCornerFilter.m */; };
+		33FC44D39A3C252E6F288A00565CD40B /* MTIBlendFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = FEBC1D778C54B5F25FF83E52DEB4AB69 /* MTIBlendFilter.m */; };
+		3409D5944C9090C49327DC5E305333A8 /* MTIComputePipeline.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B4973445B351C5ABB6B85FFF825EA3E /* MTIComputePipeline.m */; };
+		34F1BF8C23410B428DEDA6B51440DCD0 /* MTITexturePool.h in Headers */ = {isa = PBXBuildFile; fileRef = 78F7F132405D51C8039F8F0F247675DB /* MTITexturePool.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		358D2010899FF5897CF9DD198C85F333 /* MTIImageRenderingContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5FEB9053B35ED8C2EAF431B02BA985E3 /* MTIImageRenderingContext.mm */; };
+		35DB36686300153CEFA0EB88F0E48F28 /* MTIChromaKeyBlendFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DACF8FE6128C086A380E2ABC956120C /* MTIChromaKeyBlendFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3609F5A7D44F46CA9E388CA2A3520DC8 /* MTIBulgeDistortionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E49E9EF077B9155BAAAC3B46EF97BB5 /* MTIBulgeDistortionFilter.m */; };
+		37F2129364C74B9190F8E49FA31003F7 /* MTIRGBColorSpaceConversionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B1820B839CA4B878B9DA024AE1350DE /* MTIRGBColorSpaceConversionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		382DDF492E7C944F7A6D275C9463388A /* MTICVMetalTextureCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 61F8DE758E4EA6C7C8A2611F5F048193 /* MTICVMetalTextureCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3878EB704E1F2B6CAD3AF19F758988E3 /* MTIFunctionDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = B365A4039426EBFD0913D8C930F7BC1B /* MTIFunctionDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		396A23701BF3EEA9132A763D0DC4D385 /* MTIMultilayerCompositeKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F16E3200F8CD44C0EBCF31CB7D476B4 /* MTIMultilayerCompositeKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		398D07270DB72A1CA8610226D7492BF9 /* MTIMultilayerCompositeKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F16E3200F8CD44C0EBCF31CB7D476B4 /* MTIMultilayerCompositeKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		39D8628EA10787DA5172F2FC029F14AA /* MTIPixellateFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 992934579D2CE8D49CDF3DB722D326EE /* MTIPixellateFilter.m */; };
+		3A38D2E09EA0D45578A3A2C3615AB659 /* MTIRenderTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A15AFE8E136AE579B2194077C8A1390 /* MTIRenderTask.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3A3B1FDB1D15897BB28C5D4E7BE65DF8 /* MTIMPSSobelFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = DCAFD03727F6E904E3AEEAAC1CC1BE97 /* MTIMPSSobelFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3B8B7AB0191836868235DDA5393A61F4 /* MTIImageRenderingContext.h in Headers */ = {isa = PBXBuildFile; fileRef = A414EC6DE34C402428AE493B9822B9C8 /* MTIImageRenderingContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3BFB05DA28A98B1871A35D75546ABDFB /* MTIRenderPipeline.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E324DCB3CD1BE72BB6EE47DFDBA470 /* MTIRenderPipeline.m */; };
+		3D233807E70AF9AA754B87A6C6983987 /* MTITextureDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = F717F5873FADD7511C4883FB7FE39261 /* MTITextureDescriptor.m */; };
+		3DA7E2B42D15AE6AEB36650A28998F9B /* MTIColorHalftoneFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 46979D946C597284368024105C6667E2 /* MTIColorHalftoneFilter.m */; };
+		3E7F958C6B6129458101653AC0AB8E69 /* MTIImage.h in Headers */ = {isa = PBXBuildFile; fileRef = BFE0E806B256BB3A9700DB5FD424B6A9 /* MTIImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3F08B1D8B0E10C45F4177219B1990089 /* MTISKSceneRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0BBA4BBFCB7CB5A42A63C64276CD04F3 /* MTISKSceneRenderer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3F21B5F84FDEF95279451EDD6C1E74EF /* MTIKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 213784EC8936904929EA1A3380E503CB /* MTIKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		40E68CB3EEF7B32A3262764EAFD148E1 /* MTIFunctionArgumentsEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 98D888EDA81E8D36B9F3FDB956083B4E /* MTIFunctionArgumentsEncoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		41FC9E8701DB25ACD2C2A0BC83C2154B /* MTIFunctionArgumentsEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B74E8D6ABC0443FEED3026CD1E7B0D8 /* MTIFunctionArgumentsEncoder.m */; };
+		4212B77D04D95F74408EC8FCF4D477AC /* MTIRGBToneCurveFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0911B26BFD8E1F38ADA0E35009DC0F7F /* MTIRGBToneCurveFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4410BC6FAA67ACE717D4F0931D1C8323 /* MTIVibranceFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = C5D59DAF4CB77D4E67FB427915F52D4A /* MTIVibranceFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		446A3321A140CB355FFC1C353BD3EF2E /* MTIRGBColorSpaceConversionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = E112C9A658F6EC9D4035225C3BF9B8A9 /* MTIRGBColorSpaceConversionFilter.m */; };
+		448811A349C784122742575621DAAB91 /* MTIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F438C95D9F6134B973892D08D9C90F /* MTIColor.swift */; };
+		44BF489DBB53FB3715ADCDD5315406D2 /* MTIRenderGraphOptimization.m in Sources */ = {isa = PBXBuildFile; fileRef = B24021FF880799F5045E921C14BF0CC6 /* MTIRenderGraphOptimization.m */; };
+		44CFAA03249BB9DA8FA543ED9C541674 /* MTIRenderPipelineKernel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBA4F13EBECC58E28B472AD50A7CA612 /* MTIRenderPipelineKernel.swift */; };
+		452BC9B912E151F1B0C26E5556E715FE /* MTIBulgeDistortionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = E4CA643AFD489837BDA5B07F9AEF20D8 /* MTIBulgeDistortionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		46E15F2BF3A08F3467C47939620A4B4D /* MTICVMetalTextureBridging.h in Headers */ = {isa = PBXBuildFile; fileRef = A57C7A26933829A8FF6546DB7B9E5E05 /* MTICVMetalTextureBridging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		47D5C73BA2927F4C2050508F9091BA27 /* MTICoreImageRendering.h in Headers */ = {isa = PBXBuildFile; fileRef = 87D681EED87BC4A7557906E1F8707BA6 /* MTICoreImageRendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		489EBCAE973ACD757AB0EB5EA96D3584 /* MTIRGBToneCurveFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0911B26BFD8E1F38ADA0E35009DC0F7F /* MTIRGBToneCurveFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		48B007D0CC222F4AC2E7491785C3D423 /* MTISIMDArgumentEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C50ED68A4B82B87B9853A2F9350EFA3 /* MTISIMDArgumentEncoder.swift */; };
+		49DD1E9170216EF2325E2876DDC8B165 /* MTIRenderPipelineKernel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBA4F13EBECC58E28B472AD50A7CA612 /* MTIRenderPipelineKernel.swift */; };
+		4B37F0AB9CD162948F37B119DA596712 /* MTIVertex.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17E826B5869A8EDA5DCD3EBE5940963 /* MTIVertex.swift */; };
+		4BEC0CBA9F93D859CEA9B9B734D283E9 /* MTIMPSSobelFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9228D838D1402FD80B9E9D97A17D1FEE /* MTIMPSSobelFilter.m */; };
+		4CC65151132C527A579CF720C017E019 /* MTIPixelFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518C430901F215C101898B2E31020C73 /* MTIPixelFormat.swift */; };
+		4D90B73A3CE7BD7DD7844E2AB8408C05 /* MTIMemoryWarningObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C9B4C7F349CB63D814E673B0385E152 /* MTIMemoryWarningObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4EDCEEB8D3564EEB909BF48DCA966339 /* MTIImage.m in Sources */ = {isa = PBXBuildFile; fileRef = DEE8949D1E9AB7CB65D47C5DFC0E7B47 /* MTIImage.m */; };
+		50333D036C0AD11C094FF9A7F8174C6E /* MTIContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1DFACD08669DECACC3BB24468070AE /* MTIContext.swift */; };
+		509F9682D827832454AB9F086D82B73D /* MTIComputePipeline.h in Headers */ = {isa = PBXBuildFile; fileRef = EA170FD883EA613973ED2B16D80C1EBC /* MTIComputePipeline.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		50C92996719567669FE015AED0137666 /* MTIKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 213784EC8936904929EA1A3380E503CB /* MTIKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		51489A5687C3E4C274AFDB54AA1FFEC4 /* MTIComputePipelineKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = 486F3616A35FFFF2B285411311709F7F /* MTIComputePipelineKernel.m */; };
+		5171D6E72A49454CD36FAB4939C48E5A /* MTICVPixelBufferPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = EC826C41089341DF8216FEEABA77CEF1 /* MTICVPixelBufferPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		541921690512D3143E5F62F88806F0C3 /* MTIBlendFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = DE8E1F388170A671FCF62664F42CCF25 /* MTIBlendFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5467D831B6164D251BB05CECAFFCFB1B /* MTIChromaKeyBlendFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DACF8FE6128C086A380E2ABC956120C /* MTIChromaKeyBlendFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		565700C4114291A1B8A3E573A7236E33 /* MTIVector+SIMD.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D8CE33BBFC5E37449CFD2579DAAA426 /* MTIVector+SIMD.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		581DCB2E2074FE002B424192FDAFAED7 /* MTIError.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F7FCE08EC324401B150214C649B0C0C /* MTIError.m */; };
+		584AD53DC7AAC7494F8B65F2BBE4FFB6 /* MTIColorHalftoneFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B8619AA152D6BA49379AF7C071D3764 /* MTIColorHalftoneFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		58769ED741D7F2B1A4B4E1E26BEA554D /* MTIShaderLib.h in Headers */ = {isa = PBXBuildFile; fileRef = 03E34A818D7E5B628B2E20034480F7BC /* MTIShaderLib.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		58E245D92A23F8DF2B9445ADE6C7CD69 /* MTIRenderPipelineKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E9E75E54B2DDB8E89F445A0E55F55B2 /* MTIRenderPipelineKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		597299668FC0C57AB7B1FDA243136E6E /* MTIGeometry.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F14CB019480676EAFA71875A8646E37 /* MTIGeometry.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC70AF95C239CFB43F84487F85DE597 /* MTIVertex.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F4F8A8596485C0273B699F1E2BF14C3 /* MTIVertex.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5ADD68A5D87EEB85531B2804BA6ED7A4 /* MTIImagePromise.m in Sources */ = {isa = PBXBuildFile; fileRef = E6ADA49B609B3FAFADA6A2D39E688717 /* MTIImagePromise.m */; };
+		5B502D0618E62E7E6CCE34C0C7E28FB1 /* MTIColorMatrix.m in Sources */ = {isa = PBXBuildFile; fileRef = 000A839435C68C96FE3A15FC42A3D96B /* MTIColorMatrix.m */; };
+		5B8777021DCD6CB3DD612823481FDC99 /* MTISCNSceneRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = D4594ED8316E9485C8D047368DF9F011 /* MTISCNSceneRenderer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C3B86B8C66423142005084CADED6ED9 /* MTIMask.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F7A4CF15A9842965A2F34D52E517483 /* MTIMask.m */; };
+		5DEC02BA82C921C59C8643FD49BF9F08 /* MTITexturePool.h in Headers */ = {isa = PBXBuildFile; fileRef = 78F7F132405D51C8039F8F0F247675DB /* MTITexturePool.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5EF12CD1F376A6F5A6C2173CF2A341C2 /* MTIColorLookupFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6255D81F38B30694A9DB957329C7108F /* MTIColorLookupFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5F03F928D7BE8AAE74E2FD4377436F62 /* MTIMPSGaussianBlurFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 3110866B775237BA40999C9445438BC1 /* MTIMPSGaussianBlurFilter.m */; };
+		5F3D7333F4E7832785FF5E1FA691ACA6 /* MTIImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2583F32A03FF818D26995B1976152D32 /* MTIImageView.m */; };
+		5FD15C2A899F54C75DC834A2D18E0BEA /* MTIRoundCornerFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = CD942E3C1820E839A9B4B01AFB277259 /* MTIRoundCornerFilter.m */; };
+		60EA8D06752315B341B7E6109E990384 /* MTIRenderCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 907A93EBA0BDBF985570598F9ED71E85 /* MTIRenderCommand.m */; };
+		6122FE1A6F7D77194E7FD355D6E6656A /* MTITextureDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = F717F5873FADD7511C4883FB7FE39261 /* MTITextureDescriptor.m */; };
+		61A2FD9CE607E49A50908D3E39E73337 /* BlendingShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 6523B084669CA8E9CDA5E2EDF1011A04 /* BlendingShaders.metal */; };
+		627B1254EF1529D4D8CE2F7ED06C092B /* MTIRenderPassOutputDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 74B6B717A8E378D75CBA474EFD8C90F3 /* MTIRenderPassOutputDescriptor.m */; };
+		62934A61E285E6ED724F0466D9D0DDB4 /* MTIPrint.h in Headers */ = {isa = PBXBuildFile; fileRef = DDAE8FEA0BDC7BF6466286F2E1FC3B99 /* MTIPrint.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6733D5BA081316B45A297AD6E067369B /* MTIImageProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = 46925C6E8619FE7B523F2A05441ABB84 /* MTIImageProperties.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		688C8415ED4615227D153B4B74EB20E3 /* MTIContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1DFACD08669DECACC3BB24468070AE /* MTIContext.swift */; };
+		68EFCAB8B5CE480D89FF9B8DA11CA835 /* MTIMask.h in Headers */ = {isa = PBXBuildFile; fileRef = 23714C569A0099951BDF5DF5BBABA50A /* MTIMask.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		69309D87AED8DC32D2AD413A6F9B78AB /* MTIImage+Filters.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E65CFF8EB5573CC2B9608216CD44E6 /* MTIImage+Filters.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		69946A4673FD8C8215548B8EC38F5EDB /* MTIImageRenderingContext+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 6721C9D18C1B9F4B79F48A614D6073B3 /* MTIImageRenderingContext+Internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		69FC638A2D8ED1566F88883CB4EE7C9A /* MTIHexagonalBokehBlurFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DB916AE474D5DE53D48E82391A70EA0 /* MTIHexagonalBokehBlurFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6B849F9F8E2CFC807673FE7DEDEC8810 /* MTICLAHEFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F5D6306B41724303B8CD05276822338 /* MTICLAHEFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6BF28543F1876D2D41F919D29C773688 /* MTIFunctionDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EAC8394FB0E80CCE2A97F4AB4B56113 /* MTIFunctionDescriptor.swift */; };
+		6CC17FC976274F37E24BDD35EE85591F /* MTICVPixelBufferPool.m in Sources */ = {isa = PBXBuildFile; fileRef = A1425DC453E2AB8FC117D4C8E1B3F5B2 /* MTICVPixelBufferPool.m */; };
+		6DDD562158F41449FD9056CCE9B41A67 /* HighPassSkinSmoothing.metal in Sources */ = {isa = PBXBuildFile; fileRef = F4E59C977E0B5CB6322A12F776BF54DE /* HighPassSkinSmoothing.metal */; };
+		6DF0E060891C5C2881D745549FCAD70A /* CLAHE.metal in Sources */ = {isa = PBXBuildFile; fileRef = D923AAD0CB084596522F9F1B4789B175 /* CLAHE.metal */; };
+		6EAA1D78D5F2012794D7C3648C423D4C /* MTIMPSUnsharpMaskFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = D9DCB3600E15951DE046C97C55F5BE54 /* MTIMPSUnsharpMaskFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6ECEF5B2547DFFC54965E7A918600F81 /* MTIShaderFunctionConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C04E14334C83E8E5F89CB3DA2D0346 /* MTIShaderFunctionConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6F78718C399388204D04AC6CB72437B5 /* MTICVPixelBufferPool.m in Sources */ = {isa = PBXBuildFile; fileRef = A1425DC453E2AB8FC117D4C8E1B3F5B2 /* MTICVPixelBufferPool.m */; };
+		6FD6ADC9E3DF2E4B7C7CE20CF802FABB /* MTICVMetalTextureCache.m in Sources */ = {isa = PBXBuildFile; fileRef = C7905C9FDAA58B78BC083B0E2854C505 /* MTICVMetalTextureCache.m */; };
+		707CCC0D1B8A6674B6B8AC0B1E60D399 /* MTIFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = C870EA46C8220E8CFCCD47429DC0937A /* MTIFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		70B94BEC410FA3B380B2A9B3C3C5D06E /* MTIColorMatrixFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 64B2FA89E379A1E21599B10A8112AC5D /* MTIColorMatrixFilter.m */; };
+		7144EA3A924B1B576A6CA1A8352B0F83 /* MTIComputePipelineKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 636D0E86122B800AC26534C969A4B20C /* MTIComputePipelineKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		716853A0C26608CFEB0E63952F674E26 /* MTISIMDArgumentEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C50ED68A4B82B87B9853A2F9350EFA3 /* MTISIMDArgumentEncoder.swift */; };
+		723F3CDC35EC58ACF8D5ED4CF2460824 /* MTIMPSDefinitionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 95749359434BE4A174EA5690D86A960B /* MTIMPSDefinitionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		72F7D79BA560005A2318463FF6592ECB /* MTIDotScreenFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = ADDCA587F2C14BD86B32D7A835B19518 /* MTIDotScreenFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		72FFD40EEAE3B3AC51776C516F443705 /* Pods-MetalPetalExamples-MetalPetalExamples (iOS)-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EFAEF4681EE4E27E37257F48E75B5A9 /* Pods-MetalPetalExamples-MetalPetalExamples (iOS)-dummy.m */; };
-		7336A63FE6C35B128777CA0D01F4CACF /* MTICVMetalIOSurfaceBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D06881FE11756F8FCEE425B28617CAB /* MTICVMetalIOSurfaceBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7361BB1E6ED3F8A941FA79EA03959500 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 70E59D9D8EF41291B0C13BC330FA3126 /* Cocoa.framework */; };
-		7493CE554FBD34FD2D4D7331DE66E85B /* MTIPixelFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDC220791823F8B8EDCC75DEEFE5AE2 /* MTIPixelFormat.swift */; };
-		7519ED50C4E39AA9E1A0D5DB4BD2971F /* ColorConversionShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = F094BEC497F8B03C8652DF126F546372 /* ColorConversionShaders.metal */; };
-		7607996271CE1900F6FE5AD17640FD70 /* Shaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = F25E83F831680F6F145FF5803FA16038 /* Shaders.metal */; };
-		76197B1589DCDCA624656B8F154517BA /* MTIImageRenderingContext+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 6721C9D18C1B9F4B79F48A614D6073B3 /* MTIImageRenderingContext+Internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		7696694FE0748386BA8D02D825B2853D /* MTIGeometry.m in Sources */ = {isa = PBXBuildFile; fileRef = 50D57FA9342F44FD185167A3568EB56E /* MTIGeometry.m */; };
-		76AC0591BD2D2C3029CD3416D022618D /* MTIBlendFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = FEBC1D778C54B5F25FF83E52DEB4AB69 /* MTIBlendFilter.m */; };
-		76D60502F7FB3D6CED031AF2A7630C18 /* MTICorner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE571E8CB85DCF6F357CD8DAA3AE487 /* MTICorner.swift */; };
-		770D14A3E08624F975BD30C44A0A646E /* MTIDefer.h in Headers */ = {isa = PBXBuildFile; fileRef = F3127DA534F8DF0893392C62B3969338 /* MTIDefer.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		77CDB6B23737A6A89F317FFDD0355788 /* MTICVPixelBufferPool.m in Sources */ = {isa = PBXBuildFile; fileRef = A1425DC453E2AB8FC117D4C8E1B3F5B2 /* MTICVPixelBufferPool.m */; };
-		77E8FCDB244220121E56E41342E02BAF /* HighPassSkinSmoothing.metal in Sources */ = {isa = PBXBuildFile; fileRef = F4E59C977E0B5CB6322A12F776BF54DE /* HighPassSkinSmoothing.metal */; };
-		78006B40B2DAC0297B6B75D2F1816751 /* MTIFunctionArgumentsEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B74E8D6ABC0443FEED3026CD1E7B0D8 /* MTIFunctionArgumentsEncoder.m */; };
-		782C85583A960656B9F02CDE67522126 /* MTICVPixelBufferRendering.m in Sources */ = {isa = PBXBuildFile; fileRef = DB272E5AE4E21F25DB8255891881926F /* MTICVPixelBufferRendering.m */; };
-		78C3854B138B8C077CF9EB37F8B5C3FE /* MTIColor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BC89A2032F2F966D1A77702264B23EA /* MTIColor.m */; };
-		78DB8BE1C2540B9AFAF0DF3C2A4D6558 /* MTICropFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = C3C52A774103E9679118BB50F6D10E55 /* MTICropFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		796D7334827F8D2FB0D8489440831B6E /* MTITextureDimensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158A8EFE6110E8196D7C6469EDC15E63 /* MTITextureDimensions.swift */; };
-		7A3F7789C1FD3E1CBE06D73D05607354 /* MTIRoundCornerFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = CD942E3C1820E839A9B4B01AFB277259 /* MTIRoundCornerFilter.m */; };
-		7B09D0C0F7806E372FF40BD5E1BB2ACF /* MTIBlendFormulaSupport.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3648315ED673AAF957616C8B8B7B225F /* MTIBlendFormulaSupport.mm */; };
-		7B6FA64CBD80B21D6BAB7A65126634E8 /* MTIRenderGraphOptimization.h in Headers */ = {isa = PBXBuildFile; fileRef = D24DDF832828EE4F31C7C3EDC8501387 /* MTIRenderGraphOptimization.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7B994B0C5BF4201B43519C7556B005C3 /* MTIRenderPassOutputDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 74B6B717A8E378D75CBA474EFD8C90F3 /* MTIRenderPassOutputDescriptor.m */; };
-		7BA03FE3D4F4C8CDD6F21A24CC33AC5B /* MTIVertex.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D698D73004301D6721BF8A2D2D0EB6 /* MTIVertex.swift */; };
-		7D3D7E02A4DEF8C3BEF7E20FD3406312 /* MTIChromaKeyBlendFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DACF8FE6128C086A380E2ABC956120C /* MTIChromaKeyBlendFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7F50B12CA517D0FAEF482CFD74846B78 /* MTISKSceneRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 2143036CABE393784D025D87644A92CB /* MTISKSceneRenderer.m */; };
-		7F76F43A3C89FC6A43A37028999C3DE6 /* MTIVertex.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D698D73004301D6721BF8A2D2D0EB6 /* MTIVertex.swift */; };
-		80D44193AFCF19C5CAEF46CFAF66CDAF /* MTITransform.h in Headers */ = {isa = PBXBuildFile; fileRef = BE3AD47A5E5845568DFDE2162773821F /* MTITransform.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8204A4717FCBDB0F653087D5EA496BD5 /* MTICVMetalTextureBridging.h in Headers */ = {isa = PBXBuildFile; fileRef = A57C7A26933829A8FF6546DB7B9E5E05 /* MTICVMetalTextureBridging.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		827F2A019511EA5F52ED33FCDB905039 /* MTIImageProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F03CAE7F13EF0B0CBC49493F795676C /* MTIImageProperties.m */; };
-		82A2EB15EECEFBB4FADD3C002BC30E1E /* MTICLAHEFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = D6BB01559B627146085BCF1144C2DA26 /* MTICLAHEFilter.m */; };
-		8310EDE2F2F098B96831B34F078FEBA8 /* MTIFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = C870EA46C8220E8CFCCD47429DC0937A /* MTIFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8372CAF774EA51BABA4F7C941FFB1130 /* MTISIMDArgumentEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C6D6B1CC643746D5CDD2B27BE716F3 /* MTISIMDArgumentEncoder.swift */; };
-		83B1FF2FA7D546956430AC64B599A64B /* MTIMPSUnsharpMaskFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CA228D8091B478FDDCEC8727EA8F208 /* MTIMPSUnsharpMaskFilter.m */; };
-		84738AB84805CF9308EDB842E0B48F0F /* MTITransform.m in Sources */ = {isa = PBXBuildFile; fileRef = E2DA2F1560A31253421ACC61AB910417 /* MTITransform.m */; };
-		8515DEE6D3DC867B6707288D5151E012 /* MTIComputePipelineKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 636D0E86122B800AC26534C969A4B20C /* MTIComputePipelineKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		875328830B3A73151ED3600A547FC972 /* MTIHexagonalBokehBlurFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C73EBFE35DEABDFEBE99D9859B30C96 /* MTIHexagonalBokehBlurFilter.m */; };
-		87D66F9E294DFA9B158E83099BE27502 /* MTIRGBColorSpaceConversionFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC32955D75E51A051F78B9406DD9746 /* MTIRGBColorSpaceConversionFilter.swift */; };
-		885BB046AD89829B31F5F13234918F19 /* MTIRenderTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A15AFE8E136AE579B2194077C8A1390 /* MTIRenderTask.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		88BF4DB322E8E59D9A005126FFC8B93A /* MTIColorLookupFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BA57A817A151A6B179EEFE3DC8C8 /* MTIColorLookupFilter.m */; };
-		8961C7B951A9B93578FEF58AC918884A /* CLAHE.metal in Sources */ = {isa = PBXBuildFile; fileRef = D923AAD0CB084596522F9F1B4789B175 /* CLAHE.metal */; };
-		8A0F419C78DFA15F0810BE3CF002567E /* MTIPixelFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F7446D805364BCB7BCEFA4F29618902 /* MTIPixelFormat.m */; };
-		8A0FAE7B5D9679CC45961DC205C166D7 /* MTIImage+Promise.h in Headers */ = {isa = PBXBuildFile; fileRef = 08B5E898FC12525182B5795434255D8B /* MTIImage+Promise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8B4AE69242BDC456C5985CB93D6303F3 /* MTISKSceneRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0BBA4BBFCB7CB5A42A63C64276CD04F3 /* MTISKSceneRenderer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8B7E810383F67629855E13A7C3997F6D /* MTIShaderLib.h in Headers */ = {isa = PBXBuildFile; fileRef = 03E34A818D7E5B628B2E20034480F7BC /* MTIShaderLib.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8C3D8DFA16C6D6CEF3FBE76EBC233C58 /* ColorConversionShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = F094BEC497F8B03C8652DF126F546372 /* ColorConversionShaders.metal */; };
-		8CFE33AFE376ADFA7A72CC8C1B9B7445 /* MTIVector+SIMD.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D8CE33BBFC5E37449CFD2579DAAA426 /* MTIVector+SIMD.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8D6A620FC7A7DDFB266757F7F1247687 /* MTIError.h in Headers */ = {isa = PBXBuildFile; fileRef = 051D63EB3BDF7FD714F71DC83B48597F /* MTIError.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8F0498FA2B92D5E962A3AF36E47B184D /* MTIMultilayerCompositeKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9BAFF05C5720FC8E639F84631D8A92 /* MTIMultilayerCompositeKernel.m */; };
-		8F0F383CD422D90771D8126355C4E9B3 /* MTIImageViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CD698896E6D092584FCA5BD38B1C9B8 /* MTIImageViewProtocol.swift */; };
-		8F1BBD69C9E4194AB3786DD357714C31 /* MTIFunctionArgumentsEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 98D888EDA81E8D36B9F3FDB956083B4E /* MTIFunctionArgumentsEncoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8F3EABB095997D1765DD88308FEF08AF /* MTIMPSGaussianBlurFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 3110866B775237BA40999C9445438BC1 /* MTIMPSGaussianBlurFilter.m */; };
-		8F8A363CA3A4414DE040F30017D4AB30 /* MTIMultilayerCompositeKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F16E3200F8CD44C0EBCF31CB7D476B4 /* MTIMultilayerCompositeKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8FACD894E1DB2DFBCFB3263A89340602 /* MTIImage+Filters.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E65CFF8EB5573CC2B9608216CD44E6 /* MTIImage+Filters.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8FD38C6D50E2876B96C585A1E3854B01 /* MTIMask.h in Headers */ = {isa = PBXBuildFile; fileRef = 23714C569A0099951BDF5DF5BBABA50A /* MTIMask.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8FEA886DE92F91A9AB7D4C5199ABB60A /* MTIGeometry.m in Sources */ = {isa = PBXBuildFile; fileRef = 50D57FA9342F44FD185167A3568EB56E /* MTIGeometry.m */; };
-		915849A31DA864D8BD568D9D8DBDAC84 /* MTIColorMatrix.m in Sources */ = {isa = PBXBuildFile; fileRef = 000A839435C68C96FE3A15FC42A3D96B /* MTIColorMatrix.m */; };
-		92EEAC233F9B5CA0BB4C7E48331A6A71 /* MTIContext.m in Sources */ = {isa = PBXBuildFile; fileRef = BB25E2412ACAF0CD6ADE8C60161DC127 /* MTIContext.m */; };
-		936FDC586E65C69AE9F80602CDE9169A /* MTIRenderCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 907A93EBA0BDBF985570598F9ED71E85 /* MTIRenderCommand.m */; };
-		939A572046C16414A3959A30D3D8416C /* MTIVector+SIMD.m in Sources */ = {isa = PBXBuildFile; fileRef = C33CAEF97463167982B0D85B4A6F40C0 /* MTIVector+SIMD.m */; };
-		93EC7CDDF2F59EC40C55F8960F909DCF /* MTICVMetalTextureCache.m in Sources */ = {isa = PBXBuildFile; fileRef = C7905C9FDAA58B78BC083B0E2854C505 /* MTICVMetalTextureCache.m */; };
-		9480F2EFFF1361456DEFD43DC1F6BC5A /* MTIContext+Rendering.m in Sources */ = {isa = PBXBuildFile; fileRef = 44F34F35B06446E94AF6887EFE559097 /* MTIContext+Rendering.m */; };
-		94DC2228FF4BDF91EB67B0A150256BBB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D96B6F02A66345DED9C856D1BD504B40 /* Foundation.framework */; };
-		95127171A066D618A2DB9C95164DB781 /* MTIDotScreenFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = ADDCA587F2C14BD86B32D7A835B19518 /* MTIDotScreenFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9559662C3E72B6C7E7D8F869C3F86B34 /* MTIMultilayerCompositeKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F16E3200F8CD44C0EBCF31CB7D476B4 /* MTIMultilayerCompositeKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		964077B1E3B74F189774964FE84D779E /* MTIRenderCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 87CF9D85C1CDA7AB97AE28528E55DAD4 /* MTIRenderCommand.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		966D60A91125E903E2559ABF665B406E /* MTIRoundCornerFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = A3D9326B2142633F71EA01F126995043 /* MTIRoundCornerFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9733F2EDC1E16C534B327A44BF10F029 /* MTICLAHEFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F5D6306B41724303B8CD05276822338 /* MTICLAHEFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		990ECE564BF41DFFBAE309863BB9FEC2 /* MTIPixellateFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 992934579D2CE8D49CDF3DB722D326EE /* MTIPixellateFilter.m */; };
-		99467F0DA3AA6D8137ACAE489A7F7302 /* MTIMPSSobelFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9228D838D1402FD80B9E9D97A17D1FEE /* MTIMPSSobelFilter.m */; };
-		9A325287B1E002D3C9B2BADCA4A49916 /* MTITextureLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C7B79C1EF70120069525973A373B5B0 /* MTITextureLoader.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9A333D7F33CBD31A6CBCB149E0F460D0 /* MTILayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EE1C40E9FA9CD4E24E8A3A05645EC86 /* MTILayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9A3B3E828DAA47FF9B3C270F2CB31CD5 /* MTIColor.h in Headers */ = {isa = PBXBuildFile; fileRef = 1007E23586C26A5AC21D8EE48B9DD4E2 /* MTIColor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9AD442FDD1B32C6D443EC769DA265687 /* MTIFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 83E81065F318F10E0C0C2A9BBD0812CD /* MTIFilter.m */; };
-		9B5F60E956DA9E1FA3E1B2E7C6EDF80D /* MTIRGBColorSpaceConversionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = E112C9A658F6EC9D4035225C3BF9B8A9 /* MTIRGBColorSpaceConversionFilter.m */; };
+		74572DB33C0D2306B555C0928D0EE768 /* MTIImageRenderingContext+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 6721C9D18C1B9F4B79F48A614D6073B3 /* MTIImageRenderingContext+Internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		74BAF6EF9624163EE4A98271F7C0EEB1 /* MTIAlphaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1627D99729B48FFD9053B927130125 /* MTIAlphaType.swift */; };
+		75190E6BFBBD5AC660495C55BE1D0955 /* MTIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F438C95D9F6134B973892D08D9C90F /* MTIColor.swift */; };
+		757F073390244D67918CC0B926AED7A0 /* MTICoreImageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6A52788E53455D323A3C7A514A026B6 /* MTICoreImageExtension.swift */; };
+		758BF7BE7F54EC92474B48F56C82E0CE /* MTIDefer.m in Sources */ = {isa = PBXBuildFile; fileRef = 89933E584BCEDC968272B351AC127B46 /* MTIDefer.m */; };
+		75B5C461AF883C01526011895E34D9AB /* MTIPixelFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 42FDD1B7319AB7FB6CD09EF5EA835EFD /* MTIPixelFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		75B7C7AB3075A6C75DA0A6211FA51FED /* MTIPixelFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 42FDD1B7319AB7FB6CD09EF5EA835EFD /* MTIPixelFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7686F8144766D837C04BC29C0A850CB4 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D415EA68815D0046129EBDEA297DA49 /* Filter.swift */; };
+		76D9A6AD40DF026E8C84C3F31C8A1E5C /* MTITransform.m in Sources */ = {isa = PBXBuildFile; fileRef = E2DA2F1560A31253421ACC61AB910417 /* MTITransform.m */; };
+		76EFEB2CC24D0A47B4239C6CA3750093 /* MTIImageViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97E1E87D90BEC4E6991AE5AC48D888B2 /* MTIImageViewProtocol.swift */; };
+		77909903820253D1D13C207EDEAF68EF /* MTIImagePromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 43476F2131AD4026877FB1245806E517 /* MTIImagePromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		77C62A839920164C7709E8C848D73B86 /* MTIVector.h in Headers */ = {isa = PBXBuildFile; fileRef = 080D39D554DC6A497F3CB775865C8E8A /* MTIVector.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		786A2DE4A67EFC36A6009CC71940849F /* MTIRenderPipeline.h in Headers */ = {isa = PBXBuildFile; fileRef = 51A388571970F41F8AF173376B80987D /* MTIRenderPipeline.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		797D59A270BF1FFE7E5D5576F12CAE5A /* MTIMask.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F7A4CF15A9842965A2F34D52E517483 /* MTIMask.m */; };
+		798AB183ECEA7D51FBF45567E50F31A5 /* MTIComputePipeline.h in Headers */ = {isa = PBXBuildFile; fileRef = EA170FD883EA613973ED2B16D80C1EBC /* MTIComputePipeline.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		79F7BD3AAEB50429C86A6E2CA7A0C104 /* MTILayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EE1C40E9FA9CD4E24E8A3A05645EC86 /* MTILayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7A9ED326BCD3C69A7340DD7B0C09659D /* MTIBlendModes.m in Sources */ = {isa = PBXBuildFile; fileRef = AD7A7B5562D417F4DBED87CE99A5636A /* MTIBlendModes.m */; };
+		7C5E3E340D624C34B37BF516D0F92A3A /* MTIVibranceFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FDC1CD26C35E90E7FBAB6D25EFCA072 /* MTIVibranceFilter.m */; };
+		7D029F7FF262C4E0F6315FFF5A01FE66 /* MTIVideoComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB873C68D2563D202B0F6A5A1BCFB89 /* MTIVideoComposition.swift */; };
+		7D2F9E944420BA60CDA4D8F1FF66A68A /* MTIThreadSafeImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 994294A7C1F35F53E1FECEC65BB8E8C3 /* MTIThreadSafeImageView.m */; };
+		7D8CFB0B849A22FFBDB7A86D0521760B /* MTIImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 98A870F833375207F89B2FB480B7D9B4 /* MTIImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7E441ADED7E95D02EDA8EA388E670F30 /* MTIBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = A7D86EC9A144CA5053311A41AF060C52 /* MTIBuffer.m */; };
+		7E77A8998159186EC568C0FD7A5AC1A8 /* MTIContext.h in Headers */ = {isa = PBXBuildFile; fileRef = CFA4B1342272CDFC056C4CDA57558A5C /* MTIContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7F1C2AB7602B29FF760CAB9FED75BA08 /* MTIImagePromise.m in Sources */ = {isa = PBXBuildFile; fileRef = E6ADA49B609B3FAFADA6A2D39E688717 /* MTIImagePromise.m */; };
+		7F67178E16664724E0A894DCA9EADBA0 /* MTIImagePromiseDebug.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E7E883A98F26CDC01465914462E3B45 /* MTIImagePromiseDebug.m */; };
+		813934FAB4F64667726CB86F913C7247 /* MTIDrawableRendering.m in Sources */ = {isa = PBXBuildFile; fileRef = A6C55D2839E2E9BDCBC98E9FDBECDE3F /* MTIDrawableRendering.m */; };
+		81844DA114DA1612BD2C369F7A5E8721 /* MTIRGBToneCurveFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 75F8C0942B51125AD7896B3A1F810DBB /* MTIRGBToneCurveFilter.m */; };
+		81B38A634B811600AE38A2BB8FC5BC23 /* MTIVertex.m in Sources */ = {isa = PBXBuildFile; fileRef = F2CC0881E4DEACE9488067D24EC8211C /* MTIVertex.m */; };
+		81EC36D5F1EF037FC22783FC6453DBB3 /* MTIBlendModes.h in Headers */ = {isa = PBXBuildFile; fileRef = C17A0628178212F76DCE9680877FA412 /* MTIBlendModes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		830AF6C404384EDA4FF7E960F92A18C3 /* MTIFunctionDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C6A19F5CDB52E0EDA8D1B3220F0E81 /* MTIFunctionDescriptor.m */; };
+		833D8C404D9B05CE9BA645573792D596 /* MTICVPixelBufferPool.h in Headers */ = {isa = PBXBuildFile; fileRef = B3453C3DF38A3143DE7CABCE3235B93E /* MTICVPixelBufferPool.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		83940F1318B3B3B678F89A31DF46DD31 /* MTITransform.h in Headers */ = {isa = PBXBuildFile; fileRef = BE3AD47A5E5845568DFDE2162773821F /* MTITransform.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		83F9346265E3E3BD0485DB561BBC9A67 /* MTIGeometry.m in Sources */ = {isa = PBXBuildFile; fileRef = 50D57FA9342F44FD185167A3568EB56E /* MTIGeometry.m */; };
+		8505E30A2C272CB683570251D091228D /* MTISamplerDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A140A5542FB46FDEC00FF8D7BC0929E /* MTISamplerDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		85D3C231C81E1881953623CF212A6134 /* MTICorner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C94F2509FBD062966808822E78CDA1 /* MTICorner.swift */; };
+		860F5DEE95DB7B3F0A222145E2F253A6 /* MTIImageRenderingContext.h in Headers */ = {isa = PBXBuildFile; fileRef = A414EC6DE34C402428AE493B9822B9C8 /* MTIImageRenderingContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8650C65789A6BC50C2BD43593B5DA572 /* MTIImageRenderingContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5FEB9053B35ED8C2EAF431B02BA985E3 /* MTIImageRenderingContext.mm */; };
+		86979D74D4083977773B89C8FE0FB5CE /* MTICoreImageRendering.h in Headers */ = {isa = PBXBuildFile; fileRef = 87D681EED87BC4A7557906E1F8707BA6 /* MTICoreImageRendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		873753913B9DD6C6C4B048FF3FEF2293 /* MTITransformFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 122D351C6553FCA95C13D8901DDBFE9C /* MTITransformFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8752A26D6B9EB7597F1F063A1B617A48 /* MTIMPSConvolutionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = CDC6174B55D968D88043CD874E26FE76 /* MTIMPSConvolutionFilter.m */; };
+		880E7C61DB72477BEBA50DB913D92489 /* MTIMPSDefinitionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 95749359434BE4A174EA5690D86A960B /* MTIMPSDefinitionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		880F6B6175C316D98F7C78913AF2443A /* MTIRGBToneCurveFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 75F8C0942B51125AD7896B3A1F810DBB /* MTIRGBToneCurveFilter.m */; };
+		881C63463559B938506B0A4DF1D59168 /* MTIImageProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = 46925C6E8619FE7B523F2A05441ABB84 /* MTIImageProperties.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8962B28248CBD49341D47BAEDF60E390 /* MTITransformFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 122D351C6553FCA95C13D8901DDBFE9C /* MTITransformFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A99B7EE7CFFA61D7926C139174A506D /* MTIHighPassSkinSmoothingFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 3474061DE51631140016C74F20E26242 /* MTIHighPassSkinSmoothingFilter.m */; };
+		8B3F0CAF9B4C645C92D588683BC3F682 /* MTIMPSBoxBlurFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 81F9877F1AED144A6E2A911FF7013E1F /* MTIMPSBoxBlurFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BE7B99DD305F2EE50717458C3A99367 /* MTIHasher.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BDF177600159053D248158B2F1CF945 /* MTIHasher.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		8C30616E7DB0A2BDE4C22FD594203806 /* MTIMPSSobelFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9228D838D1402FD80B9E9D97A17D1FEE /* MTIMPSSobelFilter.m */; };
+		8D2D3D9805B50EC6006F8A0468A17DA5 /* MTIRenderPipeline.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E324DCB3CD1BE72BB6EE47DFDBA470 /* MTIRenderPipeline.m */; };
+		8D6858E70D6707C7AA744CFE1D68226F /* MTIRenderPassOutputDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 74B6B717A8E378D75CBA474EFD8C90F3 /* MTIRenderPassOutputDescriptor.m */; };
+		8DD499221203C7E39C07E5DF47AE3045 /* MTILayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BA3FB75D4EDB0260464604294862462 /* MTILayer.m */; };
+		8E5A6C0979F07C1A038F493A614E0CF5 /* MTIFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 83E81065F318F10E0C0C2A9BBD0812CD /* MTIFilter.m */; };
+		8EEF0D9CECD56BC2943AF1A27888006F /* MTIMPSDefinitionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = BEAFE3992F336768B1CEEBB0A76790B4 /* MTIMPSDefinitionFilter.m */; };
+		8F6AD56017A454DF1F6E892C3EC63240 /* MTIDotScreenFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 74412C1EFB36C00783733AF41B2254A4 /* MTIDotScreenFilter.m */; };
+		90069D12DC39B82D513EFFC0B2185B2D /* MTIComputePipelineKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 636D0E86122B800AC26534C969A4B20C /* MTIComputePipelineKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		908F1176FE75A34C8539E1926FB318FC /* MTIError.h in Headers */ = {isa = PBXBuildFile; fileRef = 051D63EB3BDF7FD714F71DC83B48597F /* MTIError.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		909B6F7E155CEFC4FD5CD69BD80FCB5B /* MTIMemoryWarningObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C9B4C7F349CB63D814E673B0385E152 /* MTIMemoryWarningObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		91DF5CD6327F01757CB97E5FCCC861C1 /* MTIColorMatrix.h in Headers */ = {isa = PBXBuildFile; fileRef = 2113C68ECC76617CFF10C9943A984B3A /* MTIColorMatrix.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		92708544F61538D9351B66AF3CB6796A /* MTIContext+Rendering.h in Headers */ = {isa = PBXBuildFile; fileRef = 16F169838B041AEC2503766D7B9CD801 /* MTIContext+Rendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9294E8D4490280AABB7E56B72504742E /* MTIColorLookupFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BA57A817A151A6B179EEFE3DC8C8 /* MTIColorLookupFilter.m */; };
+		92AA0B7556FDDCFE12491D5B1119B397 /* MTIMPSHistogramFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 24687AF624C1F2D905A5319C44B27222 /* MTIMPSHistogramFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		92AB75471CE1F089D321F762279FDB74 /* MTIMPSGaussianBlurFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8DE0D3B0E0C70FD0B6DE5895132A966F /* MTIMPSGaussianBlurFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		92B538EEE791DB9C482183532B202E88 /* MTIContext.m in Sources */ = {isa = PBXBuildFile; fileRef = BB25E2412ACAF0CD6ADE8C60161DC127 /* MTIContext.m */; };
+		9394EA579F531B6F2CF402C902680C0E /* MTIBlendFormulaSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = B49289A3A6CD192DB7537DE4D733EB0F /* MTIBlendFormulaSupport.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		94F9DD9B8CCA5B85811575294F49006E /* MTIBulgeDistortionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E49E9EF077B9155BAAAC3B46EF97BB5 /* MTIBulgeDistortionFilter.m */; };
+		961341E7B0469D189E70A94BF05D7DFE /* MTIRGBColorSpaceConversionFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A33495C292E252A024DFFB0ABD59052F /* MTIRGBColorSpaceConversionFilter.swift */; };
+		96E98B5638483D4146F02B8FF3EA2520 /* MTIDataBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6FC792FC8DAC9313C20C8F3E2441230 /* MTIDataBuffer.swift */; };
+		97B17CD6C5A5010F4B2EE8428CEF0DC6 /* MTIContext.m in Sources */ = {isa = PBXBuildFile; fileRef = BB25E2412ACAF0CD6ADE8C60161DC127 /* MTIContext.m */; };
+		9841CEB8EC0983B4A28C78FDD7B1595B /* MTIVertex.m in Sources */ = {isa = PBXBuildFile; fileRef = F2CC0881E4DEACE9488067D24EC8211C /* MTIVertex.m */; };
+		98725DE008B41C7A6C43C45B85AAC8A5 /* MTIDataBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6FC792FC8DAC9313C20C8F3E2441230 /* MTIDataBuffer.swift */; };
+		990039B4799817ABBEEB9D8579D00566 /* MTIGeometryUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = C9517BE2D20FDC257C0E979C3D005ABD /* MTIGeometryUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		99115A419C9B8F0F8D2D28B681D03097 /* MTIFunctionArgumentsEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 98D888EDA81E8D36B9F3FDB956083B4E /* MTIFunctionArgumentsEncoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9986EFBAABD96936C4A01FECA51A04F8 /* MTIAlphaPremultiplicationFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 19530138A14BA035658FDA26478FA30C /* MTIAlphaPremultiplicationFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9993A1E0147E28BF76960819CE59D638 /* MTIBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = A7D86EC9A144CA5053311A41AF060C52 /* MTIBuffer.m */; };
+		99E212F22BFE3079D4AF999F8AE2D7A3 /* MTICVMetalIOSurfaceBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D06881FE11756F8FCEE425B28617CAB /* MTICVMetalIOSurfaceBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9A19FDFF0109887E6EEA9B5BF0456FF0 /* MultilayerCompositeShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = ADF6D517190D4C74DE44CB5CBB62F3F4 /* MultilayerCompositeShaders.metal */; };
+		9A782A36FADEB8B028E406B97744971A /* MTITransformFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F35D202C320154242070FF675337283 /* MTITransformFilter.m */; };
+		9B313CE9AF39A480C47FE7A48CF8E776 /* MTILibrarySource.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A4F479B562C11E2F3621E63CEB019D3 /* MTILibrarySource.m */; };
+		9B39DD1A64F9A25F9B36C700CA7CC765 /* MTIRenderCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 87CF9D85C1CDA7AB97AE28528E55DAD4 /* MTIRenderCommand.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B4E8C417D0624BE642B3C5E0EAAD975 /* HighPassSkinSmoothing.metal in Sources */ = {isa = PBXBuildFile; fileRef = F4E59C977E0B5CB6322A12F776BF54DE /* HighPassSkinSmoothing.metal */; };
 		9BE3B9C98A5DECC4EF2C268D6C6DEC59 /* Pods-MetalPetalExamples-MetalPetalExamples (iOS)-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B1A14DB602D57996D1D022784D8E566 /* Pods-MetalPetalExamples-MetalPetalExamples (iOS)-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9C09918844C0E52D47FC1E6349AC8261 /* MTIHighPassSkinSmoothingFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 10D221A98BB3A4F75B78622BF5C6AD31 /* MTIHighPassSkinSmoothingFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9C0E01A1ADC2A6995C96399FE73B04B0 /* MTIMPSKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BB4C749C706E442C8638B3D5C60A200 /* MTIMPSKernel.m */; };
 		9C5C1B064F455FDCE09937C79820EFA6 /* Pods-MetalPetalExamples-MetalPetalExamples (macOS)-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 24B743E8F48899C356C8AC672FAD42F1 /* Pods-MetalPetalExamples-MetalPetalExamples (macOS)-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9D30A607CD0AEC49D227C7D4E1E84C29 /* MTITransform.m in Sources */ = {isa = PBXBuildFile; fileRef = E2DA2F1560A31253421ACC61AB910417 /* MTITransform.m */; };
-		9D39D7E5BEEF9A70053613CA9B962030 /* MTICoreImageRendering.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D93BA2041D727345B32AED92BC262FA /* MTICoreImageRendering.m */; };
-		9D75CE4EDFB89C6FCA576A63B2EED415 /* MTIRenderPassOutputDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 43358EE79231F2E49FDDB8F9707CD707 /* MTIRenderPassOutputDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9E8B509E0DFEEE2FB039EE18DDF43D94 /* MTIBulgeDistortionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E49E9EF077B9155BAAAC3B46EF97BB5 /* MTIBulgeDistortionFilter.m */; };
-		9F0AB5C4AFA459A8ABA9BA8FD5F6CC67 /* MTIRenderPipelineKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E9E75E54B2DDB8E89F445A0E55F55B2 /* MTIRenderPipelineKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A020E1152EB34114CA0BF7B729199A96 /* HighPassSkinSmoothing.metal in Sources */ = {isa = PBXBuildFile; fileRef = F4E59C977E0B5CB6322A12F776BF54DE /* HighPassSkinSmoothing.metal */; };
-		A023495D7F1D193BA832B887CEFAA4C2 /* MTIBlendFormulaSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = B49289A3A6CD192DB7537DE4D733EB0F /* MTIBlendFormulaSupport.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		A024051E78B15F2C9E599BD5289300A9 /* MTIHexagonalBokehBlurFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C73EBFE35DEABDFEBE99D9859B30C96 /* MTIHexagonalBokehBlurFilter.m */; };
-		A1CF226E79488717F9932DBE76F21187 /* MTIGeometryUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = C9517BE2D20FDC257C0E979C3D005ABD /* MTIGeometryUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A261CCB3C0E50D47DC7EF0A3DC226154 /* MTICropRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3F1D22604D4CE74FD6D91A6A00126F /* MTICropRegion.swift */; };
-		A2C4D7B6686D0070C4FD7AF81D739D0F /* MetalPetal.swift in Sources */ = {isa = PBXBuildFile; fileRef = F575DD21FD663D8B548ED1F872590F12 /* MetalPetal.swift */; };
-		A348802E2902AFFD9F1385AB64F8E6EB /* MTIBlendWithMaskFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 715856E3A7AC731446F51596360D7131 /* MTIBlendWithMaskFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A442BC2A79A3BC9D4A77079E65677365 /* MTICVPixelBufferPool.h in Headers */ = {isa = PBXBuildFile; fileRef = B3453C3DF38A3143DE7CABCE3235B93E /* MTICVPixelBufferPool.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A49191B675AC69E53524D8B8B6C6268F /* MTIVideoComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = C064D3006B9D3DA837E6A324043937EF /* MTIVideoComposition.swift */; };
-		A4CAA351E3F87AF17A354CF61D24D633 /* MTIMPSConvolutionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 07A8FE33257602CA9AF1A0401B917E72 /* MTIMPSConvolutionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A63A7045504D3BE134526C35B19E2938 /* MTIDotScreenFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 74412C1EFB36C00783733AF41B2254A4 /* MTIDotScreenFilter.m */; };
-		A749AF1CA6316C7CD442552715E17793 /* MTIImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2583F32A03FF818D26995B1976152D32 /* MTIImageView.m */; };
-		A7FA7201D8025947B64F76A8954CC92A /* MTIRenderPipeline.h in Headers */ = {isa = PBXBuildFile; fileRef = 51A388571970F41F8AF173376B80987D /* MTIRenderPipeline.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A81C0CFF887B19B20E86555C12E7461B /* MTIMPSGaussianBlurFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 3110866B775237BA40999C9445438BC1 /* MTIMPSGaussianBlurFilter.m */; };
-		A8F2565CAD6DA68FC84137F4DA471DC1 /* MTIDotScreenFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 74412C1EFB36C00783733AF41B2254A4 /* MTIDotScreenFilter.m */; };
-		A9DDB5898C3151CA01EC26A518937A63 /* BlendingShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 6523B084669CA8E9CDA5E2EDF1011A04 /* BlendingShaders.metal */; };
-		AA05CD1D535797A5D2E3EFBEC25FF3ED /* MTIImage+Filters.m in Sources */ = {isa = PBXBuildFile; fileRef = 96185B1FA2E19E616A79D99EBAD22DE2 /* MTIImage+Filters.m */; };
-		AA69FE500323D52CE779B92F7D084FC7 /* MTIAlphaPremultiplicationFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 22EFDD084C13F0A0946FC47579BEA725 /* MTIAlphaPremultiplicationFilter.m */; };
-		AB81652CA633D7A5192CBD24C35C6082 /* MTIRenderPipelineKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E9E75E54B2DDB8E89F445A0E55F55B2 /* MTIRenderPipelineKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AB9CC381F1653F9EA944F0478BFDFBD6 /* MTICoreImageRendering.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D93BA2041D727345B32AED92BC262FA /* MTICoreImageRendering.m */; };
-		ACA192BC51012CAEE5255D0608A04521 /* MTIFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 83E81065F318F10E0C0C2A9BBD0812CD /* MTIFilter.m */; };
-		AD04BABB6A85F5E89F1B5AFD59BA9B01 /* MTIKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 213784EC8936904929EA1A3380E503CB /* MTIKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AD0797D54CEA885EE3A6669CE82D1438 /* MTIMPSSobelFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = DCAFD03727F6E904E3AEEAAC1CC1BE97 /* MTIMPSSobelFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AE0D730CCDDDC133A05AB08A86F317F3 /* MTIImage.h in Headers */ = {isa = PBXBuildFile; fileRef = BFE0E806B256BB3A9700DB5FD424B6A9 /* MTIImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AECD1D904D46F9E33D899B95B7BED47C /* MTISCNSceneRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = D4594ED8316E9485C8D047368DF9F011 /* MTISCNSceneRenderer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B015ECA845E1233B0C78FEC535B91689 /* MTIHighPassSkinSmoothingFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 3474061DE51631140016C74F20E26242 /* MTIHighPassSkinSmoothingFilter.m */; };
-		B129DD269C931E7FF8E01DED3873DA69 /* MTIMemoryWarningObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 07AD86FA01273A5DF7B6F27A8378DEE9 /* MTIMemoryWarningObserver.m */; };
-		B133905F1758DED6E1F87A0B57505D67 /* MTIFunctionDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80BF9AB8BCA2347EC148983914AADDE3 /* MTIFunctionDescriptor.swift */; };
-		B21A371F70104DD25F53D0D432493ECE /* MTIComputePipeline.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B4973445B351C5ABB6B85FFF825EA3E /* MTIComputePipeline.m */; };
-		B2356EB9EE112C918FADD43A9F375CA0 /* MTITextureDimensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 794AD47DC7253C8C95184268C61F021D /* MTITextureDimensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B2459D436BFB6A892C054DC23A4305F4 /* MTIPixelFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 42FDD1B7319AB7FB6CD09EF5EA835EFD /* MTIPixelFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B27537A041973A588719C19A0147D5FC /* MTIContext+Rendering.h in Headers */ = {isa = PBXBuildFile; fileRef = 16F169838B041AEC2503766D7B9CD801 /* MTIContext+Rendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B37698AAB1A6AA94D1CB41BD963461AE /* MTIRGBToneCurveFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0911B26BFD8E1F38ADA0E35009DC0F7F /* MTIRGBToneCurveFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B3BF96FE6AC50C7C8FC86DE20C91E800 /* MTIImage.m in Sources */ = {isa = PBXBuildFile; fileRef = DEE8949D1E9AB7CB65D47C5DFC0E7B47 /* MTIImage.m */; };
-		B40B7784ACFA366B2866BF6CD6A4909F /* MTIDefer.h in Headers */ = {isa = PBXBuildFile; fileRef = F3127DA534F8DF0893392C62B3969338 /* MTIDefer.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		B44FF2A6ABEBA848E82E080459FBB942 /* MTIImagePromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 43476F2131AD4026877FB1245806E517 /* MTIImagePromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B478AFFDFCD2910D1D95282CB68C3AE5 /* MTIAlphaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 309CD50F9862DED7227D1567139AA70F /* MTIAlphaType.swift */; };
-		B48BC46DE2BED62089A4C536892752EB /* MTIImagePromiseDebug.h in Headers */ = {isa = PBXBuildFile; fileRef = 959AA90E0BA3DFD21C72EC8D1E2DBCE0 /* MTIImagePromiseDebug.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B5388D28E94B7E9BD88DECB28258CD3D /* MTIShaderFunctionConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C04E14334C83E8E5F89CB3DA2D0346 /* MTIShaderFunctionConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B68BAD4717026E6222CAAAB5615109F3 /* MTIContext+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ED6E8A8BF705A94647F4A0253AC81DB /* MTIContext+Internal.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B6F3AF992392B4BDB2E5D7F8AEE6E531 /* MTIFunctionDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80BF9AB8BCA2347EC148983914AADDE3 /* MTIFunctionDescriptor.swift */; };
-		B70EFC4DEB9A48E35A966FB12D957FFD /* MTIMPSSobelFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9228D838D1402FD80B9E9D97A17D1FEE /* MTIMPSSobelFilter.m */; };
-		B80C3FFDFF487C18DB36CC687A691C3E /* MTIMPSGaussianBlurFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8DE0D3B0E0C70FD0B6DE5895132A966F /* MTIMPSGaussianBlurFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B98343512DE7AAE6558F466DCC13387D /* MetalPetal.h in Headers */ = {isa = PBXBuildFile; fileRef = 668F9CB3802E4923A02CBE9E39CE5697 /* MetalPetal.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BA879B5C02079832FF4A5D1E76E9E7F0 /* MTIImagePromiseDebug.h in Headers */ = {isa = PBXBuildFile; fileRef = 959AA90E0BA3DFD21C72EC8D1E2DBCE0 /* MTIImagePromiseDebug.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BAB98820BEF4DB24FEAD1902C2070FD7 /* MTIImageProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = 46925C6E8619FE7B523F2A05441ABB84 /* MTIImageProperties.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BC309ADCE8A9C6816576F15C9228457F /* MTIWeakToStrongObjectsMapTable.m in Sources */ = {isa = PBXBuildFile; fileRef = 34C98F4575D79C98DB8181EAB01C2291 /* MTIWeakToStrongObjectsMapTable.m */; };
-		BC7135DB182F8695039FB0B1D1AA8035 /* MTIVector.h in Headers */ = {isa = PBXBuildFile; fileRef = 080D39D554DC6A497F3CB775865C8E8A /* MTIVector.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BC759203DE25F8CABFEC679AA59632B3 /* MTISIMDArgumentEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C6D6B1CC643746D5CDD2B27BE716F3 /* MTISIMDArgumentEncoder.swift */; };
-		BCE53E7AEA186E7A81CED81C96E75A0A /* MTIMultilayerCompositingFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DE853D3835AB5F13B27DAED6A25E0D7 /* MTIMultilayerCompositingFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BD1006FCD2B03A1824699D9D3F5E816E /* MTITextureLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 5382AA7FFB422306848695FF7CD61737 /* MTITextureLoader.m */; };
-		BDD940CA8CA856C3277A8187FFA21BA6 /* MTIMPSKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = B16EBC2392F758D3E1790251BD64BC71 /* MTIMPSKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BDDA623E1C4F9A9DDDFC5DBB4827F157 /* MTITransformFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 122D351C6553FCA95C13D8901DDBFE9C /* MTITransformFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BE1A4C0C2030A31AE7EF062837457AA5 /* MTIColorLookupFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BA57A817A151A6B179EEFE3DC8C8 /* MTIColorLookupFilter.m */; };
-		BE5A3C32D2E36DF16F19E53063CAE679 /* MTIComputePipelineKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = 486F3616A35FFFF2B285411311709F7F /* MTIComputePipelineKernel.m */; };
-		BE6F1DEDE7CC5A79443383CC31BFC084 /* MTILibrarySource.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A5A91B6B2C1086D66D70D0EC1A15246 /* MTILibrarySource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BE8AED7B1CBB7287E2884385F46CAEC7 /* MTIHighPassSkinSmoothingFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 10D221A98BB3A4F75B78622BF5C6AD31 /* MTIHighPassSkinSmoothingFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C203AE665E7FF52DF25605F1FEFD279A /* MTIVertex.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F4F8A8596485C0273B699F1E2BF14C3 /* MTIVertex.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C334BD8A26E873B1B2E0B573A585500D /* MTIBlendModes.h in Headers */ = {isa = PBXBuildFile; fileRef = C17A0628178212F76DCE9680877FA412 /* MTIBlendModes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C36B8004C4BD508F411EF9B809A4A392 /* MTIColorLookupFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6255D81F38B30694A9DB957329C7108F /* MTIColorLookupFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C61A3B9E7D7DA5DBF158E0545CC57AFA /* MTITransform.h in Headers */ = {isa = PBXBuildFile; fileRef = BE3AD47A5E5845568DFDE2162773821F /* MTITransform.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C669686749AEF704E634FA9BFA01FCEA /* MTIColorMatrix.m in Sources */ = {isa = PBXBuildFile; fileRef = 000A839435C68C96FE3A15FC42A3D96B /* MTIColorMatrix.m */; };
-		C67D6855E3410532CAAA132ADD47C2FA /* MTICVPixelBufferPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = EC826C41089341DF8216FEEABA77CEF1 /* MTICVPixelBufferPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C6B1A0F0671741EAB4579BD3FA9466BF /* MTIMPSDefinitionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 95749359434BE4A174EA5690D86A960B /* MTIMPSDefinitionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C863C90097DCAA28E7F89B9DB17C5BE7 /* MTICVMetalIOSurfaceBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 59DB6169E28AC4E89FD4E28C17D075A1 /* MTICVMetalIOSurfaceBridge.m */; };
-		C8D74F95BC303CF6204D0067F01BAF58 /* MTIRenderTask.m in Sources */ = {isa = PBXBuildFile; fileRef = A76A116553C936D5987440E70163392C /* MTIRenderTask.m */; };
-		C8FAE693A2D4FC10AB3A42CB2D1D73F5 /* MTIContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = E89795823431E721A98D88072DB54991 /* MTIContext.swift */; };
-		C91697B61939E288B4489C59744A4643 /* MTIImageProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = 46925C6E8619FE7B523F2A05441ABB84 /* MTIImageProperties.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C9EABAE65A3762B9A0889EABBC45E0C7 /* MTIColor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BC89A2032F2F966D1A77702264B23EA /* MTIColor.m */; };
-		CA3B127A03C92DBCE54D7FF9F1DCFBA3 /* MTIDataBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 556074EB4DCE458E9FFDA0303F008462 /* MTIDataBuffer.swift */; };
-		CA552E7F8AC48761249DEECF8ABED5CD /* MTICVMetalTextureCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 61F8DE758E4EA6C7C8A2611F5F048193 /* MTICVMetalTextureCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CA631F8CE939DC9048100FD7098B08CA /* MTIBlendFormulaSupport.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3648315ED673AAF957616C8B8B7B225F /* MTIBlendFormulaSupport.mm */; };
-		CBED7FDC4560A4BFC336FA9850C4C448 /* MTIBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = A7D86EC9A144CA5053311A41AF060C52 /* MTIBuffer.m */; };
-		CCEEBA81DBE75E3F2A3B215E500F71A5 /* LensBlur.metal in Sources */ = {isa = PBXBuildFile; fileRef = 0C1080D7E7CFD3D7141B80C5FDDCCBD1 /* LensBlur.metal */; };
-		CD33FF4D0EBDD1445B3A6CC1D2D6B6D5 /* MTIThreadSafeImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 994294A7C1F35F53E1FECEC65BB8E8C3 /* MTIThreadSafeImageView.m */; };
-		CDC8DEA6013DA7D26BC2DA43A93EE04E /* MTIMultilayerCompositingFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 73170EF91BB7AC39B8E7F1C4DB9B266F /* MTIMultilayerCompositingFilter.m */; };
-		CFB366C3C2C168CD389E23E55D155AAC /* MTIImagePromiseDebug.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E7E883A98F26CDC01465914462E3B45 /* MTIImagePromiseDebug.m */; };
-		D048A3FE227FCF120E1149F9F333AD8C /* MTIBlendWithMaskFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 715856E3A7AC731446F51596360D7131 /* MTIBlendWithMaskFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D0BF72DB307B321971DD89EAFF1BD425 /* MTIGeometryUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = C9517BE2D20FDC257C0E979C3D005ABD /* MTIGeometryUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D10D006636A708D3E55917D7257B9FEE /* MTILock.h in Headers */ = {isa = PBXBuildFile; fileRef = DE4504BC5F4A6A410885244736A7FAE4 /* MTILock.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D266F0E9FCB5913B9B0B0170CD00CDEB /* MTIVideoComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = C064D3006B9D3DA837E6A324043937EF /* MTIVideoComposition.swift */; };
-		D26DA200AEA91EA93DC542B52DF3CEC7 /* MTIContext+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ED6E8A8BF705A94647F4A0253AC81DB /* MTIContext+Internal.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D298E97ED6B07B4282C3740DE7FDE625 /* MTIPixellateFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 24A7D70F51687F71F429BB6A04EF89BA /* MTIPixellateFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D327C8F05D85F2A81E445C8CF076E107 /* MTIBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AA4B41672F25730E0F1CBA46DD85880 /* MTIBuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D4D5540613C18C68D4D25ECEFC406882 /* MTIFunctionDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C6A19F5CDB52E0EDA8D1B3220F0E81 /* MTIFunctionDescriptor.m */; };
-		D510F7852781538B0E70A5B88ADB8D93 /* MTIImage+Filters.m in Sources */ = {isa = PBXBuildFile; fileRef = 96185B1FA2E19E616A79D99EBAD22DE2 /* MTIImage+Filters.m */; };
-		D6063BFCE67011CC10CF15B1DF3BBD57 /* MTITextureDimensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 794AD47DC7253C8C95184268C61F021D /* MTITextureDimensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D6D4E41E17D091DD418FFED3CE044D74 /* MTIColorHalftoneFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 46979D946C597284368024105C6667E2 /* MTIColorHalftoneFilter.m */; };
-		D6FA89E4B0F0A8A6FCAFBF86DB34A57C /* MTIColorMatrixFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E30A6C224349F690A77D74AC3F1C156 /* MTIColorMatrixFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D70DBF42631072638ECD8502D9FE8F98 /* MTIDefer.m in Sources */ = {isa = PBXBuildFile; fileRef = 89933E584BCEDC968272B351AC127B46 /* MTIDefer.m */; };
+		9D3BDDCF2161C73B8094883CE714E731 /* MTICVPixelBufferPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = A0851268EA397439AA5B729FB3DC633F /* MTICVPixelBufferPromise.m */; };
+		9D84931313A180BE61AA4A95ED732F44 /* MTIVertex.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F4F8A8596485C0273B699F1E2BF14C3 /* MTIVertex.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9E6B52EBCDEB40F7868F93B29E8244DD /* MTIImageOrientation.h in Headers */ = {isa = PBXBuildFile; fileRef = 37246B9D8C729D40CDA3AB0967DD05D6 /* MTIImageOrientation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9E90A614B03AF9D2B1D04BD2B1ADB5D7 /* MTILibrarySource.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A5A91B6B2C1086D66D70D0EC1A15246 /* MTILibrarySource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F418D003BE792959C13EA97BE705F78 /* MTIGeometryUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = DCA6512368E6D9B20E3784A213050F9F /* MTIGeometryUtilities.m */; };
+		A1677E4B27AA7526B0EE37B5488C33F0 /* MTITexturePool.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7ABCB697CFDD9B0CA7CBE2DEB6EECC99 /* MTITexturePool.mm */; };
+		A184BA4046FFC3795AC5D0741DF0FC5A /* MTILayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BA3FB75D4EDB0260464604294862462 /* MTILayer.m */; };
+		A18C78340359D82080998067659DDB07 /* MTIComputePipelineKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = 486F3616A35FFFF2B285411311709F7F /* MTIComputePipelineKernel.m */; };
+		A36F2BB9C8393BD24CD8B64FDB1A32B8 /* MTIVideoComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB873C68D2563D202B0F6A5A1BCFB89 /* MTIVideoComposition.swift */; };
+		A4DAC8B16BECD40E851CCBAD27DBF416 /* MTILibrarySource.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A5A91B6B2C1086D66D70D0EC1A15246 /* MTILibrarySource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A532DAC0E30050A0B8D2C6CD7D375E14 /* MTIImage+Promise.h in Headers */ = {isa = PBXBuildFile; fileRef = 08B5E898FC12525182B5795434255D8B /* MTIImage+Promise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A5B5DB881944D26B087C906EB23B8170 /* MTIPrint.h in Headers */ = {isa = PBXBuildFile; fileRef = DDAE8FEA0BDC7BF6466286F2E1FC3B99 /* MTIPrint.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A600519F97F7D39C588D2FF6FA414A4F /* MTISamplerDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 840B7117FC626722A3F57ECB3DF7D3EF /* MTISamplerDescriptor.m */; };
+		A67AC3B937DC92EF8F36CD4B671E1715 /* MTIMPSBoxBlurFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = CC06F9F088B6E4F8C91E664F093FEA05 /* MTIMPSBoxBlurFilter.m */; };
+		A739A322716EC32D2B81E3BD73389A4D /* MTIDefer.h in Headers */ = {isa = PBXBuildFile; fileRef = F3127DA534F8DF0893392C62B3969338 /* MTIDefer.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A7A15339B0581DFB41C3010B50C530F2 /* MTIGeometryUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = DCA6512368E6D9B20E3784A213050F9F /* MTIGeometryUtilities.m */; };
+		A872665BB24D23EB9E830A566A9D56DA /* MTIMPSBoxBlurFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 81F9877F1AED144A6E2A911FF7013E1F /* MTIMPSBoxBlurFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8B45C69DC089756F2BA0D47AD6C164F /* MTIMultilayerCompositeKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9BAFF05C5720FC8E639F84631D8A92 /* MTIMultilayerCompositeKernel.m */; };
+		A904BF1FCD237F6CE7AE4CFCFB4FD639 /* MTIImage+Filters.m in Sources */ = {isa = PBXBuildFile; fileRef = 96185B1FA2E19E616A79D99EBAD22DE2 /* MTIImage+Filters.m */; };
+		AA53B3B53F102D7D5B9F0975EB1E304B /* MTIVertex.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17E826B5869A8EDA5DCD3EBE5940963 /* MTIVertex.swift */; };
+		AA5FB6E39C03374B3A37FE243FD6EDA7 /* MTICVMetalIOSurfaceBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D06881FE11756F8FCEE425B28617CAB /* MTICVMetalIOSurfaceBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA9978F2C6D5D49899F091E63ABCACA4 /* MTIMPSConvolutionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 07A8FE33257602CA9AF1A0401B917E72 /* MTIMPSConvolutionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AACD66B187AEC5AE6504287A3C63D238 /* MTIRenderGraphOptimization.m in Sources */ = {isa = PBXBuildFile; fileRef = B24021FF880799F5045E921C14BF0CC6 /* MTIRenderGraphOptimization.m */; };
+		AB43E317B401DFE5E2CA07827AAB3392 /* MTIFunctionArgumentsEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B74E8D6ABC0443FEED3026CD1E7B0D8 /* MTIFunctionArgumentsEncoder.m */; };
+		AB5B2824CCA68CB9B576BC93172F521C /* MTICVPixelBufferPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = EC826C41089341DF8216FEEABA77CEF1 /* MTICVPixelBufferPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AB70A30F19371A7C855BEBFD65A3DB32 /* MTIRGBColorSpaceConversionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = E112C9A658F6EC9D4035225C3BF9B8A9 /* MTIRGBColorSpaceConversionFilter.m */; };
+		AD01054ACCA7E09FB7D67AEDB3808C3B /* MTIHexagonalBokehBlurFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C73EBFE35DEABDFEBE99D9859B30C96 /* MTIHexagonalBokehBlurFilter.m */; };
+		AEAF25ECF3949A56BA5CC6D11EDD10E1 /* MTIImage+Filters.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E65CFF8EB5573CC2B9608216CD44E6 /* MTIImage+Filters.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AEE71825000F79C9B721D4C3CBF743D5 /* MTIHexagonalBokehBlurFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DB916AE474D5DE53D48E82391A70EA0 /* MTIHexagonalBokehBlurFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AF9FC7C8FF3DB229FE3C5EC386BED6ED /* MTICorner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C94F2509FBD062966808822E78CDA1 /* MTICorner.swift */; };
+		AFB47F0AACC0D0358AF9356E5CA8A661 /* MTIDrawableRendering.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B4FEB15A3332424BCC298AE3FE9BA /* MTIDrawableRendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B12409791B21A12977B4B0FBC13836C4 /* MTICVMetalTextureCache.m in Sources */ = {isa = PBXBuildFile; fileRef = C7905C9FDAA58B78BC083B0E2854C505 /* MTICVMetalTextureCache.m */; };
+		B162FDD6F387A6B4ADE1F1D956762FED /* LensBlur.metal in Sources */ = {isa = PBXBuildFile; fileRef = 0C1080D7E7CFD3D7141B80C5FDDCCBD1 /* LensBlur.metal */; };
+		B188397690802DEAEE8DAB9DE46CE38F /* MTIAlphaType.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A2A655423DC9C5706746A359AD4E0CF /* MTIAlphaType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B277F343DBE9945CB16A4DC0AA2C66B7 /* MTIMask.h in Headers */ = {isa = PBXBuildFile; fileRef = 23714C569A0099951BDF5DF5BBABA50A /* MTIMask.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B30E704D4DC154A5E9D119247954F7DF /* MTIBlendFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = FEBC1D778C54B5F25FF83E52DEB4AB69 /* MTIBlendFilter.m */; };
+		B395B1A687997F0A8E7092EBEAF229EA /* MTIMPSUnsharpMaskFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CA228D8091B478FDDCEC8727EA8F208 /* MTIMPSUnsharpMaskFilter.m */; };
+		B4466C033EE1A7414FC8070DB099B770 /* MTIContext+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ED6E8A8BF705A94647F4A0253AC81DB /* MTIContext+Internal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B4D10B7800EE12ACAA67A81261252979 /* MTIColorMatrixFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 64B2FA89E379A1E21599B10A8112AC5D /* MTIColorMatrixFilter.m */; };
+		B4D5152126B2A5FEF2CDBE919B2C568C /* MTIImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2583F32A03FF818D26995B1976152D32 /* MTIImageView.m */; };
+		B5AE7E5EAC54C63AF60CE2D6146DC0F6 /* MTIGeometry.m in Sources */ = {isa = PBXBuildFile; fileRef = 50D57FA9342F44FD185167A3568EB56E /* MTIGeometry.m */; };
+		B616A7F0B9E47C542A33A3163E6FF2BB /* MTIRoundCornerFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = A3D9326B2142633F71EA01F126995043 /* MTIRoundCornerFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B618A49BF8EDC18160836426E4971075 /* MTITextureLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 5382AA7FFB422306848695FF7CD61737 /* MTITextureLoader.m */; };
+		B62A224658E746D92A58077DF3C3035B /* MTICropFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = C3C52A774103E9679118BB50F6D10E55 /* MTICropFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B660BB0A0498CF4E4E959B5B39E48F24 /* MTIColorMatrix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D2796D5C6FDC685BEFA6996CC75C4B /* MTIColorMatrix.swift */; };
+		B6A085D2E14A787608F011BFE09A545F /* MTISamplerDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A140A5542FB46FDEC00FF8D7BC0929E /* MTISamplerDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B7ACDEE348601FA182CC35ADA30B2282 /* ColorConversionShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = F094BEC497F8B03C8652DF126F546372 /* ColorConversionShaders.metal */; };
+		B812CBD811BA15D869CF86A0411D0326 /* MTIRenderPassOutputDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 43358EE79231F2E49FDDB8F9707CD707 /* MTIRenderPassOutputDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B8D41863B63B74FA8EE8A218D6898A4F /* MTIColorMatrix.h in Headers */ = {isa = PBXBuildFile; fileRef = 2113C68ECC76617CFF10C9943A984B3A /* MTIColorMatrix.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9406A933C26C92F26CB036623454A98 /* MTICoreImageRendering.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D93BA2041D727345B32AED92BC262FA /* MTICoreImageRendering.m */; };
+		BAC9BC8DC4A8F3ABC3A5C3B243217539 /* MTIContext+Rendering.m in Sources */ = {isa = PBXBuildFile; fileRef = 44F34F35B06446E94AF6887EFE559097 /* MTIContext+Rendering.m */; };
+		BAD5BBE765C104D4A13F9F3B21F5ABD3 /* MTIAlphaType.m in Sources */ = {isa = PBXBuildFile; fileRef = C34ED5A0B8F0040BCA7FF07F063F4AA6 /* MTIAlphaType.m */; };
+		BC1057E8FD90B96C541999859CBFE95B /* MTIMPSDefinitionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = BEAFE3992F336768B1CEEBB0A76790B4 /* MTIMPSDefinitionFilter.m */; };
+		BC8625A6C9CF967A2FAD34B838CA4BC4 /* MTIBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AA4B41672F25730E0F1CBA46DD85880 /* MTIBuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BCCFB0882B8D8EC52E7014B6F26BFCED /* MTIPixellateFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 24A7D70F51687F71F429BB6A04EF89BA /* MTIPixellateFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BD1EB5D4D5724CC83AAD6FBB01C8FB11 /* MTIRenderTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A15AFE8E136AE579B2194077C8A1390 /* MTIRenderTask.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BE3D5342F1F5550025EA47482E7AA90A /* MTIColorHalftoneFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 46979D946C597284368024105C6667E2 /* MTIColorHalftoneFilter.m */; };
+		BE57DC171BD79CEEF6A1D3A2DABE06FA /* MTIError.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F7FCE08EC324401B150214C649B0C0C /* MTIError.m */; };
+		BE81720C5F5A3C809C545B5A754B1BE5 /* MTICropFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = C3C52A774103E9679118BB50F6D10E55 /* MTICropFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BEFA2D3EE29E0656A2724FB9635D0F5F /* MTIPixelFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518C430901F215C101898B2E31020C73 /* MTIPixelFormat.swift */; };
+		BFB08527C2711C9D52C05B6E4A371C10 /* MTIAlphaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1627D99729B48FFD9053B927130125 /* MTIAlphaType.swift */; };
+		C0AAD95E5CC8A8B5FFB39689D1378034 /* MTIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F68190E4178E5FA523E0CCF316E2AA /* MTIError.swift */; };
+		C0BD444822D5C6E499DF4424C5A35692 /* MTIMultilayerCompositingFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 73170EF91BB7AC39B8E7F1C4DB9B266F /* MTIMultilayerCompositingFilter.m */; };
+		C0D663B2365EDB34F1DB2375E93B8776 /* MTITexturePool.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7ABCB697CFDD9B0CA7CBE2DEB6EECC99 /* MTITexturePool.mm */; };
+		C14275823A4E160D7A6AD8E0422DDF05 /* MTIDrawableRendering.m in Sources */ = {isa = PBXBuildFile; fileRef = A6C55D2839E2E9BDCBC98E9FDBECDE3F /* MTIDrawableRendering.m */; };
+		C15239FEE52A06DAB841D1B6FB5F2699 /* MTIPixellateFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 992934579D2CE8D49CDF3DB722D326EE /* MTIPixellateFilter.m */; };
+		C158E309BCF8FD7E6F513CB5F4DDDDB2 /* MTIHasher.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BDF177600159053D248158B2F1CF945 /* MTIHasher.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		C1A4A49A5F1A406154C63B83F6E4C75E /* MTIMPSConvolutionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 07A8FE33257602CA9AF1A0401B917E72 /* MTIMPSConvolutionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C2A45906BC6B089BF57E99004088E5A2 /* MTIAlphaType.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A2A655423DC9C5706746A359AD4E0CF /* MTIAlphaType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C3E43706C02EAEA074A2196CFCA3A6E9 /* MTIWeakToStrongObjectsMapTable.m in Sources */ = {isa = PBXBuildFile; fileRef = 34C98F4575D79C98DB8181EAB01C2291 /* MTIWeakToStrongObjectsMapTable.m */; };
+		C40021B1ECC99ADEFED6DCE801DD4721 /* MTIRenderCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 907A93EBA0BDBF985570598F9ED71E85 /* MTIRenderCommand.m */; };
+		C52E6B6C0BE7423572018598E6AEB115 /* MTICoreImageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6A52788E53455D323A3C7A514A026B6 /* MTICoreImageExtension.swift */; };
+		C645A6A4DDD922CD60CA223BD18C80C0 /* MTIImageViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97E1E87D90BEC4E6991AE5AC48D888B2 /* MTIImageViewProtocol.swift */; };
+		C64DDE82D7AE6D0B517C1633128FCA89 /* MTIMultilayerCompositingFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DE853D3835AB5F13B27DAED6A25E0D7 /* MTIMultilayerCompositingFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C69CEADC9407F6B5A5128EC7A04A703B /* MTIBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AA4B41672F25730E0F1CBA46DD85880 /* MTIBuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C6B898B48E362CBECE91E2551C719325 /* MTIDrawableRendering.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B4FEB15A3332424BCC298AE3FE9BA /* MTIDrawableRendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C854054DC78A9366924A931B05FD6153 /* MTICropFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 39F1000E921A9281C763EDA10723C95D /* MTICropFilter.m */; };
+		C878B6ABCC015F6DB9E01E6591ADC770 /* MTIRenderPipelineKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E9E75E54B2DDB8E89F445A0E55F55B2 /* MTIRenderPipelineKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C9F1554DBEDB5ADC9EE699E63C4875C0 /* MTIMultilayerCompositingFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DE853D3835AB5F13B27DAED6A25E0D7 /* MTIMultilayerCompositingFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CA02D580B54B9011CA3B99D37A72AC6F /* MTIShaderLib.h in Headers */ = {isa = PBXBuildFile; fileRef = 03E34A818D7E5B628B2E20034480F7BC /* MTIShaderLib.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CA0D3D21C7F75C5B15C5D4AA2299C3CF /* MTIRenderPassOutputDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 43358EE79231F2E49FDDB8F9707CD707 /* MTIRenderPassOutputDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CA173895D5070144A83EAD93B273D3ED /* MTIRGBColorSpaceConversionFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A33495C292E252A024DFFB0ABD59052F /* MTIRGBColorSpaceConversionFilter.swift */; };
+		CA635A54824FA9468BB517E7B6BDE9C6 /* MTIWeakToStrongObjectsMapTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 77AB69D212A357773556E7A6D43B49F0 /* MTIWeakToStrongObjectsMapTable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CBBC130D51731D71C90329D66BB5421A /* MTIImageProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F03CAE7F13EF0B0CBC49493F795676C /* MTIImageProperties.m */; };
+		CC5D98727EBD58E430DA4BBA626271A8 /* MTIMultilayerCompositingFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 73170EF91BB7AC39B8E7F1C4DB9B266F /* MTIMultilayerCompositingFilter.m */; };
+		CCFFD3D23EC65D2A56943A7375456744 /* MTIContext+Rendering.m in Sources */ = {isa = PBXBuildFile; fileRef = 44F34F35B06446E94AF6887EFE559097 /* MTIContext+Rendering.m */; };
+		CE4A0E4EAB317A1D1C8FCCCCE38E839F /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D415EA68815D0046129EBDEA297DA49 /* Filter.swift */; };
+		CE9764EC9F77D755ACF803A2A0448006 /* MTIRenderPipelineKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = 440BA8D18A570D93B7ECDDA1AD4DDFFE /* MTIRenderPipelineKernel.m */; };
+		CFF2E13720B329F20147343DCD4719A4 /* MTIRenderPipelineKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = 440BA8D18A570D93B7ECDDA1AD4DDFFE /* MTIRenderPipelineKernel.m */; };
+		D01328E8D7B60A0EB0D6E13FC5903CFC /* MTIColorHalftoneFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B8619AA152D6BA49379AF7C071D3764 /* MTIColorHalftoneFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D13B2F1E81459283505C2A78441AF3F9 /* MTIVector.m in Sources */ = {isa = PBXBuildFile; fileRef = A0A2ED91C6BEFCCFAF239EE61BD05996 /* MTIVector.m */; };
+		D22205A56CC33438A714E22AA03725EC /* MTIMPSGaussianBlurFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 3110866B775237BA40999C9445438BC1 /* MTIMPSGaussianBlurFilter.m */; };
+		D273C015128948A1E9E4FADB973F44CA /* MTIMemoryWarningObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 07AD86FA01273A5DF7B6F27A8378DEE9 /* MTIMemoryWarningObserver.m */; };
+		D396CB4E5B46E5E9CFCD49F5A298B0E1 /* MTIBlendFormulaSupport.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3648315ED673AAF957616C8B8B7B225F /* MTIBlendFormulaSupport.mm */; };
+		D690B6AF2234AB165E9B61409074609D /* MTITextureDimensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F4BFC87BF26CE1113DCF16E8F8AEC9 /* MTITextureDimensions.swift */; };
+		D7247C5587A558F57EAEEB9BD635C426 /* MTILock.h in Headers */ = {isa = PBXBuildFile; fileRef = DE4504BC5F4A6A410885244736A7FAE4 /* MTILock.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D7323725F0D9F89402B08B295BC48F80 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 70E59D9D8EF41291B0C13BC330FA3126 /* Cocoa.framework */; };
-		D79AE42D444E83B9D83C82E03D4587D7 /* MTIContext+Rendering.m in Sources */ = {isa = PBXBuildFile; fileRef = 44F34F35B06446E94AF6887EFE559097 /* MTIContext+Rendering.m */; };
-		D7E8C74A3243FD5B0BBF7004F481E5EA /* MTILibrarySource.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A4F479B562C11E2F3621E63CEB019D3 /* MTILibrarySource.m */; };
-		D7F80EC3846B1AF270AD2049CFF41C33 /* MTIChromaKeyBlendFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 629081B3EE1DF76DB7BFBD81E70EF266 /* MTIChromaKeyBlendFilter.m */; };
-		D8180B5DE50EDB13270576346C362F33 /* MTIRenderTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A15AFE8E136AE579B2194077C8A1390 /* MTIRenderTask.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D87FC031C4064FBB4FF9BD7849D13BBD /* MTIRenderCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 907A93EBA0BDBF985570598F9ED71E85 /* MTIRenderCommand.m */; };
-		D8885A31AA97A44934C6D792CE715061 /* MTIComputePipeline.h in Headers */ = {isa = PBXBuildFile; fileRef = EA170FD883EA613973ED2B16D80C1EBC /* MTIComputePipeline.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D95987B1668D2AC4A9D9FEE137370028 /* MTIColorMatrixFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 64B2FA89E379A1E21599B10A8112AC5D /* MTIColorMatrixFilter.m */; };
-		D9AD5EDCFADD9A0F07E1FB0F62F3F297 /* MTIImageProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F03CAE7F13EF0B0CBC49493F795676C /* MTIImageProperties.m */; };
-		D9EBEB41276A200E9ED5BB1729E31E2D /* MTIMPSUnsharpMaskFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = D9DCB3600E15951DE046C97C55F5BE54 /* MTIMPSUnsharpMaskFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DA0E08D5BFF285E220B63365CFB45D9D /* MTIMultilayerCompositingFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DE853D3835AB5F13B27DAED6A25E0D7 /* MTIMultilayerCompositingFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DA7328D86C967063D54F11ED844D131C /* MTICVPixelBufferRendering.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EDC14FDCB24D11544B66C19CFC9601D /* MTICVPixelBufferRendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DBEE69247CE7A496A488890F615E2AE1 /* MTIHexagonalBokehBlurFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DB916AE474D5DE53D48E82391A70EA0 /* MTIHexagonalBokehBlurFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DCA03B2261F7323E08E64E2CAAA2EF5B /* MTIMPSBoxBlurFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = CC06F9F088B6E4F8C91E664F093FEA05 /* MTIMPSBoxBlurFilter.m */; };
-		DD505A210CF8AE17CC1692A017CCB285 /* MTIImagePromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 43476F2131AD4026877FB1245806E517 /* MTIImagePromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DDA32FBFB19EF556401978D706F6AFC1 /* MTIHexagonalBokehBlurFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DB916AE474D5DE53D48E82391A70EA0 /* MTIHexagonalBokehBlurFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DE225A4A3F9E77C79011FD290C313A0D /* MTIMask.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F7A4CF15A9842965A2F34D52E517483 /* MTIMask.m */; };
-		DE844CAC92C325152A7DFC3C307257D2 /* MTIImage+Filters.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E65CFF8EB5573CC2B9608216CD44E6 /* MTIImage+Filters.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DEC838BBAE22D3E42B83843CBF383F0C /* MultilayerCompositeShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = ADF6D517190D4C74DE44CB5CBB62F3F4 /* MultilayerCompositeShaders.metal */; };
-		DFF6122361103BFA73E0F4F73BD8318C /* MTIVibranceFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FDC1CD26C35E90E7FBAB6D25EFCA072 /* MTIVibranceFilter.m */; };
-		E04BFCEE1C4791C85FBE2147DE962D8F /* MTIFunctionArgumentsEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 98D888EDA81E8D36B9F3FDB956083B4E /* MTIFunctionArgumentsEncoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E143DC6E21ED9CBDBF33CF277A10DFA1 /* MTIDotScreenFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = ADDCA587F2C14BD86B32D7A835B19518 /* MTIDotScreenFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E19DEDCA8553E332C1EAC4653437E323 /* MTIComputePipelineKernel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06634379423486FA5C79A26134E974B6 /* MTIComputePipelineKernel.swift */; };
-		E1CDCB70F9698BE41C4C423DE7406AC0 /* MetalPetal.h in Headers */ = {isa = PBXBuildFile; fileRef = 668F9CB3802E4923A02CBE9E39CE5697 /* MetalPetal.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E2EECF2083E40DA90FD0BB76FD1AF7A7 /* MTIMPSBoxBlurFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = CC06F9F088B6E4F8C91E664F093FEA05 /* MTIMPSBoxBlurFilter.m */; };
-		E3575F88A2AF8428B9156DBE03AE1322 /* MTIMultilayerCompositeKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9BAFF05C5720FC8E639F84631D8A92 /* MTIMultilayerCompositeKernel.m */; };
-		E3EBE946FFC9B3D0A88723C02C74B61E /* MTIRoundCornerFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = A3D9326B2142633F71EA01F126995043 /* MTIRoundCornerFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E3ECC73A45EA78AE03167F6EAF23A465 /* MultilayerCompositingFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 180993A2787EFF3A8DBAA3D002CC937C /* MultilayerCompositingFilter.swift */; };
-		E56291614079F7849015E847466144CB /* MTIComputePipelineKernel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06634379423486FA5C79A26134E974B6 /* MTIComputePipelineKernel.swift */; };
-		E7310905FF5926024AF2DF5A45D38D49 /* MTIMPSHistogramFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 24687AF624C1F2D905A5319C44B27222 /* MTIMPSHistogramFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E7FFA9D2D819E622E4BF2AC4E0BA3DB8 /* MTIMPSKernel.h in Headers */ = {isa = PBXBuildFile; fileRef = B16EBC2392F758D3E1790251BD64BC71 /* MTIMPSKernel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E85524A5EC1B87D432809A0717C6C66D /* MTICVPixelBufferRendering.m in Sources */ = {isa = PBXBuildFile; fileRef = DB272E5AE4E21F25DB8255891881926F /* MTICVPixelBufferRendering.m */; };
-		E90E0C5B809FE2438B2A3F219F1DA5AC /* MTIVibranceFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FDC1CD26C35E90E7FBAB6D25EFCA072 /* MTIVibranceFilter.m */; };
-		E93E6CB5208B98B4E26A8F3736A302B1 /* MTIColorMatrix.h in Headers */ = {isa = PBXBuildFile; fileRef = 2113C68ECC76617CFF10C9943A984B3A /* MTIColorMatrix.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EA27A212D3F50236C44B50A3B530146B /* MTIHighPassSkinSmoothingFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 3474061DE51631140016C74F20E26242 /* MTIHighPassSkinSmoothingFilter.m */; };
-		EB198593DD816472DF5C98EB666778E6 /* MTIComputePipelineKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = 486F3616A35FFFF2B285411311709F7F /* MTIComputePipelineKernel.m */; };
-		EC0FD04778F71804B91888EB405B4A8A /* MTIMemoryWarningObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C9B4C7F349CB63D814E673B0385E152 /* MTIMemoryWarningObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EC9AEE0FE70C50D0905EA6D09DA84FBA /* MTIAlphaPremultiplicationFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 19530138A14BA035658FDA26478FA30C /* MTIAlphaPremultiplicationFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		ECA47F26D1ADF9533807EA241AAE3FA5 /* MTICVMetalTextureCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 61F8DE758E4EA6C7C8A2611F5F048193 /* MTICVMetalTextureCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		ECB66E671B7BECC2411CC778CAF345D8 /* MTIVector+SIMD.m in Sources */ = {isa = PBXBuildFile; fileRef = C33CAEF97463167982B0D85B4A6F40C0 /* MTIVector+SIMD.m */; };
-		ECCC260A732BEB48D7ADFF16C3C984F0 /* MTIImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2583F32A03FF818D26995B1976152D32 /* MTIImageView.m */; };
-		ED0109F71BD0598937CA347338EB4CCA /* MTIColorMatrixFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E30A6C224349F690A77D74AC3F1C156 /* MTIColorMatrixFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		ED144ADCDCD3422BC255FB91365A328E /* MTITextureLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 5382AA7FFB422306848695FF7CD61737 /* MTITextureLoader.m */; };
-		EF6314069AEC8830728E1BD4FEBCE085 /* MTIBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = A7D86EC9A144CA5053311A41AF060C52 /* MTIBuffer.m */; };
-		EF741471F3EB09D72C02725462BF23E5 /* MTIVibranceFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = C5D59DAF4CB77D4E67FB427915F52D4A /* MTIVibranceFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EFF563CED3EB4E750AA0E169E228DF22 /* MTIImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 98A870F833375207F89B2FB480B7D9B4 /* MTIImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F13BE139FA89BAFAF7D944B897CC7406 /* MTICorner.h in Headers */ = {isa = PBXBuildFile; fileRef = A89557483FFF8499123C3673D7734812 /* MTICorner.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F201C6D3373C11921B9BF1F6E75FC627 /* MTIMask.h in Headers */ = {isa = PBXBuildFile; fileRef = 23714C569A0099951BDF5DF5BBABA50A /* MTIMask.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F240779157360C9114F1AD99A0699ADE /* MTIRGBColorSpaceConversionFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = E112C9A658F6EC9D4035225C3BF9B8A9 /* MTIRGBColorSpaceConversionFilter.m */; };
-		F29F7B30B2505C10E039491469A1B6FF /* MTIVector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0243A423BEFA91D847C05973AF6C95 /* MTIVector.swift */; };
-		F3891ECBBE0FFEEBD576CDD2C760688F /* MTIImage+Promise.h in Headers */ = {isa = PBXBuildFile; fileRef = 08B5E898FC12525182B5795434255D8B /* MTIImage+Promise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F41CC1A95D680A9C95984FCB5FCCF6D5 /* MTIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276AB8C54378AD1A6E1305BBF8866223 /* MTIError.swift */; };
-		F545358FDB26E3EB412C4198E8C57A24 /* MTICoreImageRendering.h in Headers */ = {isa = PBXBuildFile; fileRef = 87D681EED87BC4A7557906E1F8707BA6 /* MTICoreImageRendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F5965192D6FD5824F1D5152EE898D042 /* MTISamplerDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A140A5542FB46FDEC00FF8D7BC0929E /* MTISamplerDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F629BEA3BB74296180E053D992B77320 /* MTIBlendWithMaskFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 10E2160AEA61ADA3331B92DDF59AE34A /* MTIBlendWithMaskFilter.m */; };
-		F7EC659BA75A7A3D33D87A9071D8A44C /* MTIContext.h in Headers */ = {isa = PBXBuildFile; fileRef = CFA4B1342272CDFC056C4CDA57558A5C /* MTIContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F8F4ABB1FB719D0BC2E90DF3DD41E1F2 /* MTIVibranceFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = C5D59DAF4CB77D4E67FB427915F52D4A /* MTIVibranceFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F9477062552F19FAF5ACFAD1EB88CCE7 /* MTIGeometryUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = DCA6512368E6D9B20E3784A213050F9F /* MTIGeometryUtilities.m */; };
-		FACEE6A8CA71D2CC1B01413013286476 /* MTIThreadSafeImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 4524341A2AE33300382F4F452296942C /* MTIThreadSafeImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FAE004B80E76BBB99C3290AB20CB2B52 /* MTICLAHEFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F5D6306B41724303B8CD05276822338 /* MTICLAHEFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FB91FBCFB591EFEE7ABF8C4105589525 /* MTICropFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = C3C52A774103E9679118BB50F6D10E55 /* MTICropFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FC4D1C2F769805F4B5548EB9F26F24D0 /* MultilayerCompositeShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = ADF6D517190D4C74DE44CB5CBB62F3F4 /* MultilayerCompositeShaders.metal */; };
-		FCD34EB925E99333FFB50364A7802629 /* MTIColorMatrix.h in Headers */ = {isa = PBXBuildFile; fileRef = 2113C68ECC76617CFF10C9943A984B3A /* MTIColorMatrix.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FD713EA13A980D3A6D1C3EAE9D5D42DE /* MTIContext+Rendering.h in Headers */ = {isa = PBXBuildFile; fileRef = 16F169838B041AEC2503766D7B9CD801 /* MTIContext+Rendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FECDC1472C070B99E18FA3D8C6744047 /* MTITextureDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FA804CE45886D4C18673E137C1AF913 /* MTITextureDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FF25DBFCEAD5D66150AAC5CC032E714C /* MTIShaderLib.h in Headers */ = {isa = PBXBuildFile; fileRef = 03E34A818D7E5B628B2E20034480F7BC /* MTIShaderLib.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FF6FC7393B03601921882A672478E502 /* MTIPrint.h in Headers */ = {isa = PBXBuildFile; fileRef = DDAE8FEA0BDC7BF6466286F2E1FC3B99 /* MTIPrint.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		FFBDE8164337C8FA9A188708979B166C /* MTIFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = C870EA46C8220E8CFCCD47429DC0937A /* MTIFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FFDFB9C20B1D96022296A3DF8E60D226 /* MTILock.h in Headers */ = {isa = PBXBuildFile; fileRef = DE4504BC5F4A6A410885244736A7FAE4 /* MTILock.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D7F1D5FD88D0822EF785D0024765C78E /* Shaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = F25E83F831680F6F145FF5803FA16038 /* Shaders.metal */; };
+		D835E073BD53C9F81AEB643A100B0E1F /* MetalPetal.swift in Sources */ = {isa = PBXBuildFile; fileRef = D91708FAA28003E520B9EF4726D7F869 /* MetalPetal.swift */; };
+		D83BA76BFEB60A4654965224B1DB1B96 /* LensBlur.metal in Sources */ = {isa = PBXBuildFile; fileRef = 0C1080D7E7CFD3D7141B80C5FDDCCBD1 /* LensBlur.metal */; };
+		D8745E15E4972277C3720637C32D78BE /* MTIBulgeDistortionFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = E4CA643AFD489837BDA5B07F9AEF20D8 /* MTIBulgeDistortionFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D896A8CD8C64B5F35FD6C147076E2C97 /* MTICoreImageRendering.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D93BA2041D727345B32AED92BC262FA /* MTICoreImageRendering.m */; };
+		D967BD8C2E5BC07CE866C02CAE6E9FDB /* MTITextureDimensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 794AD47DC7253C8C95184268C61F021D /* MTITextureDimensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DACFF20D875E71478E31B8FA4395F7FD /* MTIImagePromiseDebug.h in Headers */ = {isa = PBXBuildFile; fileRef = 959AA90E0BA3DFD21C72EC8D1E2DBCE0 /* MTIImagePromiseDebug.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DB4747C659396F209EE345147D66A583 /* MTIMPSKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BB4C749C706E442C8638B3D5C60A200 /* MTIMPSKernel.m */; };
+		DB8FBD7EE87FD197AFD590D38FEF57DF /* MTITextureLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C7B79C1EF70120069525973A373B5B0 /* MTITextureLoader.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DBDC872FA48503C40079DB1093A690CA /* MTIDefer.m in Sources */ = {isa = PBXBuildFile; fileRef = 89933E584BCEDC968272B351AC127B46 /* MTIDefer.m */; };
+		DC5385D4E888026BA897AB139D9F7502 /* MTIImagePromiseDebug.h in Headers */ = {isa = PBXBuildFile; fileRef = 959AA90E0BA3DFD21C72EC8D1E2DBCE0 /* MTIImagePromiseDebug.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DC56A91C74F7C68E06D00DB7FD01B771 /* MTIUnaryImageRenderingFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B42F783C6EA56E16971626EC3EC1356 /* MTIUnaryImageRenderingFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD24CC31D2C99E5E6FBDC30B959CF926 /* MTIBlendWithMaskFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 10E2160AEA61ADA3331B92DDF59AE34A /* MTIBlendWithMaskFilter.m */; };
+		DD58C718B9C4429A5B7EED0D5F363696 /* MTIImage+Filters.m in Sources */ = {isa = PBXBuildFile; fileRef = 96185B1FA2E19E616A79D99EBAD22DE2 /* MTIImage+Filters.m */; };
+		DE55E2D6054DE9FBBDFC483827AD1E80 /* MTIImage+Promise.h in Headers */ = {isa = PBXBuildFile; fileRef = 08B5E898FC12525182B5795434255D8B /* MTIImage+Promise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DE8E4583C815706934ADE685B479D867 /* MetalPetal.swift in Sources */ = {isa = PBXBuildFile; fileRef = D91708FAA28003E520B9EF4726D7F869 /* MetalPetal.swift */; };
+		DF31DE88C4A03CC602C18AD258BB59A9 /* MTITransform.m in Sources */ = {isa = PBXBuildFile; fileRef = E2DA2F1560A31253421ACC61AB910417 /* MTITransform.m */; };
+		DF5C67E0C0CBE2D745FDB0AC8E32DC46 /* MTIThreadSafeImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 4524341A2AE33300382F4F452296942C /* MTIThreadSafeImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DF86564E7650642BF443131ADECDAF75 /* MTIAlphaType.m in Sources */ = {isa = PBXBuildFile; fileRef = C34ED5A0B8F0040BCA7FF07F063F4AA6 /* MTIAlphaType.m */; };
+		DFDB1CD8611A0FA9DEEADBC8A3139447 /* MTIThreadSafeImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 994294A7C1F35F53E1FECEC65BB8E8C3 /* MTIThreadSafeImageView.m */; };
+		E01AFF8F96ABB33BF1C03784C8E5392E /* MTIMPSHistogramFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = B334145EDBF0EAC80F861216049C7A07 /* MTIMPSHistogramFilter.m */; };
+		E0413F7513BD2C875028CD740D45B1B6 /* ColorConversionShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = F094BEC497F8B03C8652DF126F546372 /* ColorConversionShaders.metal */; };
+		E08B97DF4A6AD4D1A3D5537540834025 /* MTIBlendFormulaSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = B49289A3A6CD192DB7537DE4D733EB0F /* MTIBlendFormulaSupport.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E0A8748533518F536DABB1F3EA683A59 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D96B6F02A66345DED9C856D1BD504B40 /* Foundation.framework */; };
+		E1B044F6D58E25E1116374FA9ACCD865 /* MTICVPixelBufferRendering.m in Sources */ = {isa = PBXBuildFile; fileRef = DB272E5AE4E21F25DB8255891881926F /* MTICVPixelBufferRendering.m */; };
+		E1EB6EC8079224F085AE418767B3D5CD /* MTICVMetalTextureBridging.h in Headers */ = {isa = PBXBuildFile; fileRef = A57C7A26933829A8FF6546DB7B9E5E05 /* MTICVMetalTextureBridging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E231235E6A0FCECD75C722CD678E1C93 /* MTIHighPassSkinSmoothingFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 3474061DE51631140016C74F20E26242 /* MTIHighPassSkinSmoothingFilter.m */; };
+		E2FAEB3BFD292E35107F30974BC09A10 /* MTISKSceneRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 2143036CABE393784D025D87644A92CB /* MTISKSceneRenderer.m */; };
+		E33D256C427B8CAC0CA1DCF3FBEB115E /* MTIHexagonalBokehBlurFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C73EBFE35DEABDFEBE99D9859B30C96 /* MTIHexagonalBokehBlurFilter.m */; };
+		E42F1ECCA7B7E954EED95A79B845796B /* MTIWeakToStrongObjectsMapTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 77AB69D212A357773556E7A6D43B49F0 /* MTIWeakToStrongObjectsMapTable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4EE1DC71D84BCDA7A9C7C36507DDA4A /* MTITransform.h in Headers */ = {isa = PBXBuildFile; fileRef = BE3AD47A5E5845568DFDE2162773821F /* MTITransform.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E62BC35964F3F3D7638D72D83E9B2629 /* MTIColorLookupFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BA57A817A151A6B179EEFE3DC8C8 /* MTIColorLookupFilter.m */; };
+		E6520C686884D86EADE1A28875691425 /* MTIVector+SIMD.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D8CE33BBFC5E37449CFD2579DAAA426 /* MTIVector+SIMD.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E6893A929C47793B4689CEC1C0C29026 /* MTISCNSceneRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9746B08D8D3984B3A8E04ABC1C79A6EC /* MTISCNSceneRenderer.m */; };
+		E726C9A2AEA59335A6D6B13455C513E7 /* MTISCNSceneRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = D4594ED8316E9485C8D047368DF9F011 /* MTISCNSceneRenderer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E77576AD81874E86A656E86FD967B340 /* MTIAlphaPremultiplicationFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 22EFDD084C13F0A0946FC47579BEA725 /* MTIAlphaPremultiplicationFilter.m */; };
+		E7F49BA7838C70B950A9719497BFCC18 /* MTIRenderTask.m in Sources */ = {isa = PBXBuildFile; fileRef = A76A116553C936D5987440E70163392C /* MTIRenderTask.m */; };
+		E9613BA6A49C71C6B6BA4D39B40B8AA8 /* MTICVMetalTextureCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 61F8DE758E4EA6C7C8A2611F5F048193 /* MTICVMetalTextureCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E9B369D6DCA0DBACFA59AC5AAC26C740 /* MTIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F68190E4178E5FA523E0CCF316E2AA /* MTIError.swift */; };
+		EA567421771E3CBB0C1FC5E40E487FBE /* MTIImage.h in Headers */ = {isa = PBXBuildFile; fileRef = BFE0E806B256BB3A9700DB5FD424B6A9 /* MTIImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EB5BEFA41349D48DD2425209C98EC585 /* MTITextureDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FA804CE45886D4C18673E137C1AF913 /* MTITextureDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EBFDD06906A69BB1C41D0F49D5F6DD7A /* MTITextureLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C7B79C1EF70120069525973A373B5B0 /* MTITextureLoader.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EE4FE56D37B5A648D86A51971D7CEC63 /* MTIChromaKeyBlendFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 629081B3EE1DF76DB7BFBD81E70EF266 /* MTIChromaKeyBlendFilter.m */; };
+		EF48B49D12CC39B7AF41339E95098CB0 /* MetalPetal-AppleSilicon-Core-Swift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EFB44E333AB6E7F988772EB608C1B10 /* MetalPetal-AppleSilicon-Core-Swift-dummy.m */; };
+		EF8E37C04582E312D50A453AFC5F5F88 /* MTIUnaryImageRenderingFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 37F59A9ECCBB13D1DA569B26EC63E5D4 /* MTIUnaryImageRenderingFilter.m */; };
+		EF8FB30FFFBDB2CB39FD6750C03CFD0A /* MTIColorMatrix.m in Sources */ = {isa = PBXBuildFile; fileRef = 000A839435C68C96FE3A15FC42A3D96B /* MTIColorMatrix.m */; };
+		F015D56AB6813CC4107F104808F0CDAA /* MTIAlphaPremultiplicationFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 19530138A14BA035658FDA26478FA30C /* MTIAlphaPremultiplicationFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F03F25E78E0B11FF28883F8B1A1533B0 /* MTICVPixelBufferRendering.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EDC14FDCB24D11544B66C19CFC9601D /* MTICVPixelBufferRendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F05FCC70697F4666C150594562546BC0 /* MTIContext+Rendering.h in Headers */ = {isa = PBXBuildFile; fileRef = 16F169838B041AEC2503766D7B9CD801 /* MTIContext+Rendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F14FC22EB6FBC6F545A2560F0028C233 /* MTISamplerDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 840B7117FC626722A3F57ECB3DF7D3EF /* MTISamplerDescriptor.m */; };
+		F15638DFA28A6E381320989697F2948A /* MTIBlendWithMaskFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 715856E3A7AC731446F51596360D7131 /* MTIBlendWithMaskFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F17B3BAF1DA8D592C9FD9E9872DF2715 /* MTICVPixelBufferPool.h in Headers */ = {isa = PBXBuildFile; fileRef = B3453C3DF38A3143DE7CABCE3235B93E /* MTICVPixelBufferPool.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F216BEA93CE966618A45A3A56AF0ACB3 /* MTIBlendFormulaSupport.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3648315ED673AAF957616C8B8B7B225F /* MTIBlendFormulaSupport.mm */; };
+		F368EA95F2AC8D2E5FD29D931DF5771D /* MTIColorMatrixFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E30A6C224349F690A77D74AC3F1C156 /* MTIColorMatrixFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F3F7ACD8D921CBDCBB78DA8C8D779C3C /* MTIDotScreenFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 74412C1EFB36C00783733AF41B2254A4 /* MTIDotScreenFilter.m */; };
+		F4B93EBDBFB3CFE6BAAC76FCCBDC1889 /* MTIColorLookupFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6255D81F38B30694A9DB957329C7108F /* MTIColorLookupFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F56CC52AF8801D399606AC1FC23C565C /* MTIWeakToStrongObjectsMapTable.m in Sources */ = {isa = PBXBuildFile; fileRef = 34C98F4575D79C98DB8181EAB01C2291 /* MTIWeakToStrongObjectsMapTable.m */; };
+		F5DAA38ED9A3F8A505EA83C3D058F634 /* Halftone.metal in Sources */ = {isa = PBXBuildFile; fileRef = 28368807F05E87E2C5E561378AC64D64 /* Halftone.metal */; };
+		F6C8D0B41423647BBC1D01ADC7911642 /* MTICorner.h in Headers */ = {isa = PBXBuildFile; fileRef = A89557483FFF8499123C3673D7734812 /* MTICorner.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F7916F982506937EE689F6E7CFDE482B /* MTILock.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E2FD4A1B19B7040FFE209F3041D729A /* MTILock.m */; };
+		F80FCDA5123E688058527BCBD158D552 /* MTIVector.m in Sources */ = {isa = PBXBuildFile; fileRef = A0A2ED91C6BEFCCFAF239EE61BD05996 /* MTIVector.m */; };
+		F856C640D7C3C780DA15A019AFBEA274 /* MTILayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EE1C40E9FA9CD4E24E8A3A05645EC86 /* MTILayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F8A3FB4E7AFC2A5BD4DDB3E4F24B3473 /* MultilayerCompositingFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19BB95D6F52A8B62151B3742655637A0 /* MultilayerCompositingFilter.swift */; };
+		F99AA2531F9350C1279415B6EE923E3C /* MTISCNSceneRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9746B08D8D3984B3A8E04ABC1C79A6EC /* MTISCNSceneRenderer.m */; };
+		F9DBC4B1A13A71AE28D48ADFD4D27BE0 /* MTIMPSGaussianBlurFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8DE0D3B0E0C70FD0B6DE5895132A966F /* MTIMPSGaussianBlurFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FAA37BD49CAC5DCA3CB6601A4EFFE452 /* MTICVPixelBufferRendering.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EDC14FDCB24D11544B66C19CFC9601D /* MTICVPixelBufferRendering.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FAC92ABDFA6272F8617286C1E9D8B333 /* MTIError.h in Headers */ = {isa = PBXBuildFile; fileRef = 051D63EB3BDF7FD714F71DC83B48597F /* MTIError.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB27ECF71B3D205A42D6204FFEC9AEA8 /* MTIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B14DABA285F792CC3CFDDC37979BC71 /* MTIImage.swift */; };
+		FC75E2F34EED12CD97468984F5183E7C /* MTIMPSBoxBlurFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = CC06F9F088B6E4F8C91E664F093FEA05 /* MTIMPSBoxBlurFilter.m */; };
+		FDACB6738965769B38A4651E0E69E9FF /* MTICVMetalIOSurfaceBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 59DB6169E28AC4E89FD4E28C17D075A1 /* MTICVMetalIOSurfaceBridge.m */; };
+		FDE03A645E1CFD16B25A4A7555D6E764 /* MTIMPSUnsharpMaskFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = D9DCB3600E15951DE046C97C55F5BE54 /* MTIMPSUnsharpMaskFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FE1BBE9BCEE6AA07C6D7651918C87875 /* MTITextureDimensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F4BFC87BF26CE1113DCF16E8F8AEC9 /* MTITextureDimensions.swift */; };
+		FE71B77670AB37A28AC8A75AE4F52EC2 /* MTIColorMatrixFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E30A6C224349F690A77D74AC3F1C156 /* MTIColorMatrixFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FEC3D8273F85D54B66A308F27EA7A048 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 70E59D9D8EF41291B0C13BC330FA3126 /* Cocoa.framework */; };
+		FF38195129E2DAA26500903390F2D000 /* Shaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = F25E83F831680F6F145FF5803FA16038 /* Shaders.metal */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		9E11E31C254E59A6DD2836BE6A8D04A4 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 45FF391DFF638DC1677EE9B92B249B48;
-			remoteInfo = "MetalPetal-AppleSilicon-Core-Swift";
-		};
-		A0B6CB4F8ECD4DACA8AF0459758741F1 /* PBXContainerItemProxy */ = {
+		82A7FA5D3EEF740BCB761ED0CA704326 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = F6A6D917959D4C48ADF90BBFC7A7F507;
 			remoteInfo = "MetalPetal-Core-Swift";
+		};
+		894DA3B8AD98236DDE10BD877F9FD624 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 45FF391DFF638DC1677EE9B92B249B48;
+			remoteInfo = "MetalPetal-AppleSilicon-Core-Swift";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -471,7 +473,6 @@
 		03E34A818D7E5B628B2E20034480F7BC /* MTIShaderLib.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIShaderLib.h; sourceTree = "<group>"; };
 		051D63EB3BDF7FD714F71DC83B48597F /* MTIError.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIError.h; sourceTree = "<group>"; };
 		0579539BAE6060DE90BACC401F6675F6 /* Pods-MetalPetalExamples-MetalPetalExamples (iOS).modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-MetalPetalExamples-MetalPetalExamples (iOS).modulemap"; sourceTree = "<group>"; };
-		06634379423486FA5C79A26134E974B6 /* MTIComputePipelineKernel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIComputePipelineKernel.swift; sourceTree = "<group>"; };
 		07A8FE33257602CA9AF1A0401B917E72 /* MTIMPSConvolutionFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMPSConvolutionFilter.h; sourceTree = "<group>"; };
 		07AD86FA01273A5DF7B6F27A8378DEE9 /* MTIMemoryWarningObserver.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMemoryWarningObserver.m; sourceTree = "<group>"; };
 		080D39D554DC6A497F3CB775865C8E8A /* MTIVector.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIVector.h; sourceTree = "<group>"; };
@@ -483,18 +484,18 @@
 		0D47A3A6BBB5BC63F774948BED29F508 /* Pods-MetalPetalExamples-MetalPetalExamples (macOS)-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-MetalPetalExamples-MetalPetalExamples (macOS)-dummy.m"; sourceTree = "<group>"; };
 		0E7E883A98F26CDC01465914462E3B45 /* MTIImagePromiseDebug.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIImagePromiseDebug.m; sourceTree = "<group>"; };
 		0EE1C40E9FA9CD4E24E8A3A05645EC86 /* MTILayer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTILayer.h; sourceTree = "<group>"; };
-		0EE571E8CB85DCF6F357CD8DAA3AE487 /* MTICorner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTICorner.swift; sourceTree = "<group>"; };
 		0EFAEF4681EE4E27E37257F48E75B5A9 /* Pods-MetalPetalExamples-MetalPetalExamples (iOS)-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-MetalPetalExamples-MetalPetalExamples (iOS)-dummy.m"; sourceTree = "<group>"; };
+		0F42FFF4671ABF7D97023F18B62349C2 /* MTIComputePipelineKernel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIComputePipelineKernel.swift; sourceTree = "<group>"; };
 		0F5D6306B41724303B8CD05276822338 /* MTICLAHEFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICLAHEFilter.h; sourceTree = "<group>"; };
 		1007E23586C26A5AC21D8EE48B9DD4E2 /* MTIColor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIColor.h; sourceTree = "<group>"; };
 		10D221A98BB3A4F75B78622BF5C6AD31 /* MTIHighPassSkinSmoothingFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIHighPassSkinSmoothingFilter.h; sourceTree = "<group>"; };
 		10E2160AEA61ADA3331B92DDF59AE34A /* MTIBlendWithMaskFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIBlendWithMaskFilter.m; sourceTree = "<group>"; };
 		11B1545083C4F30C077FAD91B412DA77 /* MetalPetal-Core-Swift-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "MetalPetal-Core-Swift-Info.plist"; path = "../MetalPetal-Core-Swift/MetalPetal-Core-Swift-Info.plist"; sourceTree = "<group>"; };
 		122D351C6553FCA95C13D8901DDBFE9C /* MTITransformFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTITransformFilter.h; sourceTree = "<group>"; };
-		158A8EFE6110E8196D7C6469EDC15E63 /* MTITextureDimensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTITextureDimensions.swift; sourceTree = "<group>"; };
 		16F169838B041AEC2503766D7B9CD801 /* MTIContext+Rendering.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MTIContext+Rendering.h"; sourceTree = "<group>"; };
-		180993A2787EFF3A8DBAA3D002CC937C /* MultilayerCompositingFilter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MultilayerCompositingFilter.swift; sourceTree = "<group>"; };
 		19530138A14BA035658FDA26478FA30C /* MTIAlphaPremultiplicationFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIAlphaPremultiplicationFilter.h; sourceTree = "<group>"; };
+		19BB95D6F52A8B62151B3742655637A0 /* MultilayerCompositingFilter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MultilayerCompositingFilter.swift; sourceTree = "<group>"; };
+		1B14DABA285F792CC3CFDDC37979BC71 /* MTIImage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIImage.swift; sourceTree = "<group>"; };
 		1B1820B839CA4B878B9DA024AE1350DE /* MTIRGBColorSpaceConversionFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRGBColorSpaceConversionFilter.h; sourceTree = "<group>"; };
 		1BB4C749C706E442C8638B3D5C60A200 /* MTIMPSKernel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMPSKernel.m; sourceTree = "<group>"; };
 		1C73EBFE35DEABDFEBE99D9859B30C96 /* MTIHexagonalBokehBlurFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIHexagonalBokehBlurFilter.m; sourceTree = "<group>"; };
@@ -516,14 +517,13 @@
 		24B743E8F48899C356C8AC672FAD42F1 /* Pods-MetalPetalExamples-MetalPetalExamples (macOS)-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-MetalPetalExamples-MetalPetalExamples (macOS)-umbrella.h"; sourceTree = "<group>"; };
 		2583F32A03FF818D26995B1976152D32 /* MTIImageView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIImageView.m; sourceTree = "<group>"; };
 		26B549968261A5B414B775D3424FD0DC /* MetalPetal-Core-Swift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "MetalPetal-Core-Swift-dummy.m"; path = "../MetalPetal-Core-Swift/MetalPetal-Core-Swift-dummy.m"; sourceTree = "<group>"; };
-		276AB8C54378AD1A6E1305BBF8866223 /* MTIError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIError.swift; sourceTree = "<group>"; };
 		276B4FEB15A3332424BCC298AE3FE9BA /* MTIDrawableRendering.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIDrawableRendering.h; sourceTree = "<group>"; };
-		280BBD2FFA2096DEB29F65AA3A746F97 /* MTIColor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIColor.swift; sourceTree = "<group>"; };
 		28368807F05E87E2C5E561378AC64D64 /* Halftone.metal */ = {isa = PBXFileReference; includeInIndex = 1; path = Halftone.metal; sourceTree = "<group>"; };
 		2A705843283D25F9B8159D6E0E87B00E /* MetalPetal-Core-Swift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "MetalPetal-Core-Swift.debug.xcconfig"; path = "../MetalPetal-Core-Swift/MetalPetal-Core-Swift.debug.xcconfig"; sourceTree = "<group>"; };
 		2ACACC0E0CAB75B0CF585D20FB2D9CF1 /* Pods-MetalPetalExamples-MetalPetalExamples (iOS)-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-MetalPetalExamples-MetalPetalExamples (iOS)-Info.plist"; sourceTree = "<group>"; };
+		2D415EA68815D0046129EBDEA297DA49 /* Filter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Filter.swift; sourceTree = "<group>"; };
+		2EAC8394FB0E80CCE2A97F4AB4B56113 /* MTIFunctionDescriptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIFunctionDescriptor.swift; sourceTree = "<group>"; };
 		2F35D202C320154242070FF675337283 /* MTITransformFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTITransformFilter.m; sourceTree = "<group>"; };
-		309CD50F9862DED7227D1567139AA70F /* MTIAlphaType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIAlphaType.swift; sourceTree = "<group>"; };
 		3110866B775237BA40999C9445438BC1 /* MTIMPSGaussianBlurFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMPSGaussianBlurFilter.m; sourceTree = "<group>"; };
 		32649AF567A0346EAB8CD35723F6C9F6 /* MetalPetal-AppleSilicon-Core-Swift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "MetalPetal-AppleSilicon-Core-Swift.debug.xcconfig"; sourceTree = "<group>"; };
 		335F61D37D6136DB031911E5C28ADD1F /* Pods-MetalPetalExamples-MetalPetalExamples (macOS)-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-MetalPetalExamples-MetalPetalExamples (macOS)-acknowledgements.plist"; sourceTree = "<group>"; };
@@ -534,7 +534,6 @@
 		37F59A9ECCBB13D1DA569B26EC63E5D4 /* MTIUnaryImageRenderingFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIUnaryImageRenderingFilter.m; sourceTree = "<group>"; };
 		39F1000E921A9281C763EDA10723C95D /* MTICropFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTICropFilter.m; sourceTree = "<group>"; };
 		3BDF177600159053D248158B2F1CF945 /* MTIHasher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIHasher.h; sourceTree = "<group>"; };
-		3CD698896E6D092584FCA5BD38B1C9B8 /* MTIImageViewProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIImageViewProtocol.swift; sourceTree = "<group>"; };
 		3D8CE33BBFC5E37449CFD2579DAAA426 /* MTIVector+SIMD.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MTIVector+SIMD.h"; sourceTree = "<group>"; };
 		3DACF8FE6128C086A380E2ABC956120C /* MTIChromaKeyBlendFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIChromaKeyBlendFilter.h; sourceTree = "<group>"; };
 		3E49E9EF077B9155BAAAC3B46EF97BB5 /* MTIBulgeDistortionFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIBulgeDistortionFilter.m; sourceTree = "<group>"; };
@@ -546,27 +545,29 @@
 		43358EE79231F2E49FDDB8F9707CD707 /* MTIRenderPassOutputDescriptor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRenderPassOutputDescriptor.h; sourceTree = "<group>"; };
 		43476F2131AD4026877FB1245806E517 /* MTIImagePromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIImagePromise.h; sourceTree = "<group>"; };
 		440BA8D18A570D93B7ECDDA1AD4DDFFE /* MTIRenderPipelineKernel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIRenderPipelineKernel.m; sourceTree = "<group>"; };
+		44D2796D5C6FDC685BEFA6996CC75C4B /* MTIColorMatrix.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIColorMatrix.swift; sourceTree = "<group>"; };
 		44F34F35B06446E94AF6887EFE559097 /* MTIContext+Rendering.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "MTIContext+Rendering.m"; sourceTree = "<group>"; };
 		4524341A2AE33300382F4F452296942C /* MTIThreadSafeImageView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIThreadSafeImageView.h; sourceTree = "<group>"; };
 		46925C6E8619FE7B523F2A05441ABB84 /* MTIImageProperties.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIImageProperties.h; sourceTree = "<group>"; };
 		46979D946C597284368024105C6667E2 /* MTIColorHalftoneFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIColorHalftoneFilter.m; sourceTree = "<group>"; };
 		486F3616A35FFFF2B285411311709F7F /* MTIComputePipelineKernel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIComputePipelineKernel.m; sourceTree = "<group>"; };
+		48F68190E4178E5FA523E0CCF316E2AA /* MTIError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIError.swift; sourceTree = "<group>"; };
 		4A4F479B562C11E2F3621E63CEB019D3 /* MTILibrarySource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTILibrarySource.m; sourceTree = "<group>"; };
 		4B42F783C6EA56E16971626EC3EC1356 /* MTIUnaryImageRenderingFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIUnaryImageRenderingFilter.h; sourceTree = "<group>"; };
 		4B74E8D6ABC0443FEED3026CD1E7B0D8 /* MTIFunctionArgumentsEncoder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIFunctionArgumentsEncoder.m; sourceTree = "<group>"; };
+		4C50ED68A4B82B87B9853A2F9350EFA3 /* MTISIMDArgumentEncoder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTISIMDArgumentEncoder.swift; sourceTree = "<group>"; };
 		4C9B4C7F349CB63D814E673B0385E152 /* MTIMemoryWarningObserver.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMemoryWarningObserver.h; sourceTree = "<group>"; };
 		4D06881FE11756F8FCEE425B28617CAB /* MTICVMetalIOSurfaceBridge.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICVMetalIOSurfaceBridge.h; sourceTree = "<group>"; };
 		4F14CB019480676EAFA71875A8646E37 /* MTIGeometry.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIGeometry.h; sourceTree = "<group>"; };
 		4F3FC2AF37E4FD7EA01EAEEDD438195D /* Pods-MetalPetalExamples-MetalPetalExamples (macOS)-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-MetalPetalExamples-MetalPetalExamples (macOS)-acknowledgements.markdown"; sourceTree = "<group>"; };
 		4FDC1CD26C35E90E7FBAB6D25EFCA072 /* MTIVibranceFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIVibranceFilter.m; sourceTree = "<group>"; };
 		50D57FA9342F44FD185167A3568EB56E /* MTIGeometry.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIGeometry.m; sourceTree = "<group>"; };
+		518C430901F215C101898B2E31020C73 /* MTIPixelFormat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIPixelFormat.swift; sourceTree = "<group>"; };
 		51A388571970F41F8AF173376B80987D /* MTIRenderPipeline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRenderPipeline.h; sourceTree = "<group>"; };
-		51E63002E575273A6B29BAAFD639A807 /* MTIImage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIImage.swift; sourceTree = "<group>"; };
 		5382AA7FFB422306848695FF7CD61737 /* MTITextureLoader.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTITextureLoader.m; sourceTree = "<group>"; };
 		538DEB678852DE42D5EA65D6218C3289 /* MetalPetal.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = MetalPetal.modulemap; sourceTree = "<group>"; };
-		552422256A92E5B0BD669E908CE3895A /* MTIColorMatrix.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIColorMatrix.swift; sourceTree = "<group>"; };
-		556074EB4DCE458E9FFDA0303F008462 /* MTIDataBuffer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIDataBuffer.swift; sourceTree = "<group>"; };
 		59DB6169E28AC4E89FD4E28C17D075A1 /* MTICVMetalIOSurfaceBridge.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTICVMetalIOSurfaceBridge.m; sourceTree = "<group>"; };
+		5C1627D99729B48FFD9053B927130125 /* MTIAlphaType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIAlphaType.swift; sourceTree = "<group>"; };
 		5C7B79C1EF70120069525973A373B5B0 /* MTITextureLoader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTITextureLoader.h; sourceTree = "<group>"; };
 		5E30A6C224349F690A77D74AC3F1C156 /* MTIColorMatrixFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIColorMatrixFilter.h; sourceTree = "<group>"; };
 		5F7446D805364BCB7BCEFA4F29618902 /* MTIPixelFormat.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIPixelFormat.m; sourceTree = "<group>"; };
@@ -582,7 +583,6 @@
 		6721C9D18C1B9F4B79F48A614D6073B3 /* MTIImageRenderingContext+Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MTIImageRenderingContext+Internal.h"; sourceTree = "<group>"; };
 		69FA8D0A47409B355C884A1E6598F295 /* Pods-MetalPetalExamples-MetalPetalExamples (macOS).release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-MetalPetalExamples-MetalPetalExamples (macOS).release.xcconfig"; sourceTree = "<group>"; };
 		6A140A5542FB46FDEC00FF8D7BC0929E /* MTISamplerDescriptor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTISamplerDescriptor.h; sourceTree = "<group>"; };
-		6A1A4E83423BA248CF37F5CA880CFC73 /* MTICoreImageExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTICoreImageExtension.swift; sourceTree = "<group>"; };
 		6A2A655423DC9C5706746A359AD4E0CF /* MTIAlphaType.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIAlphaType.h; sourceTree = "<group>"; };
 		6A5A91B6B2C1086D66D70D0EC1A15246 /* MTILibrarySource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTILibrarySource.h; sourceTree = "<group>"; };
 		6AA4B41672F25730E0F1CBA46DD85880 /* MTIBuffer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIBuffer.h; sourceTree = "<group>"; };
@@ -596,16 +596,15 @@
 		74B6B717A8E378D75CBA474EFD8C90F3 /* MTIRenderPassOutputDescriptor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIRenderPassOutputDescriptor.m; sourceTree = "<group>"; };
 		75F8C0942B51125AD7896B3A1F810DBB /* MTIRGBToneCurveFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIRGBToneCurveFilter.m; sourceTree = "<group>"; };
 		77AB69D212A357773556E7A6D43B49F0 /* MTIWeakToStrongObjectsMapTable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIWeakToStrongObjectsMapTable.h; sourceTree = "<group>"; };
+		77C19153B5BDAEEAECA3BE20650B76F7 /* MTICropRegion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTICropRegion.swift; sourceTree = "<group>"; };
 		78F7F132405D51C8039F8F0F247675DB /* MTITexturePool.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTITexturePool.h; sourceTree = "<group>"; };
 		794AD47DC7253C8C95184268C61F021D /* MTITextureDimensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTITextureDimensions.h; sourceTree = "<group>"; };
 		7A15AFE8E136AE579B2194077C8A1390 /* MTIRenderTask.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRenderTask.h; sourceTree = "<group>"; };
 		7A31547F3EE88D9AE377FDB11E88071E /* MetalPetal.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = MetalPetal.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		7ABCB697CFDD9B0CA7CBE2DEB6EECC99 /* MTITexturePool.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = MTITexturePool.mm; sourceTree = "<group>"; };
-		7B0243A423BEFA91D847C05973AF6C95 /* MTIVector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIVector.swift; sourceTree = "<group>"; };
 		7BA3FB75D4EDB0260464604294862462 /* MTILayer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTILayer.m; sourceTree = "<group>"; };
-		7C3F1D22604D4CE74FD6D91A6A00126F /* MTICropRegion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTICropRegion.swift; sourceTree = "<group>"; };
+		7E1DFACD08669DECACC3BB24468070AE /* MTIContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIContext.swift; sourceTree = "<group>"; };
 		7ED6E8A8BF705A94647F4A0253AC81DB /* MTIContext+Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MTIContext+Internal.h"; sourceTree = "<group>"; };
-		80BF9AB8BCA2347EC148983914AADDE3 /* MTIFunctionDescriptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIFunctionDescriptor.swift; sourceTree = "<group>"; };
 		81F9877F1AED144A6E2A911FF7013E1F /* MTIMPSBoxBlurFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMPSBoxBlurFilter.h; sourceTree = "<group>"; };
 		83E81065F318F10E0C0C2A9BBD0812CD /* MTIFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIFilter.m; sourceTree = "<group>"; };
 		840B7117FC626722A3F57ECB3DF7D3EF /* MTISamplerDescriptor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTISamplerDescriptor.m; sourceTree = "<group>"; };
@@ -613,6 +612,7 @@
 		87CF9D85C1CDA7AB97AE28528E55DAD4 /* MTIRenderCommand.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRenderCommand.h; sourceTree = "<group>"; };
 		87D681EED87BC4A7557906E1F8707BA6 /* MTICoreImageRendering.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICoreImageRendering.h; sourceTree = "<group>"; };
 		89933E584BCEDC968272B351AC127B46 /* MTIDefer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIDefer.m; sourceTree = "<group>"; };
+		8BB873C68D2563D202B0F6A5A1BCFB89 /* MTIVideoComposition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIVideoComposition.swift; sourceTree = "<group>"; };
 		8BC89A2032F2F966D1A77702264B23EA /* MTIColor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIColor.m; sourceTree = "<group>"; };
 		8CB8C8025B70C8621D44C258994E56A4 /* Pods-MetalPetalExamples-MetalPetalExamples (macOS).debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-MetalPetalExamples-MetalPetalExamples (macOS).debug.xcconfig"; sourceTree = "<group>"; };
 		8DE0D3B0E0C70FD0B6DE5895132A966F /* MTIMPSGaussianBlurFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMPSGaussianBlurFilter.h; sourceTree = "<group>"; };
@@ -625,6 +625,7 @@
 		959AA90E0BA3DFD21C72EC8D1E2DBCE0 /* MTIImagePromiseDebug.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIImagePromiseDebug.h; sourceTree = "<group>"; };
 		96185B1FA2E19E616A79D99EBAD22DE2 /* MTIImage+Filters.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "MTIImage+Filters.m"; sourceTree = "<group>"; };
 		9746B08D8D3984B3A8E04ABC1C79A6EC /* MTISCNSceneRenderer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTISCNSceneRenderer.m; sourceTree = "<group>"; };
+		97E1E87D90BEC4E6991AE5AC48D888B2 /* MTIImageViewProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIImageViewProtocol.swift; sourceTree = "<group>"; };
 		98A870F833375207F89B2FB480B7D9B4 /* MTIImageView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIImageView.h; sourceTree = "<group>"; };
 		98D888EDA81E8D36B9F3FDB956083B4E /* MTIFunctionArgumentsEncoder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIFunctionArgumentsEncoder.h; sourceTree = "<group>"; };
 		992934579D2CE8D49CDF3DB722D326EE /* MTIPixellateFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIPixellateFilter.m; sourceTree = "<group>"; };
@@ -643,6 +644,7 @@
 		A0A2ED91C6BEFCCFAF239EE61BD05996 /* MTIVector.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIVector.m; sourceTree = "<group>"; };
 		A1425DC453E2AB8FC117D4C8E1B3F5B2 /* MTICVPixelBufferPool.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTICVPixelBufferPool.m; sourceTree = "<group>"; };
 		A221DCE21795331B6A14E14B3B8A773C /* MetalPetal-AppleSilicon-Core-Swift */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "MetalPetal-AppleSilicon-Core-Swift"; path = MetalPetal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A33495C292E252A024DFFB0ABD59052F /* MTIRGBColorSpaceConversionFilter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIRGBColorSpaceConversionFilter.swift; sourceTree = "<group>"; };
 		A3D9326B2142633F71EA01F126995043 /* MTIRoundCornerFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRoundCornerFilter.h; sourceTree = "<group>"; };
 		A414EC6DE34C402428AE493B9822B9C8 /* MTIImageRenderingContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIImageRenderingContext.h; sourceTree = "<group>"; };
 		A57C7A26933829A8FF6546DB7B9E5E05 /* MTICVMetalTextureBridging.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICVMetalTextureBridging.h; sourceTree = "<group>"; };
@@ -655,6 +657,7 @@
 		ADDCA587F2C14BD86B32D7A835B19518 /* MTIDotScreenFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIDotScreenFilter.h; sourceTree = "<group>"; };
 		ADF6D517190D4C74DE44CB5CBB62F3F4 /* MultilayerCompositeShaders.metal */ = {isa = PBXFileReference; includeInIndex = 1; path = MultilayerCompositeShaders.metal; sourceTree = "<group>"; };
 		B16EBC2392F758D3E1790251BD64BC71 /* MTIMPSKernel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMPSKernel.h; sourceTree = "<group>"; };
+		B17E826B5869A8EDA5DCD3EBE5940963 /* MTIVertex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIVertex.swift; sourceTree = "<group>"; };
 		B24021FF880799F5045E921C14BF0CC6 /* MTIRenderGraphOptimization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIRenderGraphOptimization.m; sourceTree = "<group>"; };
 		B334145EDBF0EAC80F861216049C7A07 /* MTIMPSHistogramFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMPSHistogramFilter.m; sourceTree = "<group>"; };
 		B3453C3DF38A3143DE7CABCE3235B93E /* MTICVPixelBufferPool.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICVPixelBufferPool.h; sourceTree = "<group>"; };
@@ -662,18 +665,19 @@
 		B49289A3A6CD192DB7537DE4D733EB0F /* MTIBlendFormulaSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIBlendFormulaSupport.h; sourceTree = "<group>"; };
 		B4C2BA57A817A151A6B179EEFE3DC8C8 /* MTIColorLookupFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIColorLookupFilter.m; sourceTree = "<group>"; };
 		B533868228AD4FEAE2A37EE6B93B59EB /* MetalPetal-Core-Swift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; name = "MetalPetal-Core-Swift.modulemap"; path = "../MetalPetal-Core-Swift/MetalPetal-Core-Swift.modulemap"; sourceTree = "<group>"; };
-		B89E166384417C93EEEB709D6E4A9DE1 /* Filter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Filter.swift; sourceTree = "<group>"; };
+		B6FC792FC8DAC9313C20C8F3E2441230 /* MTIDataBuffer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIDataBuffer.swift; sourceTree = "<group>"; };
 		BB25E2412ACAF0CD6ADE8C60161DC127 /* MTIContext.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIContext.m; sourceTree = "<group>"; };
 		BE3AD47A5E5845568DFDE2162773821F /* MTITransform.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTITransform.h; sourceTree = "<group>"; };
 		BEAFE3992F336768B1CEEBB0A76790B4 /* MTIMPSDefinitionFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMPSDefinitionFilter.m; sourceTree = "<group>"; };
 		BFE0E806B256BB3A9700DB5FD424B6A9 /* MTIImage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIImage.h; sourceTree = "<group>"; };
-		C064D3006B9D3DA837E6A324043937EF /* MTIVideoComposition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIVideoComposition.swift; sourceTree = "<group>"; };
+		C0F438C95D9F6134B973892D08D9C90F /* MTIColor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIColor.swift; sourceTree = "<group>"; };
 		C17A0628178212F76DCE9680877FA412 /* MTIBlendModes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIBlendModes.h; sourceTree = "<group>"; };
 		C33CAEF97463167982B0D85B4A6F40C0 /* MTIVector+SIMD.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "MTIVector+SIMD.m"; sourceTree = "<group>"; };
 		C34ED5A0B8F0040BCA7FF07F063F4AA6 /* MTIAlphaType.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIAlphaType.m; sourceTree = "<group>"; };
 		C3C52A774103E9679118BB50F6D10E55 /* MTICropFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICropFilter.h; sourceTree = "<group>"; };
 		C5D59DAF4CB77D4E67FB427915F52D4A /* MTIVibranceFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIVibranceFilter.h; sourceTree = "<group>"; };
-		C5D698D73004301D6721BF8A2D2D0EB6 /* MTIVertex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIVertex.swift; sourceTree = "<group>"; };
+		C6A52788E53455D323A3C7A514A026B6 /* MTICoreImageExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTICoreImageExtension.swift; sourceTree = "<group>"; };
+		C6C94F2509FBD062966808822E78CDA1 /* MTICorner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTICorner.swift; sourceTree = "<group>"; };
 		C7905C9FDAA58B78BC083B0E2854C505 /* MTICVMetalTextureCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTICVMetalTextureCache.m; sourceTree = "<group>"; };
 		C870EA46C8220E8CFCCD47429DC0937A /* MTIFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIFilter.h; sourceTree = "<group>"; };
 		C87E642E4802C59658D87E7058A192BD /* Pods-MetalPetalExamples-MetalPetalExamples (iOS).release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-MetalPetalExamples-MetalPetalExamples (iOS).release.xcconfig"; sourceTree = "<group>"; };
@@ -685,7 +689,8 @@
 		D24DDF832828EE4F31C7C3EDC8501387 /* MTIRenderGraphOptimization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIRenderGraphOptimization.h; sourceTree = "<group>"; };
 		D4594ED8316E9485C8D047368DF9F011 /* MTISCNSceneRenderer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTISCNSceneRenderer.h; sourceTree = "<group>"; };
 		D6BB01559B627146085BCF1144C2DA26 /* MTICLAHEFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTICLAHEFilter.m; sourceTree = "<group>"; };
-		D8C6D6B1CC643746D5CDD2B27BE716F3 /* MTISIMDArgumentEncoder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTISIMDArgumentEncoder.swift; sourceTree = "<group>"; };
+		D8F4BFC87BF26CE1113DCF16E8F8AEC9 /* MTITextureDimensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTITextureDimensions.swift; sourceTree = "<group>"; };
+		D91708FAA28003E520B9EF4726D7F869 /* MetalPetal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MetalPetal.swift; sourceTree = "<group>"; };
 		D923AAD0CB084596522F9F1B4789B175 /* CLAHE.metal */ = {isa = PBXFileReference; includeInIndex = 1; path = CLAHE.metal; sourceTree = "<group>"; };
 		D96B6F02A66345DED9C856D1BD504B40 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		D9DCB3600E15951DE046C97C55F5BE54 /* MTIMPSUnsharpMaskFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMPSUnsharpMaskFilter.h; sourceTree = "<group>"; };
@@ -693,7 +698,6 @@
 		DCA6512368E6D9B20E3784A213050F9F /* MTIGeometryUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIGeometryUtilities.m; sourceTree = "<group>"; };
 		DCAFD03727F6E904E3AEEAAC1CC1BE97 /* MTIMPSSobelFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIMPSSobelFilter.h; sourceTree = "<group>"; };
 		DDAE8FEA0BDC7BF6466286F2E1FC3B99 /* MTIPrint.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIPrint.h; sourceTree = "<group>"; };
-		DDDC220791823F8B8EDCC75DEEFE5AE2 /* MTIPixelFormat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIPixelFormat.swift; sourceTree = "<group>"; };
 		DE4504BC5F4A6A410885244736A7FAE4 /* MTILock.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTILock.h; sourceTree = "<group>"; };
 		DE72E310B0B5D4708C68402660CD3BA4 /* Pods-MetalPetalExamples-MetalPetalExamples (macOS)-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-MetalPetalExamples-MetalPetalExamples (macOS)-frameworks.sh"; sourceTree = "<group>"; };
 		DE8E1F388170A671FCF62664F42CCF25 /* MTIBlendFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIBlendFilter.h; sourceTree = "<group>"; };
@@ -703,9 +707,10 @@
 		E45DADC9ED7F67B45549BBD3BC1755BF /* MetalPetal-Core-Swift */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "MetalPetal-Core-Swift"; path = MetalPetal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4CA643AFD489837BDA5B07F9AEF20D8 /* MTIBulgeDistortionFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIBulgeDistortionFilter.h; sourceTree = "<group>"; };
 		E6ADA49B609B3FAFADA6A2D39E688717 /* MTIImagePromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIImagePromise.m; sourceTree = "<group>"; };
+		E7943BF975882151B9BD025A7A616607 /* MTIVector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIVector.swift; sourceTree = "<group>"; };
 		E7DF12693A45897175F60127B439D16A /* MetalPetal-Core-Swift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "MetalPetal-Core-Swift.release.xcconfig"; path = "../MetalPetal-Core-Swift/MetalPetal-Core-Swift.release.xcconfig"; sourceTree = "<group>"; };
-		E89795823431E721A98D88072DB54991 /* MTIContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIContext.swift; sourceTree = "<group>"; };
 		EA170FD883EA613973ED2B16D80C1EBC /* MTIComputePipeline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIComputePipeline.h; sourceTree = "<group>"; };
+		EBA4F13EBECC58E28B472AD50A7CA612 /* MTIRenderPipelineKernel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIRenderPipelineKernel.swift; sourceTree = "<group>"; };
 		EC826C41089341DF8216FEEABA77CEF1 /* MTICVPixelBufferPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTICVPixelBufferPromise.h; sourceTree = "<group>"; };
 		EE9BAFF05C5720FC8E639F84631D8A92 /* MTIMultilayerCompositeKernel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIMultilayerCompositeKernel.m; sourceTree = "<group>"; };
 		EFAA10005743551A20106493A5E46F07 /* Pods-MetalPetalExamples-MetalPetalExamples (iOS)-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-MetalPetalExamples-MetalPetalExamples (iOS)-acknowledgements.plist"; sourceTree = "<group>"; };
@@ -714,22 +719,12 @@
 		F2CC0881E4DEACE9488067D24EC8211C /* MTIVertex.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIVertex.m; sourceTree = "<group>"; };
 		F3127DA534F8DF0893392C62B3969338 /* MTIDefer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MTIDefer.h; sourceTree = "<group>"; };
 		F4E59C977E0B5CB6322A12F776BF54DE /* HighPassSkinSmoothing.metal */ = {isa = PBXFileReference; includeInIndex = 1; path = HighPassSkinSmoothing.metal; sourceTree = "<group>"; };
-		F575DD21FD663D8B548ED1F872590F12 /* MetalPetal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MetalPetal.swift; sourceTree = "<group>"; };
 		F717F5873FADD7511C4883FB7FE39261 /* MTITextureDescriptor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTITextureDescriptor.m; sourceTree = "<group>"; };
 		FAF57654779509E76735FAB325EC058B /* MetalPetal-AppleSilicon-Core-Swift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "MetalPetal-AppleSilicon-Core-Swift.release.xcconfig"; sourceTree = "<group>"; };
-		FCC32955D75E51A051F78B9406DD9746 /* MTIRGBColorSpaceConversionFilter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MTIRGBColorSpaceConversionFilter.swift; sourceTree = "<group>"; };
 		FEBC1D778C54B5F25FF83E52DEB4AB69 /* MTIBlendFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MTIBlendFilter.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		01542B9DCA383C7031C69AB9DD568C97 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				7361BB1E6ED3F8A941FA79EA03959500 /* Cocoa.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		3F5B3FEBF06CDBA6DAC7991AE4B4E5C9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -746,24 +741,60 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6335179AE0BE1FC69DFBD90EABC12FE4 /* Frameworks */ = {
+		58B4147D29923907DD21BE12D0E78072 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				94DC2228FF4BDF91EB67B0A150256BBB /* Foundation.framework in Frameworks */,
+				FEC3D8273F85D54B66A308F27EA7A048 /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9285C5448EAB7F22D2B698ABFAEAD616 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E0A8748533518F536DABB1F3EA683A59 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0A26B10BF5C2C03B1B2E8F988D130553 /* Swift */ = {
+			isa = PBXGroup;
+			children = (
+				D91708FAA28003E520B9EF4726D7F869 /* MetalPetal.swift */,
+				5C1627D99729B48FFD9053B927130125 /* MTIAlphaType.swift */,
+				C0F438C95D9F6134B973892D08D9C90F /* MTIColor.swift */,
+				44D2796D5C6FDC685BEFA6996CC75C4B /* MTIColorMatrix.swift */,
+				7E1DFACD08669DECACC3BB24468070AE /* MTIContext.swift */,
+				C6A52788E53455D323A3C7A514A026B6 /* MTICoreImageExtension.swift */,
+				C6C94F2509FBD062966808822E78CDA1 /* MTICorner.swift */,
+				77C19153B5BDAEEAECA3BE20650B76F7 /* MTICropRegion.swift */,
+				B6FC792FC8DAC9313C20C8F3E2441230 /* MTIDataBuffer.swift */,
+				48F68190E4178E5FA523E0CCF316E2AA /* MTIError.swift */,
+				2EAC8394FB0E80CCE2A97F4AB4B56113 /* MTIFunctionDescriptor.swift */,
+				1B14DABA285F792CC3CFDDC37979BC71 /* MTIImage.swift */,
+				518C430901F215C101898B2E31020C73 /* MTIPixelFormat.swift */,
+				4C50ED68A4B82B87B9853A2F9350EFA3 /* MTISIMDArgumentEncoder.swift */,
+				D8F4BFC87BF26CE1113DCF16E8F8AEC9 /* MTITextureDimensions.swift */,
+				E7943BF975882151B9BD025A7A616607 /* MTIVector.swift */,
+				B17E826B5869A8EDA5DCD3EBE5940963 /* MTIVertex.swift */,
+				8BB873C68D2563D202B0F6A5A1BCFB89 /* MTIVideoComposition.swift */,
+				EC96EF51E3085A5C299A7A9CDB588C16 /* Filters */,
+				4693215B449327FF762553E815011C39 /* Kernels */,
+				AC7A4E94289E9B5C7A35F90E7810D4B5 /* UI */,
+			);
+			name = Swift;
+			sourceTree = "<group>";
+		};
 		1397CD9F7C9EF03F12D0A847937A0E59 /* MetalPetal */ = {
 			isa = PBXGroup;
 			children = (
 				3E3EC1D234AB979DDC8124BF3282D437 /* Core */,
 				5A071B4EA514C66FB2451886D76D3266 /* Pod */,
 				787FD96A450C032656F878A085A92FFD /* Support Files */,
-				D6082EC0229CBF9FCF02841037819C2F /* Swift */,
+				0A26B10BF5C2C03B1B2E8F988D130553 /* Swift */,
 			);
 			name = MetalPetal;
 			path = ../Frameworks/MetalPetal;
@@ -913,6 +944,16 @@
 			path = Kernels;
 			sourceTree = "<group>";
 		};
+		4693215B449327FF762553E815011C39 /* Kernels */ = {
+			isa = PBXGroup;
+			children = (
+				0F42FFF4671ABF7D97023F18B62349C2 /* MTIComputePipelineKernel.swift */,
+				EBA4F13EBECC58E28B472AD50A7CA612 /* MTIRenderPipelineKernel.swift */,
+			);
+			name = Kernels;
+			path = Kernels;
+			sourceTree = "<group>";
+		};
 		57023583EAD2DA905BBAAE53A3F233D4 /* Pods-MetalPetalExamples-MetalPetalExamples (iOS) */ = {
 			isa = PBXGroup;
 			children = (
@@ -947,15 +988,6 @@
 			name = Pod;
 			sourceTree = "<group>";
 		};
-		765458CD5CED9C188A2C5A15B81B4FBD /* UI */ = {
-			isa = PBXGroup;
-			children = (
-				3CD698896E6D092584FCA5BD38B1C9B8 /* MTIImageViewProtocol.swift */,
-			);
-			name = UI;
-			path = UI;
-			sourceTree = "<group>";
-		};
 		787FD96A450C032656F878A085A92FFD /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -972,17 +1004,6 @@
 			);
 			name = "Support Files";
 			path = "../../Pods/Target Support Files/MetalPetal-AppleSilicon-Core-Swift";
-			sourceTree = "<group>";
-		};
-		7F3FE9E76D0119DB0BF3427722A6A302 /* Filters */ = {
-			isa = PBXGroup;
-			children = (
-				B89E166384417C93EEEB709D6E4A9DE1 /* Filter.swift */,
-				FCC32955D75E51A051F78B9406DD9746 /* MTIRGBColorSpaceConversionFilter.swift */,
-				180993A2787EFF3A8DBAA3D002CC937C /* MultilayerCompositingFilter.swift */,
-			);
-			name = Filters;
-			path = Filters;
 			sourceTree = "<group>";
 		};
 		A4C391CC27F112247362C05E46D7F5B2 /* Shaders */ = {
@@ -1022,6 +1043,15 @@
 				93F04452328C5602341AD80451DD9D4E /* Pods-MetalPetalExamples-MetalPetalExamples (macOS) */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		AC7A4E94289E9B5C7A35F90E7810D4B5 /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				97E1E87D90BEC4E6991AE5AC48D888B2 /* MTIImageViewProtocol.swift */,
+			);
+			name = UI;
+			path = UI;
 			sourceTree = "<group>";
 		};
 		B2352AA60241BEFFF05872845C365185 /* SpriteKit */ = {
@@ -1123,15 +1153,6 @@
 			path = UI;
 			sourceTree = "<group>";
 		};
-		CA64FE6A7844288EA74BAB49B558497A /* Kernels */ = {
-			isa = PBXGroup;
-			children = (
-				06634379423486FA5C79A26134E974B6 /* MTIComputePipelineKernel.swift */,
-			);
-			name = Kernels;
-			path = Kernels;
-			sourceTree = "<group>";
-		};
 		CE99DF0ABA5FB7E00AC2861D6C3EE997 /* OS X */ = {
 			isa = PBXGroup;
 			children = (
@@ -1151,32 +1172,15 @@
 			);
 			sourceTree = "<group>";
 		};
-		D6082EC0229CBF9FCF02841037819C2F /* Swift */ = {
+		EC96EF51E3085A5C299A7A9CDB588C16 /* Filters */ = {
 			isa = PBXGroup;
 			children = (
-				F575DD21FD663D8B548ED1F872590F12 /* MetalPetal.swift */,
-				309CD50F9862DED7227D1567139AA70F /* MTIAlphaType.swift */,
-				280BBD2FFA2096DEB29F65AA3A746F97 /* MTIColor.swift */,
-				552422256A92E5B0BD669E908CE3895A /* MTIColorMatrix.swift */,
-				E89795823431E721A98D88072DB54991 /* MTIContext.swift */,
-				6A1A4E83423BA248CF37F5CA880CFC73 /* MTICoreImageExtension.swift */,
-				0EE571E8CB85DCF6F357CD8DAA3AE487 /* MTICorner.swift */,
-				7C3F1D22604D4CE74FD6D91A6A00126F /* MTICropRegion.swift */,
-				556074EB4DCE458E9FFDA0303F008462 /* MTIDataBuffer.swift */,
-				276AB8C54378AD1A6E1305BBF8866223 /* MTIError.swift */,
-				80BF9AB8BCA2347EC148983914AADDE3 /* MTIFunctionDescriptor.swift */,
-				51E63002E575273A6B29BAAFD639A807 /* MTIImage.swift */,
-				DDDC220791823F8B8EDCC75DEEFE5AE2 /* MTIPixelFormat.swift */,
-				D8C6D6B1CC643746D5CDD2B27BE716F3 /* MTISIMDArgumentEncoder.swift */,
-				158A8EFE6110E8196D7C6469EDC15E63 /* MTITextureDimensions.swift */,
-				7B0243A423BEFA91D847C05973AF6C95 /* MTIVector.swift */,
-				C5D698D73004301D6721BF8A2D2D0EB6 /* MTIVertex.swift */,
-				C064D3006B9D3DA837E6A324043937EF /* MTIVideoComposition.swift */,
-				7F3FE9E76D0119DB0BF3427722A6A302 /* Filters */,
-				CA64FE6A7844288EA74BAB49B558497A /* Kernels */,
-				765458CD5CED9C188A2C5A15B81B4FBD /* UI */,
+				2D415EA68815D0046129EBDEA297DA49 /* Filter.swift */,
+				A33495C292E252A024DFFB0ABD59052F /* MTIRGBColorSpaceConversionFilter.swift */,
+				19BB95D6F52A8B62151B3742655637A0 /* MultilayerCompositingFilter.swift */,
 			);
-			name = Swift;
+			name = Filters;
+			path = Filters;
 			sourceTree = "<group>";
 		};
 		EE58FB25FB26FBE93E1DDB02442D3DE6 /* Development Pods */ = {
@@ -1223,213 +1227,213 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8C794246DE221D49D0971923F992CC48 /* Headers */ = {
+		88655156E4E556B338292E6921C2A8EF /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B98343512DE7AAE6558F466DCC13387D /* MetalPetal.h in Headers */,
-				60B72AA53E8832E275DF28A7C978E84A /* MTIAlphaPremultiplicationFilter.h in Headers */,
-				1AF5316B29366ECF5CA60C62D91E5E2C /* MTIAlphaType.h in Headers */,
-				71843C09630B70FEEE6B64744D1814B9 /* MTIBlendFilter.h in Headers */,
-				64E50A879993E3E698EC3C3FB9946B28 /* MTIBlendFormulaSupport.h in Headers */,
-				0EBA5AD4DD5C1739ECDB5A6F786A1F7B /* MTIBlendModes.h in Headers */,
-				D048A3FE227FCF120E1149F9F333AD8C /* MTIBlendWithMaskFilter.h in Headers */,
-				D327C8F05D85F2A81E445C8CF076E107 /* MTIBuffer.h in Headers */,
-				0E94F2157BE15060EF8F133FFEB8FEB5 /* MTIBulgeDistortionFilter.h in Headers */,
-				01AEEC95D70894F877BAF5C6105EBA42 /* MTIChromaKeyBlendFilter.h in Headers */,
-				FAE004B80E76BBB99C3290AB20CB2B52 /* MTICLAHEFilter.h in Headers */,
-				9A3B3E828DAA47FF9B3C270F2CB31CD5 /* MTIColor.h in Headers */,
-				469B31B6032959FA3F7BB836E3F95EB3 /* MTIColorHalftoneFilter.h in Headers */,
-				C36B8004C4BD508F411EF9B809A4A392 /* MTIColorLookupFilter.h in Headers */,
-				E93E6CB5208B98B4E26A8F3736A302B1 /* MTIColorMatrix.h in Headers */,
-				ED0109F71BD0598937CA347338EB4CCA /* MTIColorMatrixFilter.h in Headers */,
-				D8885A31AA97A44934C6D792CE715061 /* MTIComputePipeline.h in Headers */,
-				8515DEE6D3DC867B6707288D5151E012 /* MTIComputePipelineKernel.h in Headers */,
-				F7EC659BA75A7A3D33D87A9071D8A44C /* MTIContext.h in Headers */,
-				B68BAD4717026E6222CAAAB5615109F3 /* MTIContext+Internal.h in Headers */,
-				B27537A041973A588719C19A0147D5FC /* MTIContext+Rendering.h in Headers */,
-				5A0EC99D78A3D501AB62370246E5CC03 /* MTICoreImageRendering.h in Headers */,
-				2553A3190093084041E60F34CEE61343 /* MTICorner.h in Headers */,
-				78DB8BE1C2540B9AFAF0DF3C2A4D6558 /* MTICropFilter.h in Headers */,
-				47DF07B897952BFED77C18A2412693BB /* MTICVMetalIOSurfaceBridge.h in Headers */,
-				69A68C401C6F02568AB6A7A1F7094E3C /* MTICVMetalTextureBridging.h in Headers */,
-				CA552E7F8AC48761249DEECF8ABED5CD /* MTICVMetalTextureCache.h in Headers */,
-				A442BC2A79A3BC9D4A77079E65677365 /* MTICVPixelBufferPool.h in Headers */,
-				C67D6855E3410532CAAA132ADD47C2FA /* MTICVPixelBufferPromise.h in Headers */,
-				DA7328D86C967063D54F11ED844D131C /* MTICVPixelBufferRendering.h in Headers */,
-				770D14A3E08624F975BD30C44A0A646E /* MTIDefer.h in Headers */,
-				E143DC6E21ED9CBDBF33CF277A10DFA1 /* MTIDotScreenFilter.h in Headers */,
-				07C3922298947352F06631DF450F1BC6 /* MTIDrawableRendering.h in Headers */,
-				16ED7C4D298BF1B4D334D919A3D6677F /* MTIError.h in Headers */,
-				FFBDE8164337C8FA9A188708979B166C /* MTIFilter.h in Headers */,
-				8F1BBD69C9E4194AB3786DD357714C31 /* MTIFunctionArgumentsEncoder.h in Headers */,
-				69104B8C914B8B7CB5FDE03FEDB6C490 /* MTIFunctionDescriptor.h in Headers */,
-				48985AB97BAB8E9FB41D133CAB8D30C7 /* MTIGeometry.h in Headers */,
-				A1CF226E79488717F9932DBE76F21187 /* MTIGeometryUtilities.h in Headers */,
-				582243E1725B2AA81CF832FDA7DCDB5D /* MTIHasher.h in Headers */,
-				DBEE69247CE7A496A488890F615E2AE1 /* MTIHexagonalBokehBlurFilter.h in Headers */,
-				576633A3DB59A02E86CCF716EA671054 /* MTIHighPassSkinSmoothingFilter.h in Headers */,
-				625E0C00F2AC62084323EBDD933F89A4 /* MTIImage.h in Headers */,
-				8FACD894E1DB2DFBCFB3263A89340602 /* MTIImage+Filters.h in Headers */,
-				F3891ECBBE0FFEEBD576CDD2C760688F /* MTIImage+Promise.h in Headers */,
-				2CD6C8FB6F10D47D6F03865EDF46286D /* MTIImageOrientation.h in Headers */,
-				DD505A210CF8AE17CC1692A017CCB285 /* MTIImagePromise.h in Headers */,
-				B48BC46DE2BED62089A4C536892752EB /* MTIImagePromiseDebug.h in Headers */,
-				BAB98820BEF4DB24FEAD1902C2070FD7 /* MTIImageProperties.h in Headers */,
-				153EE663866DE85B3C3EFF3A096B1947 /* MTIImageRenderingContext.h in Headers */,
-				76197B1589DCDCA624656B8F154517BA /* MTIImageRenderingContext+Internal.h in Headers */,
-				130D583C45D8796EBE76B00E52A7212F /* MTIImageView.h in Headers */,
-				612B8BF91EECAD9FB61272510C3986E3 /* MTIKernel.h in Headers */,
-				68B586497951C0460308F4675C116B41 /* MTILayer.h in Headers */,
-				BE6F1DEDE7CC5A79443383CC31BFC084 /* MTILibrarySource.h in Headers */,
-				FFDFB9C20B1D96022296A3DF8E60D226 /* MTILock.h in Headers */,
-				F201C6D3373C11921B9BF1F6E75FC627 /* MTIMask.h in Headers */,
-				EC0FD04778F71804B91888EB405B4A8A /* MTIMemoryWarningObserver.h in Headers */,
-				2A1C57E38632E67D5694C4BA04F72A07 /* MTIMPSBoxBlurFilter.h in Headers */,
-				A4CAA351E3F87AF17A354CF61D24D633 /* MTIMPSConvolutionFilter.h in Headers */,
-				665450C77CC799B2D3156DBB4BBC1AE6 /* MTIMPSDefinitionFilter.h in Headers */,
-				B80C3FFDFF487C18DB36CC687A691C3E /* MTIMPSGaussianBlurFilter.h in Headers */,
-				E7310905FF5926024AF2DF5A45D38D49 /* MTIMPSHistogramFilter.h in Headers */,
-				E7FFA9D2D819E622E4BF2AC4E0BA3DB8 /* MTIMPSKernel.h in Headers */,
-				AD0797D54CEA885EE3A6669CE82D1438 /* MTIMPSSobelFilter.h in Headers */,
-				D9EBEB41276A200E9ED5BB1729E31E2D /* MTIMPSUnsharpMaskFilter.h in Headers */,
-				9559662C3E72B6C7E7D8F869C3F86B34 /* MTIMultilayerCompositeKernel.h in Headers */,
-				DA0E08D5BFF285E220B63365CFB45D9D /* MTIMultilayerCompositingFilter.h in Headers */,
-				35B442C2FAEC027B79034BC2EA639DB3 /* MTIPixelFormat.h in Headers */,
-				1D65BF7C4ACAC6C966EC864D4CADA09C /* MTIPixellateFilter.h in Headers */,
-				16EAE26EC8D347AF57A233F39A56308C /* MTIPrint.h in Headers */,
-				2C034A8EAE9426828151A9043971FF95 /* MTIRenderCommand.h in Headers */,
-				7B6FA64CBD80B21D6BAB7A65126634E8 /* MTIRenderGraphOptimization.h in Headers */,
-				02E1F1D589E91C0A814EE935D8DAE9C5 /* MTIRenderPassOutputDescriptor.h in Headers */,
-				467DA02A9B44F7A9B16FC2A2494094BC /* MTIRenderPipeline.h in Headers */,
-				AB81652CA633D7A5192CBD24C35C6082 /* MTIRenderPipelineKernel.h in Headers */,
-				D8180B5DE50EDB13270576346C362F33 /* MTIRenderTask.h in Headers */,
-				4F99AC101C7FC2444B557BE52FC9C187 /* MTIRGBColorSpaceConversionFilter.h in Headers */,
-				B37698AAB1A6AA94D1CB41BD963461AE /* MTIRGBToneCurveFilter.h in Headers */,
-				966D60A91125E903E2559ABF665B406E /* MTIRoundCornerFilter.h in Headers */,
-				333EE6D72940A5EAB203DDA0BE25CB2F /* MTISamplerDescriptor.h in Headers */,
-				AECD1D904D46F9E33D899B95B7BED47C /* MTISCNSceneRenderer.h in Headers */,
-				59E82117CD951017897E9A6F7AF96466 /* MTIShaderFunctionConstants.h in Headers */,
-				8B7E810383F67629855E13A7C3997F6D /* MTIShaderLib.h in Headers */,
-				067245457876A1EFC0030E825A478448 /* MTISKSceneRenderer.h in Headers */,
-				216BF36CCABD68DF6ED62EC205526AA0 /* MTITextureDescriptor.h in Headers */,
-				D6063BFCE67011CC10CF15B1DF3BBD57 /* MTITextureDimensions.h in Headers */,
-				288EEE25DB081E4B815A0D0A24F2F12C /* MTITextureLoader.h in Headers */,
-				0F50B431D306F22004B9B1F235B20E28 /* MTITexturePool.h in Headers */,
-				4584CF4DA4DEE9E41C453638155F96D7 /* MTIThreadSafeImageView.h in Headers */,
-				80D44193AFCF19C5CAEF46CFAF66CDAF /* MTITransform.h in Headers */,
-				BDDA623E1C4F9A9DDDFC5DBB4827F157 /* MTITransformFilter.h in Headers */,
-				3CBF9762DAAEFD882E8DCFEF77A0AFBE /* MTIUnaryImageRenderingFilter.h in Headers */,
-				BC7135DB182F8695039FB0B1D1AA8035 /* MTIVector.h in Headers */,
-				8CFE33AFE376ADFA7A72CC8C1B9B7445 /* MTIVector+SIMD.h in Headers */,
-				C203AE665E7FF52DF25605F1FEFD279A /* MTIVertex.h in Headers */,
-				EF741471F3EB09D72C02725462BF23E5 /* MTIVibranceFilter.h in Headers */,
-				507A62AF045B7CFA3B4135BEBAC18A6D /* MTIWeakToStrongObjectsMapTable.h in Headers */,
+				1F8420B1C4516C9DEE224D8FDD1877D9 /* MetalPetal.h in Headers */,
+				9986EFBAABD96936C4A01FECA51A04F8 /* MTIAlphaPremultiplicationFilter.h in Headers */,
+				C2A45906BC6B089BF57E99004088E5A2 /* MTIAlphaType.h in Headers */,
+				251445AECEF1EA98684F626949808502 /* MTIBlendFilter.h in Headers */,
+				E08B97DF4A6AD4D1A3D5537540834025 /* MTIBlendFormulaSupport.h in Headers */,
+				1CE253FE94CDD4233F7BFFB13277C5C6 /* MTIBlendModes.h in Headers */,
+				189331A12A1F294A4EE7F87798C2AE06 /* MTIBlendWithMaskFilter.h in Headers */,
+				BC8625A6C9CF967A2FAD34B838CA4BC4 /* MTIBuffer.h in Headers */,
+				D8745E15E4972277C3720637C32D78BE /* MTIBulgeDistortionFilter.h in Headers */,
+				35DB36686300153CEFA0EB88F0E48F28 /* MTIChromaKeyBlendFilter.h in Headers */,
+				22D638F1118FDC05D8A3D52530740291 /* MTICLAHEFilter.h in Headers */,
+				0D9A36D7192C0E036999E9C22AE35C7D /* MTIColor.h in Headers */,
+				D01328E8D7B60A0EB0D6E13FC5903CFC /* MTIColorHalftoneFilter.h in Headers */,
+				5EF12CD1F376A6F5A6C2173CF2A341C2 /* MTIColorLookupFilter.h in Headers */,
+				91DF5CD6327F01757CB97E5FCCC861C1 /* MTIColorMatrix.h in Headers */,
+				FE71B77670AB37A28AC8A75AE4F52EC2 /* MTIColorMatrixFilter.h in Headers */,
+				798AB183ECEA7D51FBF45567E50F31A5 /* MTIComputePipeline.h in Headers */,
+				7144EA3A924B1B576A6CA1A8352B0F83 /* MTIComputePipelineKernel.h in Headers */,
+				7E77A8998159186EC568C0FD7A5AC1A8 /* MTIContext.h in Headers */,
+				B4466C033EE1A7414FC8070DB099B770 /* MTIContext+Internal.h in Headers */,
+				92708544F61538D9351B66AF3CB6796A /* MTIContext+Rendering.h in Headers */,
+				47D5C73BA2927F4C2050508F9091BA27 /* MTICoreImageRendering.h in Headers */,
+				F6C8D0B41423647BBC1D01ADC7911642 /* MTICorner.h in Headers */,
+				B62A224658E746D92A58077DF3C3035B /* MTICropFilter.h in Headers */,
+				99E212F22BFE3079D4AF999F8AE2D7A3 /* MTICVMetalIOSurfaceBridge.h in Headers */,
+				46E15F2BF3A08F3467C47939620A4B4D /* MTICVMetalTextureBridging.h in Headers */,
+				382DDF492E7C944F7A6D275C9463388A /* MTICVMetalTextureCache.h in Headers */,
+				833D8C404D9B05CE9BA645573792D596 /* MTICVPixelBufferPool.h in Headers */,
+				5171D6E72A49454CD36FAB4939C48E5A /* MTICVPixelBufferPromise.h in Headers */,
+				FAA37BD49CAC5DCA3CB6601A4EFFE452 /* MTICVPixelBufferRendering.h in Headers */,
+				A739A322716EC32D2B81E3BD73389A4D /* MTIDefer.h in Headers */,
+				1E7A7D0CC793F3889542B8B9C81A9D1E /* MTIDotScreenFilter.h in Headers */,
+				C6B898B48E362CBECE91E2551C719325 /* MTIDrawableRendering.h in Headers */,
+				FAC92ABDFA6272F8617286C1E9D8B333 /* MTIError.h in Headers */,
+				338B52C22DDF20527FDE83CC5C612C1A /* MTIFilter.h in Headers */,
+				40E68CB3EEF7B32A3262764EAFD148E1 /* MTIFunctionArgumentsEncoder.h in Headers */,
+				3878EB704E1F2B6CAD3AF19F758988E3 /* MTIFunctionDescriptor.h in Headers */,
+				597299668FC0C57AB7B1FDA243136E6E /* MTIGeometry.h in Headers */,
+				990039B4799817ABBEEB9D8579D00566 /* MTIGeometryUtilities.h in Headers */,
+				8BE7B99DD305F2EE50717458C3A99367 /* MTIHasher.h in Headers */,
+				AEE71825000F79C9B721D4C3CBF743D5 /* MTIHexagonalBokehBlurFilter.h in Headers */,
+				9C09918844C0E52D47FC1E6349AC8261 /* MTIHighPassSkinSmoothingFilter.h in Headers */,
+				3E7F958C6B6129458101653AC0AB8E69 /* MTIImage.h in Headers */,
+				69309D87AED8DC32D2AD413A6F9B78AB /* MTIImage+Filters.h in Headers */,
+				DE55E2D6054DE9FBBDFC483827AD1E80 /* MTIImage+Promise.h in Headers */,
+				9E6B52EBCDEB40F7868F93B29E8244DD /* MTIImageOrientation.h in Headers */,
+				32E419761A5275222374E6C4E9499B2E /* MTIImagePromise.h in Headers */,
+				DACFF20D875E71478E31B8FA4395F7FD /* MTIImagePromiseDebug.h in Headers */,
+				881C63463559B938506B0A4DF1D59168 /* MTIImageProperties.h in Headers */,
+				860F5DEE95DB7B3F0A222145E2F253A6 /* MTIImageRenderingContext.h in Headers */,
+				69946A4673FD8C8215548B8EC38F5EDB /* MTIImageRenderingContext+Internal.h in Headers */,
+				001362E589693207CF42E87A39808CC2 /* MTIImageView.h in Headers */,
+				50C92996719567669FE015AED0137666 /* MTIKernel.h in Headers */,
+				79F7BD3AAEB50429C86A6E2CA7A0C104 /* MTILayer.h in Headers */,
+				A4DAC8B16BECD40E851CCBAD27DBF416 /* MTILibrarySource.h in Headers */,
+				133D19E0496AC5BEEFF94A2D71BE684A /* MTILock.h in Headers */,
+				B277F343DBE9945CB16A4DC0AA2C66B7 /* MTIMask.h in Headers */,
+				909B6F7E155CEFC4FD5CD69BD80FCB5B /* MTIMemoryWarningObserver.h in Headers */,
+				8B3F0CAF9B4C645C92D588683BC3F682 /* MTIMPSBoxBlurFilter.h in Headers */,
+				C1A4A49A5F1A406154C63B83F6E4C75E /* MTIMPSConvolutionFilter.h in Headers */,
+				880E7C61DB72477BEBA50DB913D92489 /* MTIMPSDefinitionFilter.h in Headers */,
+				92AB75471CE1F089D321F762279FDB74 /* MTIMPSGaussianBlurFilter.h in Headers */,
+				15F9BA9BDE2370D1558E39F411B01481 /* MTIMPSHistogramFilter.h in Headers */,
+				16EB001C607C9651255A47F663E04889 /* MTIMPSKernel.h in Headers */,
+				3A3B1FDB1D15897BB28C5D4E7BE65DF8 /* MTIMPSSobelFilter.h in Headers */,
+				FDE03A645E1CFD16B25A4A7555D6E764 /* MTIMPSUnsharpMaskFilter.h in Headers */,
+				398D07270DB72A1CA8610226D7492BF9 /* MTIMultilayerCompositeKernel.h in Headers */,
+				C9F1554DBEDB5ADC9EE699E63C4875C0 /* MTIMultilayerCompositingFilter.h in Headers */,
+				75B5C461AF883C01526011895E34D9AB /* MTIPixelFormat.h in Headers */,
+				1CC7BBCDD47A9245566798BA843EBF1D /* MTIPixellateFilter.h in Headers */,
+				62934A61E285E6ED724F0466D9D0DDB4 /* MTIPrint.h in Headers */,
+				9B39DD1A64F9A25F9B36C700CA7CC765 /* MTIRenderCommand.h in Headers */,
+				10B6C2018B13F1F150781552E1BB91AE /* MTIRenderGraphOptimization.h in Headers */,
+				B812CBD811BA15D869CF86A0411D0326 /* MTIRenderPassOutputDescriptor.h in Headers */,
+				786A2DE4A67EFC36A6009CC71940849F /* MTIRenderPipeline.h in Headers */,
+				C878B6ABCC015F6DB9E01E6591ADC770 /* MTIRenderPipelineKernel.h in Headers */,
+				BD1EB5D4D5724CC83AAD6FBB01C8FB11 /* MTIRenderTask.h in Headers */,
+				37F2129364C74B9190F8E49FA31003F7 /* MTIRGBColorSpaceConversionFilter.h in Headers */,
+				4212B77D04D95F74408EC8FCF4D477AC /* MTIRGBToneCurveFilter.h in Headers */,
+				B616A7F0B9E47C542A33A3163E6FF2BB /* MTIRoundCornerFilter.h in Headers */,
+				8505E30A2C272CB683570251D091228D /* MTISamplerDescriptor.h in Headers */,
+				E726C9A2AEA59335A6D6B13455C513E7 /* MTISCNSceneRenderer.h in Headers */,
+				290691A3D0EF0FD535FE38899EE9A5AE /* MTIShaderFunctionConstants.h in Headers */,
+				CA02D580B54B9011CA3B99D37A72AC6F /* MTIShaderLib.h in Headers */,
+				2061A892EA38A2E047BCC5CC96E55084 /* MTISKSceneRenderer.h in Headers */,
+				09CF02C00484BC81DF5C3B06CB4CDD38 /* MTITextureDescriptor.h in Headers */,
+				1E8E88C16D52E202DD5C921E0BF9B88F /* MTITextureDimensions.h in Headers */,
+				DB8FBD7EE87FD197AFD590D38FEF57DF /* MTITextureLoader.h in Headers */,
+				5DEC02BA82C921C59C8643FD49BF9F08 /* MTITexturePool.h in Headers */,
+				0D98D2D0849CD47D89D4CE118B390D7E /* MTIThreadSafeImageView.h in Headers */,
+				E4EE1DC71D84BCDA7A9C7C36507DDA4A /* MTITransform.h in Headers */,
+				873753913B9DD6C6C4B048FF3FEF2293 /* MTITransformFilter.h in Headers */,
+				026FBC14CC0957D963925C9429AAAF1F /* MTIUnaryImageRenderingFilter.h in Headers */,
+				77C62A839920164C7709E8C848D73B86 /* MTIVector.h in Headers */,
+				E6520C686884D86EADE1A28875691425 /* MTIVector+SIMD.h in Headers */,
+				5AC70AF95C239CFB43F84487F85DE597 /* MTIVertex.h in Headers */,
+				4410BC6FAA67ACE717D4F0931D1C8323 /* MTIVibranceFilter.h in Headers */,
+				CA635A54824FA9468BB517E7B6BDE9C6 /* MTIWeakToStrongObjectsMapTable.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CC20FFC5EE4AEDF7A789E31F441BB1BE /* Headers */ = {
+		C9DEE97494FE487CEF8BE947E4063B47 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E1CDCB70F9698BE41C4C423DE7406AC0 /* MetalPetal.h in Headers */,
-				EC9AEE0FE70C50D0905EA6D09DA84FBA /* MTIAlphaPremultiplicationFilter.h in Headers */,
-				321FE7551030F8DA4F55F3FC68DB365C /* MTIAlphaType.h in Headers */,
-				00235F0491A9259D4512D48CC0463031 /* MTIBlendFilter.h in Headers */,
-				A023495D7F1D193BA832B887CEFAA4C2 /* MTIBlendFormulaSupport.h in Headers */,
-				C334BD8A26E873B1B2E0B573A585500D /* MTIBlendModes.h in Headers */,
-				A348802E2902AFFD9F1385AB64F8E6EB /* MTIBlendWithMaskFilter.h in Headers */,
-				3BABA99F6FE83B9C2731C75D9AF86396 /* MTIBuffer.h in Headers */,
-				3F5ADCFFE30F94A6DC8286B0E4DC5F9C /* MTIBulgeDistortionFilter.h in Headers */,
-				7D3D7E02A4DEF8C3BEF7E20FD3406312 /* MTIChromaKeyBlendFilter.h in Headers */,
-				9733F2EDC1E16C534B327A44BF10F029 /* MTICLAHEFilter.h in Headers */,
-				60A40C54F8FD2581C201CA36A09CE175 /* MTIColor.h in Headers */,
-				35245C218B84572B71704764EE4F6C16 /* MTIColorHalftoneFilter.h in Headers */,
-				19739045AA3ED655D90577B8DBCEEE30 /* MTIColorLookupFilter.h in Headers */,
-				FCD34EB925E99333FFB50364A7802629 /* MTIColorMatrix.h in Headers */,
-				D6FA89E4B0F0A8A6FCAFBF86DB34A57C /* MTIColorMatrixFilter.h in Headers */,
-				72A4445A5F255BBFDA971F3C844CFDA0 /* MTIComputePipeline.h in Headers */,
-				259D5E73986871205C97D2FB06166A65 /* MTIComputePipelineKernel.h in Headers */,
-				6F845D308972C21F984332D0320BFFA9 /* MTIContext.h in Headers */,
-				D26DA200AEA91EA93DC542B52DF3CEC7 /* MTIContext+Internal.h in Headers */,
-				FD713EA13A980D3A6D1C3EAE9D5D42DE /* MTIContext+Rendering.h in Headers */,
-				F545358FDB26E3EB412C4198E8C57A24 /* MTICoreImageRendering.h in Headers */,
-				F13BE139FA89BAFAF7D944B897CC7406 /* MTICorner.h in Headers */,
-				FB91FBCFB591EFEE7ABF8C4105589525 /* MTICropFilter.h in Headers */,
-				7336A63FE6C35B128777CA0D01F4CACF /* MTICVMetalIOSurfaceBridge.h in Headers */,
-				8204A4717FCBDB0F653087D5EA496BD5 /* MTICVMetalTextureBridging.h in Headers */,
-				ECA47F26D1ADF9533807EA241AAE3FA5 /* MTICVMetalTextureCache.h in Headers */,
-				66C0F39A6EBC8BACE13A6104F961ECDC /* MTICVPixelBufferPool.h in Headers */,
-				4C102891C499D765EEB0BF18CEBB4864 /* MTICVPixelBufferPromise.h in Headers */,
-				1A65FE65FCDE0ADD61E46D6E779DCED8 /* MTICVPixelBufferRendering.h in Headers */,
-				B40B7784ACFA366B2866BF6CD6A4909F /* MTIDefer.h in Headers */,
-				95127171A066D618A2DB9C95164DB781 /* MTIDotScreenFilter.h in Headers */,
-				0C39A08D382E5F0FC919E54347EBAB09 /* MTIDrawableRendering.h in Headers */,
-				8D6A620FC7A7DDFB266757F7F1247687 /* MTIError.h in Headers */,
-				8310EDE2F2F098B96831B34F078FEBA8 /* MTIFilter.h in Headers */,
-				E04BFCEE1C4791C85FBE2147DE962D8F /* MTIFunctionArgumentsEncoder.h in Headers */,
-				3A1434CAE3289CD23BB0844C38412228 /* MTIFunctionDescriptor.h in Headers */,
-				22BD36FB9F82D896D0C9F04384C140D2 /* MTIGeometry.h in Headers */,
-				D0BF72DB307B321971DD89EAFF1BD425 /* MTIGeometryUtilities.h in Headers */,
-				058E45FC1961F60910E986559DE49023 /* MTIHasher.h in Headers */,
-				DDA32FBFB19EF556401978D706F6AFC1 /* MTIHexagonalBokehBlurFilter.h in Headers */,
-				BE8AED7B1CBB7287E2884385F46CAEC7 /* MTIHighPassSkinSmoothingFilter.h in Headers */,
-				AE0D730CCDDDC133A05AB08A86F317F3 /* MTIImage.h in Headers */,
-				DE844CAC92C325152A7DFC3C307257D2 /* MTIImage+Filters.h in Headers */,
-				8A0FAE7B5D9679CC45961DC205C166D7 /* MTIImage+Promise.h in Headers */,
-				6E917648AB6B7E6812C01D1FBD96E5B9 /* MTIImageOrientation.h in Headers */,
-				B44FF2A6ABEBA848E82E080459FBB942 /* MTIImagePromise.h in Headers */,
-				BA879B5C02079832FF4A5D1E76E9E7F0 /* MTIImagePromiseDebug.h in Headers */,
-				C91697B61939E288B4489C59744A4643 /* MTIImageProperties.h in Headers */,
-				336AEA2AC2DC753940F831D7EF979873 /* MTIImageRenderingContext.h in Headers */,
-				36A57667E8B1324E6B73E74A7621C8B3 /* MTIImageRenderingContext+Internal.h in Headers */,
-				EFF563CED3EB4E750AA0E169E228DF22 /* MTIImageView.h in Headers */,
-				AD04BABB6A85F5E89F1B5AFD59BA9B01 /* MTIKernel.h in Headers */,
-				9A333D7F33CBD31A6CBCB149E0F460D0 /* MTILayer.h in Headers */,
-				0D7187D1C699890A1EE5FE6BA63DCE88 /* MTILibrarySource.h in Headers */,
-				D10D006636A708D3E55917D7257B9FEE /* MTILock.h in Headers */,
-				8FD38C6D50E2876B96C585A1E3854B01 /* MTIMask.h in Headers */,
-				21C632305A0211E88823333D9ACF0A58 /* MTIMemoryWarningObserver.h in Headers */,
-				30EADE84841C2FB99365DDDF8EE0206E /* MTIMPSBoxBlurFilter.h in Headers */,
-				2B52D17A1D9E5ECB1099D8E63E65D002 /* MTIMPSConvolutionFilter.h in Headers */,
-				C6B1A0F0671741EAB4579BD3FA9466BF /* MTIMPSDefinitionFilter.h in Headers */,
-				6BC177AB439C12E7110E5E7E6445D1B4 /* MTIMPSGaussianBlurFilter.h in Headers */,
-				5190745568E814356FFFEBE75A83CD2D /* MTIMPSHistogramFilter.h in Headers */,
-				BDD940CA8CA856C3277A8187FFA21BA6 /* MTIMPSKernel.h in Headers */,
-				155B8DA3CB30DB553D649FA6517A70D0 /* MTIMPSSobelFilter.h in Headers */,
-				0D578AD22DF5005B83AAD38DB021C870 /* MTIMPSUnsharpMaskFilter.h in Headers */,
-				8F8A363CA3A4414DE040F30017D4AB30 /* MTIMultilayerCompositeKernel.h in Headers */,
-				BCE53E7AEA186E7A81CED81C96E75A0A /* MTIMultilayerCompositingFilter.h in Headers */,
-				B2459D436BFB6A892C054DC23A4305F4 /* MTIPixelFormat.h in Headers */,
-				D298E97ED6B07B4282C3740DE7FDE625 /* MTIPixellateFilter.h in Headers */,
-				FF6FC7393B03601921882A672478E502 /* MTIPrint.h in Headers */,
-				964077B1E3B74F189774964FE84D779E /* MTIRenderCommand.h in Headers */,
-				52A6DA45AA8ACF95731D7F937017DE5B /* MTIRenderGraphOptimization.h in Headers */,
-				9D75CE4EDFB89C6FCA576A63B2EED415 /* MTIRenderPassOutputDescriptor.h in Headers */,
-				A7FA7201D8025947B64F76A8954CC92A /* MTIRenderPipeline.h in Headers */,
-				9F0AB5C4AFA459A8ABA9BA8FD5F6CC67 /* MTIRenderPipelineKernel.h in Headers */,
-				885BB046AD89829B31F5F13234918F19 /* MTIRenderTask.h in Headers */,
-				01A9404BF6EB829608DCD93C325838AC /* MTIRGBColorSpaceConversionFilter.h in Headers */,
-				0190647FF3989CF9F1C2CDD7D778BAE9 /* MTIRGBToneCurveFilter.h in Headers */,
-				E3EBE946FFC9B3D0A88723C02C74B61E /* MTIRoundCornerFilter.h in Headers */,
-				F5965192D6FD5824F1D5152EE898D042 /* MTISamplerDescriptor.h in Headers */,
-				28A29688291A102408C75B1A527F41FD /* MTISCNSceneRenderer.h in Headers */,
-				B5388D28E94B7E9BD88DECB28258CD3D /* MTIShaderFunctionConstants.h in Headers */,
-				FF25DBFCEAD5D66150AAC5CC032E714C /* MTIShaderLib.h in Headers */,
-				8B4AE69242BDC456C5985CB93D6303F3 /* MTISKSceneRenderer.h in Headers */,
-				FECDC1472C070B99E18FA3D8C6744047 /* MTITextureDescriptor.h in Headers */,
-				B2356EB9EE112C918FADD43A9F375CA0 /* MTITextureDimensions.h in Headers */,
-				9A325287B1E002D3C9B2BADCA4A49916 /* MTITextureLoader.h in Headers */,
-				49EC910DC164112886D58B0547290F63 /* MTITexturePool.h in Headers */,
-				FACEE6A8CA71D2CC1B01413013286476 /* MTIThreadSafeImageView.h in Headers */,
-				C61A3B9E7D7DA5DBF158E0545CC57AFA /* MTITransform.h in Headers */,
-				3EFED067898AC6B94F776D4F135EB623 /* MTITransformFilter.h in Headers */,
-				593AB10A059003F0A0D8FD5BDD8CE325 /* MTIUnaryImageRenderingFilter.h in Headers */,
-				173F1FCE6E6E59ADFEEA818285BFF31E /* MTIVector.h in Headers */,
-				122BEFA0BF053D9CF1E800534C97BE61 /* MTIVector+SIMD.h in Headers */,
-				4634E84E2983621AB44C3CB428E84935 /* MTIVertex.h in Headers */,
-				F8F4ABB1FB719D0BC2E90DF3DD41E1F2 /* MTIVibranceFilter.h in Headers */,
-				27C3A188EB3D223366FC737DF884D4B5 /* MTIWeakToStrongObjectsMapTable.h in Headers */,
+				14EA54D62411CEDD28176E6AD04776CA /* MetalPetal.h in Headers */,
+				F015D56AB6813CC4107F104808F0CDAA /* MTIAlphaPremultiplicationFilter.h in Headers */,
+				B188397690802DEAEE8DAB9DE46CE38F /* MTIAlphaType.h in Headers */,
+				541921690512D3143E5F62F88806F0C3 /* MTIBlendFilter.h in Headers */,
+				9394EA579F531B6F2CF402C902680C0E /* MTIBlendFormulaSupport.h in Headers */,
+				81EC36D5F1EF037FC22783FC6453DBB3 /* MTIBlendModes.h in Headers */,
+				F15638DFA28A6E381320989697F2948A /* MTIBlendWithMaskFilter.h in Headers */,
+				C69CEADC9407F6B5A5128EC7A04A703B /* MTIBuffer.h in Headers */,
+				452BC9B912E151F1B0C26E5556E715FE /* MTIBulgeDistortionFilter.h in Headers */,
+				5467D831B6164D251BB05CECAFFCFB1B /* MTIChromaKeyBlendFilter.h in Headers */,
+				6B849F9F8E2CFC807673FE7DEDEC8810 /* MTICLAHEFilter.h in Headers */,
+				0EFB04322B15DAE03B9921170BE7539F /* MTIColor.h in Headers */,
+				584AD53DC7AAC7494F8B65F2BBE4FFB6 /* MTIColorHalftoneFilter.h in Headers */,
+				F4B93EBDBFB3CFE6BAAC76FCCBDC1889 /* MTIColorLookupFilter.h in Headers */,
+				B8D41863B63B74FA8EE8A218D6898A4F /* MTIColorMatrix.h in Headers */,
+				F368EA95F2AC8D2E5FD29D931DF5771D /* MTIColorMatrixFilter.h in Headers */,
+				509F9682D827832454AB9F086D82B73D /* MTIComputePipeline.h in Headers */,
+				90069D12DC39B82D513EFFC0B2185B2D /* MTIComputePipelineKernel.h in Headers */,
+				2AD2BFD04531BF82EC6767B160B9E864 /* MTIContext.h in Headers */,
+				0A36CAC0445EE1EBC783A1010A1F00FA /* MTIContext+Internal.h in Headers */,
+				F05FCC70697F4666C150594562546BC0 /* MTIContext+Rendering.h in Headers */,
+				86979D74D4083977773B89C8FE0FB5CE /* MTICoreImageRendering.h in Headers */,
+				1AD2250FCB18FACC4F430D9E33180F5C /* MTICorner.h in Headers */,
+				BE81720C5F5A3C809C545B5A754B1BE5 /* MTICropFilter.h in Headers */,
+				AA5FB6E39C03374B3A37FE243FD6EDA7 /* MTICVMetalIOSurfaceBridge.h in Headers */,
+				E1EB6EC8079224F085AE418767B3D5CD /* MTICVMetalTextureBridging.h in Headers */,
+				E9613BA6A49C71C6B6BA4D39B40B8AA8 /* MTICVMetalTextureCache.h in Headers */,
+				F17B3BAF1DA8D592C9FD9E9872DF2715 /* MTICVPixelBufferPool.h in Headers */,
+				AB5B2824CCA68CB9B576BC93172F521C /* MTICVPixelBufferPromise.h in Headers */,
+				F03F25E78E0B11FF28883F8B1A1533B0 /* MTICVPixelBufferRendering.h in Headers */,
+				2858B78549AFB39CC543180D1A3B75F4 /* MTIDefer.h in Headers */,
+				72F7D79BA560005A2318463FF6592ECB /* MTIDotScreenFilter.h in Headers */,
+				AFB47F0AACC0D0358AF9356E5CA8A661 /* MTIDrawableRendering.h in Headers */,
+				908F1176FE75A34C8539E1926FB318FC /* MTIError.h in Headers */,
+				707CCC0D1B8A6674B6B8AC0B1E60D399 /* MTIFilter.h in Headers */,
+				99115A419C9B8F0F8D2D28B681D03097 /* MTIFunctionArgumentsEncoder.h in Headers */,
+				23E1ADB154ABEAFAEA426E1A0D6124F3 /* MTIFunctionDescriptor.h in Headers */,
+				31DF76FE5FE8FF4F0534C946B8AC7C82 /* MTIGeometry.h in Headers */,
+				27E276CE7E4B60C9D2CA022D606E8889 /* MTIGeometryUtilities.h in Headers */,
+				C158E309BCF8FD7E6F513CB5F4DDDDB2 /* MTIHasher.h in Headers */,
+				69FC638A2D8ED1566F88883CB4EE7C9A /* MTIHexagonalBokehBlurFilter.h in Headers */,
+				0922437ED2C409ADC150F2130F827473 /* MTIHighPassSkinSmoothingFilter.h in Headers */,
+				EA567421771E3CBB0C1FC5E40E487FBE /* MTIImage.h in Headers */,
+				AEAF25ECF3949A56BA5CC6D11EDD10E1 /* MTIImage+Filters.h in Headers */,
+				A532DAC0E30050A0B8D2C6CD7D375E14 /* MTIImage+Promise.h in Headers */,
+				2A26F9F487DA48E51CDD1F5BFF167F4B /* MTIImageOrientation.h in Headers */,
+				77909903820253D1D13C207EDEAF68EF /* MTIImagePromise.h in Headers */,
+				DC5385D4E888026BA897AB139D9F7502 /* MTIImagePromiseDebug.h in Headers */,
+				6733D5BA081316B45A297AD6E067369B /* MTIImageProperties.h in Headers */,
+				3B8B7AB0191836868235DDA5393A61F4 /* MTIImageRenderingContext.h in Headers */,
+				74572DB33C0D2306B555C0928D0EE768 /* MTIImageRenderingContext+Internal.h in Headers */,
+				7D8CFB0B849A22FFBDB7A86D0521760B /* MTIImageView.h in Headers */,
+				3F21B5F84FDEF95279451EDD6C1E74EF /* MTIKernel.h in Headers */,
+				F856C640D7C3C780DA15A019AFBEA274 /* MTILayer.h in Headers */,
+				9E90A614B03AF9D2B1D04BD2B1ADB5D7 /* MTILibrarySource.h in Headers */,
+				D7247C5587A558F57EAEEB9BD635C426 /* MTILock.h in Headers */,
+				68EFCAB8B5CE480D89FF9B8DA11CA835 /* MTIMask.h in Headers */,
+				4D90B73A3CE7BD7DD7844E2AB8408C05 /* MTIMemoryWarningObserver.h in Headers */,
+				A872665BB24D23EB9E830A566A9D56DA /* MTIMPSBoxBlurFilter.h in Headers */,
+				AA9978F2C6D5D49899F091E63ABCACA4 /* MTIMPSConvolutionFilter.h in Headers */,
+				723F3CDC35EC58ACF8D5ED4CF2460824 /* MTIMPSDefinitionFilter.h in Headers */,
+				F9DBC4B1A13A71AE28D48ADFD4D27BE0 /* MTIMPSGaussianBlurFilter.h in Headers */,
+				92AA0B7556FDDCFE12491D5B1119B397 /* MTIMPSHistogramFilter.h in Headers */,
+				261A1F8C38BB1E71529AEC471A61DC75 /* MTIMPSKernel.h in Headers */,
+				1322F21B578EC30CD87A87E8BC72173E /* MTIMPSSobelFilter.h in Headers */,
+				6EAA1D78D5F2012794D7C3648C423D4C /* MTIMPSUnsharpMaskFilter.h in Headers */,
+				396A23701BF3EEA9132A763D0DC4D385 /* MTIMultilayerCompositeKernel.h in Headers */,
+				C64DDE82D7AE6D0B517C1633128FCA89 /* MTIMultilayerCompositingFilter.h in Headers */,
+				75B7C7AB3075A6C75DA0A6211FA51FED /* MTIPixelFormat.h in Headers */,
+				BCCFB0882B8D8EC52E7014B6F26BFCED /* MTIPixellateFilter.h in Headers */,
+				A5B5DB881944D26B087C906EB23B8170 /* MTIPrint.h in Headers */,
+				003B64A419DA9E091AC7DC25080FBCF7 /* MTIRenderCommand.h in Headers */,
+				284FA298476286A17D2DA68322971332 /* MTIRenderGraphOptimization.h in Headers */,
+				CA0D3D21C7F75C5B15C5D4AA2299C3CF /* MTIRenderPassOutputDescriptor.h in Headers */,
+				2344975842F430D8464688366E68DB8A /* MTIRenderPipeline.h in Headers */,
+				58E245D92A23F8DF2B9445ADE6C7CD69 /* MTIRenderPipelineKernel.h in Headers */,
+				3A38D2E09EA0D45578A3A2C3615AB659 /* MTIRenderTask.h in Headers */,
+				26814C5EFFE7BAF4CA261CA925EC73A7 /* MTIRGBColorSpaceConversionFilter.h in Headers */,
+				489EBCAE973ACD757AB0EB5EA96D3584 /* MTIRGBToneCurveFilter.h in Headers */,
+				2AEBAE803B152A5446841939B00F9AD5 /* MTIRoundCornerFilter.h in Headers */,
+				B6A085D2E14A787608F011BFE09A545F /* MTISamplerDescriptor.h in Headers */,
+				5B8777021DCD6CB3DD612823481FDC99 /* MTISCNSceneRenderer.h in Headers */,
+				6ECEF5B2547DFFC54965E7A918600F81 /* MTIShaderFunctionConstants.h in Headers */,
+				58769ED741D7F2B1A4B4E1E26BEA554D /* MTIShaderLib.h in Headers */,
+				3F08B1D8B0E10C45F4177219B1990089 /* MTISKSceneRenderer.h in Headers */,
+				EB5BEFA41349D48DD2425209C98EC585 /* MTITextureDescriptor.h in Headers */,
+				D967BD8C2E5BC07CE866C02CAE6E9FDB /* MTITextureDimensions.h in Headers */,
+				EBFDD06906A69BB1C41D0F49D5F6DD7A /* MTITextureLoader.h in Headers */,
+				34F1BF8C23410B428DEDA6B51440DCD0 /* MTITexturePool.h in Headers */,
+				DF5C67E0C0CBE2D745FDB0AC8E32DC46 /* MTIThreadSafeImageView.h in Headers */,
+				83940F1318B3B3B678F89A31DF46DD31 /* MTITransform.h in Headers */,
+				8962B28248CBD49341D47BAEDF60E390 /* MTITransformFilter.h in Headers */,
+				DC56A91C74F7C68E06D00DB7FD01B771 /* MTIUnaryImageRenderingFilter.h in Headers */,
+				0D1BB1456AB76A8D5519350779C9B5E2 /* MTIVector.h in Headers */,
+				565700C4114291A1B8A3E573A7236E33 /* MTIVector+SIMD.h in Headers */,
+				9D84931313A180BE61AA4A95ED732F44 /* MTIVertex.h in Headers */,
+				1D4F410643339F5CBBC6DAFB865ADF7A /* MTIVibranceFilter.h in Headers */,
+				E42F1ECCA7B7E954EED95A79B845796B /* MTIWeakToStrongObjectsMapTable.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1438,13 +1442,13 @@
 /* Begin PBXNativeTarget section */
 		45FF391DFF638DC1677EE9B92B249B48 /* MetalPetal-AppleSilicon-Core-Swift */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = C22633A65204489CF110D9FDB3FC7F3A /* Build configuration list for PBXNativeTarget "MetalPetal-AppleSilicon-Core-Swift" */;
+			buildConfigurationList = 4C939637B6E242093DB07A03EEE9AC1E /* Build configuration list for PBXNativeTarget "MetalPetal-AppleSilicon-Core-Swift" */;
 			buildPhases = (
-				CC20FFC5EE4AEDF7A789E31F441BB1BE /* Headers */,
-				7F4F181DE3FBA8A4BDD6CF42321EBDC5 /* Sources */,
-				01542B9DCA383C7031C69AB9DD568C97 /* Frameworks */,
-				FDE261D3CCD6544C959799CC9A9D0832 /* Resources */,
-				F2B0E01A9682CEC3151D5BDA998BAF30 /* [CP-User] Build Metal Library - MSL 2.3 */,
+				88655156E4E556B338292E6921C2A8EF /* Headers */,
+				F2129F9E510C2147C0D8BA7194F65242 /* Sources */,
+				58B4147D29923907DD21BE12D0E78072 /* Frameworks */,
+				A627877AD2C5A344CD39872BCB948BF9 /* Resources */,
+				6E8C326A24FEE34BE4EC822928E9049B /* [CP-User] Build Metal Library - MSL 2.3 */,
 			);
 			buildRules = (
 			);
@@ -1467,7 +1471,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				B1706C1BF123C372EDBD4BEB8169D925 /* PBXTargetDependency */,
+				289206C6D9256266F7B72DE3700396F1 /* PBXTargetDependency */,
 			);
 			name = "Pods-MetalPetalExamples-MetalPetalExamples (iOS)";
 			productName = Pods_MetalPetalExamples_MetalPetalExamples__iOS_;
@@ -1486,7 +1490,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				B0544A167C3FEB2E499B597FBB05575E /* PBXTargetDependency */,
+				08FFF79E72F8B8A6F9B88DB496D549E8 /* PBXTargetDependency */,
 			);
 			name = "Pods-MetalPetalExamples-MetalPetalExamples (macOS)";
 			productName = Pods_MetalPetalExamples_MetalPetalExamples__macOS_;
@@ -1495,12 +1499,12 @@
 		};
 		F6A6D917959D4C48ADF90BBFC7A7F507 /* MetalPetal-Core-Swift */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 7B162AEC40B51F017FAB0CB6600BF2EF /* Build configuration list for PBXNativeTarget "MetalPetal-Core-Swift" */;
+			buildConfigurationList = 0E1AE4933E8EE6659B3B6035D6A763F6 /* Build configuration list for PBXNativeTarget "MetalPetal-Core-Swift" */;
 			buildPhases = (
-				8C794246DE221D49D0971923F992CC48 /* Headers */,
-				CB27F8BF690B24B89B243DF878D9D5C4 /* Sources */,
-				6335179AE0BE1FC69DFBD90EABC12FE4 /* Frameworks */,
-				3D0E534C43A640362ED36D1B94A589AB /* Resources */,
+				C9DEE97494FE487CEF8BE947E4063B47 /* Headers */,
+				E2890553B87F17DCEFC96B7E1B6A064B /* Sources */,
+				9285C5448EAB7F22D2B698ABFAEAD616 /* Frameworks */,
+				58AC96757E99C12830D6D8ABD62F5674 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1542,14 +1546,14 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		3D0E534C43A640362ED36D1B94A589AB /* Resources */ = {
+		44A1E11E957F6221BBB79D8C27FFF72A /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		44A1E11E957F6221BBB79D8C27FFF72A /* Resources */ = {
+		58AC96757E99C12830D6D8ABD62F5674 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1563,7 +1567,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FDE261D3CCD6544C959799CC9A9D0832 /* Resources */ = {
+		A627877AD2C5A344CD39872BCB948BF9 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1573,7 +1577,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		F2B0E01A9682CEC3151D5BDA998BAF30 /* [CP-User] Build Metal Library - MSL 2.3 */ = {
+		6E8C326A24FEE34BE4EC822928E9049B /* [CP-User] Build Metal Library - MSL 2.3 */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1586,131 +1590,6 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		7F4F181DE3FBA8A4BDD6CF42321EBDC5 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				10964BEE67B2E23C32E6F759A37EB317 /* BlendingShaders.metal in Sources */,
-				8961C7B951A9B93578FEF58AC918884A /* CLAHE.metal in Sources */,
-				7519ED50C4E39AA9E1A0D5DB4BD2971F /* ColorConversionShaders.metal in Sources */,
-				4A19FA56D86AD2B4CCD4737B7CE75C30 /* Filter.swift in Sources */,
-				3D0361DD2645DB3F321FD7663C16D5D6 /* Halftone.metal in Sources */,
-				77E8FCDB244220121E56E41342E02BAF /* HighPassSkinSmoothing.metal in Sources */,
-				CCEEBA81DBE75E3F2A3B215E500F71A5 /* LensBlur.metal in Sources */,
-				A2C4D7B6686D0070C4FD7AF81D739D0F /* MetalPetal.swift in Sources */,
-				11BCB443600343EEBFE0852A6C9A1115 /* MetalPetal-AppleSilicon-Core-Swift-dummy.m in Sources */,
-				342EDE24E2BE32D7B7C8F1A2C71A900D /* MTIAlphaPremultiplicationFilter.m in Sources */,
-				38230EB4E35D71E0B7C923D4649D5E0A /* MTIAlphaType.m in Sources */,
-				11D97F98169CF75F50EE244326EE41A6 /* MTIAlphaType.swift in Sources */,
-				76AC0591BD2D2C3029CD3416D022618D /* MTIBlendFilter.m in Sources */,
-				CA631F8CE939DC9048100FD7098B08CA /* MTIBlendFormulaSupport.mm in Sources */,
-				659C58572C899D571AFC2967461079C2 /* MTIBlendModes.m in Sources */,
-				F629BEA3BB74296180E053D992B77320 /* MTIBlendWithMaskFilter.m in Sources */,
-				CBED7FDC4560A4BFC336FA9850C4C448 /* MTIBuffer.m in Sources */,
-				015710863A6B5BF7E3A3DD1501EFFAD5 /* MTIBulgeDistortionFilter.m in Sources */,
-				D7F80EC3846B1AF270AD2049CFF41C33 /* MTIChromaKeyBlendFilter.m in Sources */,
-				82A2EB15EECEFBB4FADD3C002BC30E1E /* MTICLAHEFilter.m in Sources */,
-				C9EABAE65A3762B9A0889EABBC45E0C7 /* MTIColor.m in Sources */,
-				6A279C3035413444801E01993974A5AC /* MTIColor.swift in Sources */,
-				48A95C67B1DA4A98DA0E53027614997C /* MTIColorHalftoneFilter.m in Sources */,
-				88BF4DB322E8E59D9A005126FFC8B93A /* MTIColorLookupFilter.m in Sources */,
-				915849A31DA864D8BD568D9D8DBDAC84 /* MTIColorMatrix.m in Sources */,
-				29D6C4953E04FD4BC82BF6595321BA3F /* MTIColorMatrix.swift in Sources */,
-				0F6CAA934DD9F39020105D7214F6BEB8 /* MTIColorMatrixFilter.m in Sources */,
-				6FF6348699E19D6CE0DDB6C300B6A548 /* MTIComputePipeline.m in Sources */,
-				BE5A3C32D2E36DF16F19E53063CAE679 /* MTIComputePipelineKernel.m in Sources */,
-				E56291614079F7849015E847466144CB /* MTIComputePipelineKernel.swift in Sources */,
-				5E1CF22E49BF171ABA368CA2F010E01D /* MTIContext.m in Sources */,
-				C8FAE693A2D4FC10AB3A42CB2D1D73F5 /* MTIContext.swift in Sources */,
-				9480F2EFFF1361456DEFD43DC1F6BC5A /* MTIContext+Rendering.m in Sources */,
-				475F26BF11553F5CB9C8D0D93CA5DDA8 /* MTICoreImageExtension.swift in Sources */,
-				9D39D7E5BEEF9A70053613CA9B962030 /* MTICoreImageRendering.m in Sources */,
-				499651A8E2A9465075F1378B2195AB75 /* MTICorner.swift in Sources */,
-				415A281074BAB281FE46BE97939EFF83 /* MTICropFilter.m in Sources */,
-				42033C3DF83595C9D6014BBB04D94BE2 /* MTICropRegion.swift in Sources */,
-				2835BDB54C161BA078F3F1E9609BCFC8 /* MTICVMetalIOSurfaceBridge.m in Sources */,
-				0534E035455A8EA6447B6BC91DAFF13A /* MTICVMetalTextureCache.m in Sources */,
-				1B4D322E613865672E3731795B56635A /* MTICVPixelBufferPool.m in Sources */,
-				40463437E0FA47121CCFF4A2A9E66390 /* MTICVPixelBufferPromise.m in Sources */,
-				782C85583A960656B9F02CDE67522126 /* MTICVPixelBufferRendering.m in Sources */,
-				CA3B127A03C92DBCE54D7FF9F1DCFBA3 /* MTIDataBuffer.swift in Sources */,
-				D70DBF42631072638ECD8502D9FE8F98 /* MTIDefer.m in Sources */,
-				A63A7045504D3BE134526C35B19E2938 /* MTIDotScreenFilter.m in Sources */,
-				4A6C1B7BDA6ECDFD2CF80A96279B0AF8 /* MTIDrawableRendering.m in Sources */,
-				006C2144D5BAA26883511F622BB9E79D /* MTIError.m in Sources */,
-				F41CC1A95D680A9C95984FCB5FCCF6D5 /* MTIError.swift in Sources */,
-				ACA192BC51012CAEE5255D0608A04521 /* MTIFilter.m in Sources */,
-				78006B40B2DAC0297B6B75D2F1816751 /* MTIFunctionArgumentsEncoder.m in Sources */,
-				D4D5540613C18C68D4D25ECEFC406882 /* MTIFunctionDescriptor.m in Sources */,
-				B133905F1758DED6E1F87A0B57505D67 /* MTIFunctionDescriptor.swift in Sources */,
-				7696694FE0748386BA8D02D825B2853D /* MTIGeometry.m in Sources */,
-				179DDECC0EB2E0F7C204B35B16E53207 /* MTIGeometryUtilities.m in Sources */,
-				A024051E78B15F2C9E599BD5289300A9 /* MTIHexagonalBokehBlurFilter.m in Sources */,
-				B015ECA845E1233B0C78FEC535B91689 /* MTIHighPassSkinSmoothingFilter.m in Sources */,
-				189A43D6FC85FB7294B27B884902A5ED /* MTIImage.m in Sources */,
-				2884C75DF7774C040518A354329AE71F /* MTIImage.swift in Sources */,
-				D510F7852781538B0E70A5B88ADB8D93 /* MTIImage+Filters.m in Sources */,
-				4198A11BAF4CDF95EEBBC168D2AD6643 /* MTIImageOrientation.m in Sources */,
-				5101829E6F5E4DCDAF299CB4048D6B5B /* MTIImagePromise.m in Sources */,
-				3987ACA16772306AFA479B5771641068 /* MTIImagePromiseDebug.m in Sources */,
-				D9AD5EDCFADD9A0F07E1FB0F62F3F297 /* MTIImageProperties.m in Sources */,
-				11F66110D506FB2ED6A0DB9E7AC0A028 /* MTIImageRenderingContext.mm in Sources */,
-				ECCC260A732BEB48D7ADFF16C3C984F0 /* MTIImageView.m in Sources */,
-				6CA036A7572C9050E2F9BFF148E0CFA3 /* MTIImageViewProtocol.swift in Sources */,
-				35EEB23D8BE6BB1821F9578D2D495A7A /* MTILayer.m in Sources */,
-				D7E8C74A3243FD5B0BBF7004F481E5EA /* MTILibrarySource.m in Sources */,
-				5AB1031301EFAF70FDA74D8A65826305 /* MTILock.m in Sources */,
-				368C2A24B2BDAC44F6434B7BD4F12412 /* MTIMask.m in Sources */,
-				4A69B59CCCF6C310B96CD15C3FF4F8CB /* MTIMemoryWarningObserver.m in Sources */,
-				E2EECF2083E40DA90FD0BB76FD1AF7A7 /* MTIMPSBoxBlurFilter.m in Sources */,
-				05AD893CE9887703CF011EE1E1D51595 /* MTIMPSConvolutionFilter.m in Sources */,
-				320CF4E92E751D32ED4ED998A8A5C313 /* MTIMPSDefinitionFilter.m in Sources */,
-				8F3EABB095997D1765DD88308FEF08AF /* MTIMPSGaussianBlurFilter.m in Sources */,
-				4699E6C436AEE62AF2E0D7473ABF0613 /* MTIMPSHistogramFilter.m in Sources */,
-				1BD63595B54D57B8B569D38FBADEE083 /* MTIMPSKernel.m in Sources */,
-				99467F0DA3AA6D8137ACAE489A7F7302 /* MTIMPSSobelFilter.m in Sources */,
-				102018F6FE0B34F3A09B2698A59008E7 /* MTIMPSUnsharpMaskFilter.m in Sources */,
-				E3575F88A2AF8428B9156DBE03AE1322 /* MTIMultilayerCompositeKernel.m in Sources */,
-				1E87143D632E6ED44E33A51FF5119EFE /* MTIMultilayerCompositingFilter.m in Sources */,
-				125FC8D28B6E83A5B5E367B5C5603FDF /* MTIPixelFormat.m in Sources */,
-				3224ECCA420E4C101496CE2097023135 /* MTIPixelFormat.swift in Sources */,
-				990ECE564BF41DFFBAE309863BB9FEC2 /* MTIPixellateFilter.m in Sources */,
-				D87FC031C4064FBB4FF9BD7849D13BBD /* MTIRenderCommand.m in Sources */,
-				159CE0D1FD59ECA6EBFF56353F2B36DD /* MTIRenderGraphOptimization.m in Sources */,
-				7B994B0C5BF4201B43519C7556B005C3 /* MTIRenderPassOutputDescriptor.m in Sources */,
-				6DAD76239DEDE4646762B079912969A7 /* MTIRenderPipeline.m in Sources */,
-				398DA92AAD713C594A433ED23F72A904 /* MTIRenderPipelineKernel.m in Sources */,
-				C8D74F95BC303CF6204D0067F01BAF58 /* MTIRenderTask.m in Sources */,
-				F240779157360C9114F1AD99A0699ADE /* MTIRGBColorSpaceConversionFilter.m in Sources */,
-				87D66F9E294DFA9B158E83099BE27502 /* MTIRGBColorSpaceConversionFilter.swift in Sources */,
-				02419DA36EC317F9E2994D564B22319F /* MTIRGBToneCurveFilter.m in Sources */,
-				7A3F7789C1FD3E1CBE06D73D05607354 /* MTIRoundCornerFilter.m in Sources */,
-				21BC465115AEEE25563B970628136C6A /* MTISamplerDescriptor.m in Sources */,
-				5056959258D5D43AEB6D2D069AF50E5B /* MTISCNSceneRenderer.m in Sources */,
-				8372CAF774EA51BABA4F7C941FFB1130 /* MTISIMDArgumentEncoder.swift in Sources */,
-				2ADA939A3839B6C97C5C9CDA0EA4889C /* MTISKSceneRenderer.m in Sources */,
-				3753DD6BF4B567A9848D18C862C2EABF /* MTITextureDescriptor.m in Sources */,
-				796D7334827F8D2FB0D8489440831B6E /* MTITextureDimensions.swift in Sources */,
-				BD1006FCD2B03A1824699D9D3F5E816E /* MTITextureLoader.m in Sources */,
-				6C37EB742B0A74800A1AF4970748A179 /* MTITexturePool.mm in Sources */,
-				CD33FF4D0EBDD1445B3A6CC1D2D6B6D5 /* MTIThreadSafeImageView.m in Sources */,
-				84738AB84805CF9308EDB842E0B48F0F /* MTITransform.m in Sources */,
-				5F3511FAC419BB2093D6980CF75405F5 /* MTITransformFilter.m in Sources */,
-				50642D0BC3CCD36A27675F847C01EFFA /* MTIUnaryImageRenderingFilter.m in Sources */,
-				6D85117AD4E195D1FCA10C53D3500394 /* MTIVector.m in Sources */,
-				F29F7B30B2505C10E039491469A1B6FF /* MTIVector.swift in Sources */,
-				ECB66E671B7BECC2411CC778CAF345D8 /* MTIVector+SIMD.m in Sources */,
-				66148B7E5F1AC04045DB055876411EB9 /* MTIVertex.m in Sources */,
-				7F76F43A3C89FC6A43A37028999C3DE6 /* MTIVertex.swift in Sources */,
-				E90E0C5B809FE2438B2A3F219F1DA5AC /* MTIVibranceFilter.m in Sources */,
-				D266F0E9FCB5913B9B0B0170CD00CDEB /* MTIVideoComposition.swift in Sources */,
-				BC309ADCE8A9C6816576F15C9228457F /* MTIWeakToStrongObjectsMapTable.m in Sources */,
-				FC4D1C2F769805F4B5548EB9F26F24D0 /* MultilayerCompositeShaders.metal in Sources */,
-				E3ECC73A45EA78AE03167F6EAF23A465 /* MultilayerCompositingFilter.swift in Sources */,
-				0F32341ABFBA2A611C6781C2A08072AA /* Shaders.metal in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		A178B5BF2EB65B04BA016B9339F505D9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1727,145 +1606,272 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CB27F8BF690B24B89B243DF878D9D5C4 /* Sources */ = {
+		E2890553B87F17DCEFC96B7E1B6A064B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A9DDB5898C3151CA01EC26A518937A63 /* BlendingShaders.metal in Sources */,
-				54121B89BE1470C25A47765D2D4AF933 /* CLAHE.metal in Sources */,
-				8C3D8DFA16C6D6CEF3FBE76EBC233C58 /* ColorConversionShaders.metal in Sources */,
-				0DFEE533BE7709A5B2BD5D408903C755 /* Filter.swift in Sources */,
-				41E1AAF1BA9D9E64F8738DA5119F615C /* Halftone.metal in Sources */,
-				A020E1152EB34114CA0BF7B729199A96 /* HighPassSkinSmoothing.metal in Sources */,
-				2267FB9F7A1B79D732803253D1F020C1 /* LensBlur.metal in Sources */,
-				647F4331B40BAC5B1061A99FF549B75F /* MetalPetal.swift in Sources */,
-				6F26D473E61ECD3E9F3ED9177B79CF46 /* MetalPetal-Core-Swift-dummy.m in Sources */,
-				AA69FE500323D52CE779B92F7D084FC7 /* MTIAlphaPremultiplicationFilter.m in Sources */,
-				5B082992674DF3431999F3DE312BBF9E /* MTIAlphaType.m in Sources */,
-				B478AFFDFCD2910D1D95282CB68C3AE5 /* MTIAlphaType.swift in Sources */,
-				0B92F78362327F440FC48BF542B62545 /* MTIBlendFilter.m in Sources */,
-				7B09D0C0F7806E372FF40BD5E1BB2ACF /* MTIBlendFormulaSupport.mm in Sources */,
-				5852A7C9051F13D03651D2A9D5C2A183 /* MTIBlendModes.m in Sources */,
-				43871131954C0206C614FD97623D183B /* MTIBlendWithMaskFilter.m in Sources */,
-				EF6314069AEC8830728E1BD4FEBCE085 /* MTIBuffer.m in Sources */,
-				9E8B509E0DFEEE2FB039EE18DDF43D94 /* MTIBulgeDistortionFilter.m in Sources */,
-				454425F8DDF617C11A3AEF04B6C94BAB /* MTIChromaKeyBlendFilter.m in Sources */,
-				074EB089446469E2C2F6147950D74251 /* MTICLAHEFilter.m in Sources */,
-				78C3854B138B8C077CF9EB37F8B5C3FE /* MTIColor.m in Sources */,
-				5078A57645E04D88FD0AA5AC9EBA305B /* MTIColor.swift in Sources */,
-				D6D4E41E17D091DD418FFED3CE044D74 /* MTIColorHalftoneFilter.m in Sources */,
-				BE1A4C0C2030A31AE7EF062837457AA5 /* MTIColorLookupFilter.m in Sources */,
-				C669686749AEF704E634FA9BFA01FCEA /* MTIColorMatrix.m in Sources */,
-				37D2BEB5C25F4451696B0E3527FC3C8E /* MTIColorMatrix.swift in Sources */,
-				D95987B1668D2AC4A9D9FEE137370028 /* MTIColorMatrixFilter.m in Sources */,
-				B21A371F70104DD25F53D0D432493ECE /* MTIComputePipeline.m in Sources */,
-				EB198593DD816472DF5C98EB666778E6 /* MTIComputePipelineKernel.m in Sources */,
-				E19DEDCA8553E332C1EAC4653437E323 /* MTIComputePipelineKernel.swift in Sources */,
-				92EEAC233F9B5CA0BB4C7E48331A6A71 /* MTIContext.m in Sources */,
-				728B6F33F0F24380939D3F1821212FF9 /* MTIContext.swift in Sources */,
-				D79AE42D444E83B9D83C82E03D4587D7 /* MTIContext+Rendering.m in Sources */,
-				53FD27529F5A2D539711FF11F6E4DBF2 /* MTICoreImageExtension.swift in Sources */,
-				AB9CC381F1653F9EA944F0478BFDFBD6 /* MTICoreImageRendering.m in Sources */,
-				76D60502F7FB3D6CED031AF2A7630C18 /* MTICorner.swift in Sources */,
-				718CBF45818689C4ABF19BB2FAF8C777 /* MTICropFilter.m in Sources */,
-				A261CCB3C0E50D47DC7EF0A3DC226154 /* MTICropRegion.swift in Sources */,
-				C863C90097DCAA28E7F89B9DB17C5BE7 /* MTICVMetalIOSurfaceBridge.m in Sources */,
-				93EC7CDDF2F59EC40C55F8960F909DCF /* MTICVMetalTextureCache.m in Sources */,
-				77CDB6B23737A6A89F317FFDD0355788 /* MTICVPixelBufferPool.m in Sources */,
-				67A5D60A676BDE3DA0EA6D06B9C2FF2C /* MTICVPixelBufferPromise.m in Sources */,
-				E85524A5EC1B87D432809A0717C6C66D /* MTICVPixelBufferRendering.m in Sources */,
-				512FC088C712346837D7749838950EE9 /* MTIDataBuffer.swift in Sources */,
-				66F3E571043AF76E01EFF74EBE9668E8 /* MTIDefer.m in Sources */,
-				A8F2565CAD6DA68FC84137F4DA471DC1 /* MTIDotScreenFilter.m in Sources */,
-				72B4635DBD62C443BA0EA74729C93CB2 /* MTIDrawableRendering.m in Sources */,
-				47A3C30D260E06CF2FF0B806899AE21A /* MTIError.m in Sources */,
-				2B655844FC2B11D0257FDF6B69C8C411 /* MTIError.swift in Sources */,
-				9AD442FDD1B32C6D443EC769DA265687 /* MTIFilter.m in Sources */,
-				064D621013E15A47E35779EE561F5CCD /* MTIFunctionArgumentsEncoder.m in Sources */,
-				0B41B0EC7E50016A72D0106AFF2AC3F8 /* MTIFunctionDescriptor.m in Sources */,
-				B6F3AF992392B4BDB2E5D7F8AEE6E531 /* MTIFunctionDescriptor.swift in Sources */,
-				8FEA886DE92F91A9AB7D4C5199ABB60A /* MTIGeometry.m in Sources */,
-				F9477062552F19FAF5ACFAD1EB88CCE7 /* MTIGeometryUtilities.m in Sources */,
-				875328830B3A73151ED3600A547FC972 /* MTIHexagonalBokehBlurFilter.m in Sources */,
-				EA27A212D3F50236C44B50A3B530146B /* MTIHighPassSkinSmoothingFilter.m in Sources */,
-				B3BF96FE6AC50C7C8FC86DE20C91E800 /* MTIImage.m in Sources */,
-				0AC064CF0CB95E93A87BB770BCA2815C /* MTIImage.swift in Sources */,
-				AA05CD1D535797A5D2E3EFBEC25FF3ED /* MTIImage+Filters.m in Sources */,
-				72C323C1C5DA6F97F0B84138F84813FD /* MTIImageOrientation.m in Sources */,
-				48567A3B459C02145D42E6B18E910DF4 /* MTIImagePromise.m in Sources */,
-				CFB366C3C2C168CD389E23E55D155AAC /* MTIImagePromiseDebug.m in Sources */,
-				827F2A019511EA5F52ED33FCDB905039 /* MTIImageProperties.m in Sources */,
-				331C7B01BE2023F50C54BB0DD652C319 /* MTIImageRenderingContext.mm in Sources */,
-				A749AF1CA6316C7CD442552715E17793 /* MTIImageView.m in Sources */,
-				8F0F383CD422D90771D8126355C4E9B3 /* MTIImageViewProtocol.swift in Sources */,
-				1DC7B047407B3CD9D678B43D22DAD310 /* MTILayer.m in Sources */,
-				1779CC837B4F250D79443B3D8B198032 /* MTILibrarySource.m in Sources */,
-				064CBE9EBB8B994BB45D3A39F8C38EFD /* MTILock.m in Sources */,
-				DE225A4A3F9E77C79011FD290C313A0D /* MTIMask.m in Sources */,
-				B129DD269C931E7FF8E01DED3873DA69 /* MTIMemoryWarningObserver.m in Sources */,
-				DCA03B2261F7323E08E64E2CAAA2EF5B /* MTIMPSBoxBlurFilter.m in Sources */,
-				3E1A72F2CC20C7E913AF1294CA0B4195 /* MTIMPSConvolutionFilter.m in Sources */,
-				42C9D2B27632B7AD8A88DD41C2A20EE6 /* MTIMPSDefinitionFilter.m in Sources */,
-				A81C0CFF887B19B20E86555C12E7461B /* MTIMPSGaussianBlurFilter.m in Sources */,
-				5568EDE85B6BE0A193AB1F88C5B4B9D4 /* MTIMPSHistogramFilter.m in Sources */,
-				4EAAF7D56633A2FA01DC8AF8B3A3CF8F /* MTIMPSKernel.m in Sources */,
-				B70EFC4DEB9A48E35A966FB12D957FFD /* MTIMPSSobelFilter.m in Sources */,
-				83B1FF2FA7D546956430AC64B599A64B /* MTIMPSUnsharpMaskFilter.m in Sources */,
-				8F0498FA2B92D5E962A3AF36E47B184D /* MTIMultilayerCompositeKernel.m in Sources */,
-				CDC8DEA6013DA7D26BC2DA43A93EE04E /* MTIMultilayerCompositingFilter.m in Sources */,
-				8A0F419C78DFA15F0810BE3CF002567E /* MTIPixelFormat.m in Sources */,
-				7493CE554FBD34FD2D4D7331DE66E85B /* MTIPixelFormat.swift in Sources */,
-				4A24FEAF10E281525CEEEE31817AA91A /* MTIPixellateFilter.m in Sources */,
-				936FDC586E65C69AE9F80602CDE9169A /* MTIRenderCommand.m in Sources */,
-				2710A66105F1B6F40437D928E59AD897 /* MTIRenderGraphOptimization.m in Sources */,
-				13D160628C5A4B863D0775243971E619 /* MTIRenderPassOutputDescriptor.m in Sources */,
-				5435874B16422A94A7610712CA0D6D0E /* MTIRenderPipeline.m in Sources */,
-				638318991CF13F5F123C35B05F62EB32 /* MTIRenderPipelineKernel.m in Sources */,
-				6728C3B58C0CB6311E997E91EA8E5C2B /* MTIRenderTask.m in Sources */,
-				9B5F60E956DA9E1FA3E1B2E7C6EDF80D /* MTIRGBColorSpaceConversionFilter.m in Sources */,
-				37CD99098AFC9672B7289F7463D00CDE /* MTIRGBColorSpaceConversionFilter.swift in Sources */,
-				2CC3F9E6FC9D667772ED151EC3407445 /* MTIRGBToneCurveFilter.m in Sources */,
-				4DC0E85B28F6A92B7A43863E8E4B3DF2 /* MTIRoundCornerFilter.m in Sources */,
-				6728FD117837B15975E55B40BAF73B13 /* MTISamplerDescriptor.m in Sources */,
-				11E75D2FE1FDA360549888B70E276B87 /* MTISCNSceneRenderer.m in Sources */,
-				BC759203DE25F8CABFEC679AA59632B3 /* MTISIMDArgumentEncoder.swift in Sources */,
-				7F50B12CA517D0FAEF482CFD74846B78 /* MTISKSceneRenderer.m in Sources */,
-				26AE971F328604F57179C3DCB459B7DC /* MTITextureDescriptor.m in Sources */,
-				0C0A939767611A000FCC342947524B0D /* MTITextureDimensions.swift in Sources */,
-				ED144ADCDCD3422BC255FB91365A328E /* MTITextureLoader.m in Sources */,
-				46AE830885D7C4520ED11B4418AFE3C0 /* MTITexturePool.mm in Sources */,
-				2B64207A54CB0958341FA531F4968F8D /* MTIThreadSafeImageView.m in Sources */,
-				9D30A607CD0AEC49D227C7D4E1E84C29 /* MTITransform.m in Sources */,
-				5156A16D10AAE8BA3D835F220079AF84 /* MTITransformFilter.m in Sources */,
-				1FD1656C7673AD4D078E2F5E8146505D /* MTIUnaryImageRenderingFilter.m in Sources */,
-				1948FA7423818BCA9EDC3729827B5E16 /* MTIVector.m in Sources */,
-				3867631C1634FAE24EEE6F5C3BEE5340 /* MTIVector.swift in Sources */,
-				939A572046C16414A3959A30D3D8416C /* MTIVector+SIMD.m in Sources */,
-				20E86D9B075E0A9D84AF4BA891FC5BA5 /* MTIVertex.m in Sources */,
-				7BA03FE3D4F4C8CDD6F21A24CC33AC5B /* MTIVertex.swift in Sources */,
-				DFF6122361103BFA73E0F4F73BD8318C /* MTIVibranceFilter.m in Sources */,
-				A49191B675AC69E53524D8B8B6C6268F /* MTIVideoComposition.swift in Sources */,
-				686249B00AED228CBBF3A38C593DB45D /* MTIWeakToStrongObjectsMapTable.m in Sources */,
-				DEC838BBAE22D3E42B83843CBF383F0C /* MultilayerCompositeShaders.metal in Sources */,
-				6557BD226D6C45867932A8854927EDCB /* MultilayerCompositingFilter.swift in Sources */,
-				7607996271CE1900F6FE5AD17640FD70 /* Shaders.metal in Sources */,
+				245FE5FA7D7DD7B639080073BC18DA83 /* BlendingShaders.metal in Sources */,
+				16DE1A54C75B724849D7E8A4B5185CEB /* CLAHE.metal in Sources */,
+				B7ACDEE348601FA182CC35ADA30B2282 /* ColorConversionShaders.metal in Sources */,
+				CE4A0E4EAB317A1D1C8FCCCCE38E839F /* Filter.swift in Sources */,
+				F5DAA38ED9A3F8A505EA83C3D058F634 /* Halftone.metal in Sources */,
+				6DDD562158F41449FD9056CCE9B41A67 /* HighPassSkinSmoothing.metal in Sources */,
+				B162FDD6F387A6B4ADE1F1D956762FED /* LensBlur.metal in Sources */,
+				D835E073BD53C9F81AEB643A100B0E1F /* MetalPetal.swift in Sources */,
+				063F1A6F923D206B18BA799722A4ECD6 /* MetalPetal-Core-Swift-dummy.m in Sources */,
+				2C26F2DED7CDDBA6B89EC8BD93284F58 /* MTIAlphaPremultiplicationFilter.m in Sources */,
+				BAD5BBE765C104D4A13F9F3B21F5ABD3 /* MTIAlphaType.m in Sources */,
+				BFB08527C2711C9D52C05B6E4A371C10 /* MTIAlphaType.swift in Sources */,
+				B30E704D4DC154A5E9D119247954F7DF /* MTIBlendFilter.m in Sources */,
+				F216BEA93CE966618A45A3A56AF0ACB3 /* MTIBlendFormulaSupport.mm in Sources */,
+				0D4BD6C4DF7B4CF3AC0437E12A7814F8 /* MTIBlendModes.m in Sources */,
+				DD24CC31D2C99E5E6FBDC30B959CF926 /* MTIBlendWithMaskFilter.m in Sources */,
+				9993A1E0147E28BF76960819CE59D638 /* MTIBuffer.m in Sources */,
+				3609F5A7D44F46CA9E388CA2A3520DC8 /* MTIBulgeDistortionFilter.m in Sources */,
+				EE4FE56D37B5A648D86A51971D7CEC63 /* MTIChromaKeyBlendFilter.m in Sources */,
+				26E62FB3A9327FB43DD3894CA2FB9B3B /* MTICLAHEFilter.m in Sources */,
+				118FA4A4D35F7A141EDD57788BBC195F /* MTIColor.m in Sources */,
+				448811A349C784122742575621DAAB91 /* MTIColor.swift in Sources */,
+				BE3D5342F1F5550025EA47482E7AA90A /* MTIColorHalftoneFilter.m in Sources */,
+				9294E8D4490280AABB7E56B72504742E /* MTIColorLookupFilter.m in Sources */,
+				EF8FB30FFFBDB2CB39FD6750C03CFD0A /* MTIColorMatrix.m in Sources */,
+				19E9675F764F36ADD522206CFCEE2926 /* MTIColorMatrix.swift in Sources */,
+				B4D10B7800EE12ACAA67A81261252979 /* MTIColorMatrixFilter.m in Sources */,
+				2C4F6CFC2325E5714C7AD50FF85634D6 /* MTIComputePipeline.m in Sources */,
+				A18C78340359D82080998067659DDB07 /* MTIComputePipelineKernel.m in Sources */,
+				0B99ABB700B1A2C1E4927F77CEB0C056 /* MTIComputePipelineKernel.swift in Sources */,
+				97B17CD6C5A5010F4B2EE8428CEF0DC6 /* MTIContext.m in Sources */,
+				50333D036C0AD11C094FF9A7F8174C6E /* MTIContext.swift in Sources */,
+				BAC9BC8DC4A8F3ABC3A5C3B243217539 /* MTIContext+Rendering.m in Sources */,
+				C52E6B6C0BE7423572018598E6AEB115 /* MTICoreImageExtension.swift in Sources */,
+				D896A8CD8C64B5F35FD6C147076E2C97 /* MTICoreImageRendering.m in Sources */,
+				85D3C231C81E1881953623CF212A6134 /* MTICorner.swift in Sources */,
+				07A619C1778D0121F79B699EF4AA186F /* MTICropFilter.m in Sources */,
+				041FE793D0C8BC9A30CE9B47B6AE9030 /* MTICropRegion.swift in Sources */,
+				FDACB6738965769B38A4651E0E69E9FF /* MTICVMetalIOSurfaceBridge.m in Sources */,
+				6FD6ADC9E3DF2E4B7C7CE20CF802FABB /* MTICVMetalTextureCache.m in Sources */,
+				6CC17FC976274F37E24BDD35EE85591F /* MTICVPixelBufferPool.m in Sources */,
+				9D3BDDCF2161C73B8094883CE714E731 /* MTICVPixelBufferPromise.m in Sources */,
+				E1B044F6D58E25E1116374FA9ACCD865 /* MTICVPixelBufferRendering.m in Sources */,
+				96E98B5638483D4146F02B8FF3EA2520 /* MTIDataBuffer.swift in Sources */,
+				758BF7BE7F54EC92474B48F56C82E0CE /* MTIDefer.m in Sources */,
+				8F6AD56017A454DF1F6E892C3EC63240 /* MTIDotScreenFilter.m in Sources */,
+				C14275823A4E160D7A6AD8E0422DDF05 /* MTIDrawableRendering.m in Sources */,
+				BE57DC171BD79CEEF6A1D3A2DABE06FA /* MTIError.m in Sources */,
+				C0AAD95E5CC8A8B5FFB39689D1378034 /* MTIError.swift in Sources */,
+				8E5A6C0979F07C1A038F493A614E0CF5 /* MTIFilter.m in Sources */,
+				41FC9E8701DB25ACD2C2A0BC83C2154B /* MTIFunctionArgumentsEncoder.m in Sources */,
+				30BE829A942C705C13C4E7A5205B5D23 /* MTIFunctionDescriptor.m in Sources */,
+				161E572D54EF23A8B1CC314ACCA79E44 /* MTIFunctionDescriptor.swift in Sources */,
+				B5AE7E5EAC54C63AF60CE2D6146DC0F6 /* MTIGeometry.m in Sources */,
+				A7A15339B0581DFB41C3010B50C530F2 /* MTIGeometryUtilities.m in Sources */,
+				E33D256C427B8CAC0CA1DCF3FBEB115E /* MTIHexagonalBokehBlurFilter.m in Sources */,
+				E231235E6A0FCECD75C722CD678E1C93 /* MTIHighPassSkinSmoothingFilter.m in Sources */,
+				4EDCEEB8D3564EEB909BF48DCA966339 /* MTIImage.m in Sources */,
+				2649EC58DC80DFF70B4FADA70FE1240B /* MTIImage.swift in Sources */,
+				DD58C718B9C4429A5B7EED0D5F363696 /* MTIImage+Filters.m in Sources */,
+				245763C99C0CF86A8EBC71AE05FE713F /* MTIImageOrientation.m in Sources */,
+				5ADD68A5D87EEB85531B2804BA6ED7A4 /* MTIImagePromise.m in Sources */,
+				03305132F86EBB8DDCA217239DBC267A /* MTIImagePromiseDebug.m in Sources */,
+				CBBC130D51731D71C90329D66BB5421A /* MTIImageProperties.m in Sources */,
+				8650C65789A6BC50C2BD43593B5DA572 /* MTIImageRenderingContext.mm in Sources */,
+				5F3D7333F4E7832785FF5E1FA691ACA6 /* MTIImageView.m in Sources */,
+				C645A6A4DDD922CD60CA223BD18C80C0 /* MTIImageViewProtocol.swift in Sources */,
+				8DD499221203C7E39C07E5DF47AE3045 /* MTILayer.m in Sources */,
+				9B313CE9AF39A480C47FE7A48CF8E776 /* MTILibrarySource.m in Sources */,
+				0EA69462B28F12D66728C72FADBFC317 /* MTILock.m in Sources */,
+				5C3B86B8C66423142005084CADED6ED9 /* MTIMask.m in Sources */,
+				0968F5C611F48AF648768E38C70736AB /* MTIMemoryWarningObserver.m in Sources */,
+				FC75E2F34EED12CD97468984F5183E7C /* MTIMPSBoxBlurFilter.m in Sources */,
+				05D05D673BB26DBB62CE7E7D710B38C5 /* MTIMPSConvolutionFilter.m in Sources */,
+				BC1057E8FD90B96C541999859CBFE95B /* MTIMPSDefinitionFilter.m in Sources */,
+				D22205A56CC33438A714E22AA03725EC /* MTIMPSGaussianBlurFilter.m in Sources */,
+				30E6AF38938075389E245216A5924EBC /* MTIMPSHistogramFilter.m in Sources */,
+				9C0E01A1ADC2A6995C96399FE73B04B0 /* MTIMPSKernel.m in Sources */,
+				4BEC0CBA9F93D859CEA9B9B734D283E9 /* MTIMPSSobelFilter.m in Sources */,
+				B395B1A687997F0A8E7092EBEAF229EA /* MTIMPSUnsharpMaskFilter.m in Sources */,
+				1476BB1C60E4F071865750854430D982 /* MTIMultilayerCompositeKernel.m in Sources */,
+				C0BD444822D5C6E499DF4424C5A35692 /* MTIMultilayerCompositingFilter.m in Sources */,
+				014006CFCFDD8D98911D73A314EFFA25 /* MTIPixelFormat.m in Sources */,
+				BEFA2D3EE29E0656A2724FB9635D0F5F /* MTIPixelFormat.swift in Sources */,
+				39D8628EA10787DA5172F2FC029F14AA /* MTIPixellateFilter.m in Sources */,
+				C40021B1ECC99ADEFED6DCE801DD4721 /* MTIRenderCommand.m in Sources */,
+				AACD66B187AEC5AE6504287A3C63D238 /* MTIRenderGraphOptimization.m in Sources */,
+				8D6858E70D6707C7AA744CFE1D68226F /* MTIRenderPassOutputDescriptor.m in Sources */,
+				3BFB05DA28A98B1871A35D75546ABDFB /* MTIRenderPipeline.m in Sources */,
+				CFF2E13720B329F20147343DCD4719A4 /* MTIRenderPipelineKernel.m in Sources */,
+				44CFAA03249BB9DA8FA543ED9C541674 /* MTIRenderPipelineKernel.swift in Sources */,
+				E7F49BA7838C70B950A9719497BFCC18 /* MTIRenderTask.m in Sources */,
+				446A3321A140CB355FFC1C353BD3EF2E /* MTIRGBColorSpaceConversionFilter.m in Sources */,
+				CA173895D5070144A83EAD93B273D3ED /* MTIRGBColorSpaceConversionFilter.swift in Sources */,
+				81844DA114DA1612BD2C369F7A5E8721 /* MTIRGBToneCurveFilter.m in Sources */,
+				33AD45FC0411FFA4182D04E5758E20D0 /* MTIRoundCornerFilter.m in Sources */,
+				A600519F97F7D39C588D2FF6FA414A4F /* MTISamplerDescriptor.m in Sources */,
+				F99AA2531F9350C1279415B6EE923E3C /* MTISCNSceneRenderer.m in Sources */,
+				716853A0C26608CFEB0E63952F674E26 /* MTISIMDArgumentEncoder.swift in Sources */,
+				20C757107CEB0E667E30E93343E89D61 /* MTISKSceneRenderer.m in Sources */,
+				6122FE1A6F7D77194E7FD355D6E6656A /* MTITextureDescriptor.m in Sources */,
+				FE1BBE9BCEE6AA07C6D7651918C87875 /* MTITextureDimensions.swift in Sources */,
+				B618A49BF8EDC18160836426E4971075 /* MTITextureLoader.m in Sources */,
+				C0D663B2365EDB34F1DB2375E93B8776 /* MTITexturePool.mm in Sources */,
+				7D2F9E944420BA60CDA4D8F1FF66A68A /* MTIThreadSafeImageView.m in Sources */,
+				DF31DE88C4A03CC602C18AD258BB59A9 /* MTITransform.m in Sources */,
+				265C602D6A5078FB18A166EFBC44B6F6 /* MTITransformFilter.m in Sources */,
+				EF8E37C04582E312D50A453AFC5F5F88 /* MTIUnaryImageRenderingFilter.m in Sources */,
+				D13B2F1E81459283505C2A78441AF3F9 /* MTIVector.m in Sources */,
+				10F4ABC5C5B969B92C6D5241F5A51021 /* MTIVector.swift in Sources */,
+				06BC8D5C5111208A01C0F85BE05DCA66 /* MTIVector+SIMD.m in Sources */,
+				81B38A634B811600AE38A2BB8FC5BC23 /* MTIVertex.m in Sources */,
+				AA53B3B53F102D7D5B9F0975EB1E304B /* MTIVertex.swift in Sources */,
+				04B17D1FD7EB0779AB6372AF208D0486 /* MTIVibranceFilter.m in Sources */,
+				A36F2BB9C8393BD24CD8B64FDB1A32B8 /* MTIVideoComposition.swift in Sources */,
+				F56CC52AF8801D399606AC1FC23C565C /* MTIWeakToStrongObjectsMapTable.m in Sources */,
+				30ED9652958E4F99C6C749064FB711DD /* MultilayerCompositeShaders.metal in Sources */,
+				F8A3FB4E7AFC2A5BD4DDB3E4F24B3473 /* MultilayerCompositingFilter.swift in Sources */,
+				FF38195129E2DAA26500903390F2D000 /* Shaders.metal in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F2129F9E510C2147C0D8BA7194F65242 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				61A2FD9CE607E49A50908D3E39E73337 /* BlendingShaders.metal in Sources */,
+				6DF0E060891C5C2881D745549FCAD70A /* CLAHE.metal in Sources */,
+				E0413F7513BD2C875028CD740D45B1B6 /* ColorConversionShaders.metal in Sources */,
+				7686F8144766D837C04BC29C0A850CB4 /* Filter.swift in Sources */,
+				2B517B58B69223F713E5C29C4E195D73 /* Halftone.metal in Sources */,
+				9B4E8C417D0624BE642B3C5E0EAAD975 /* HighPassSkinSmoothing.metal in Sources */,
+				D83BA76BFEB60A4654965224B1DB1B96 /* LensBlur.metal in Sources */,
+				DE8E4583C815706934ADE685B479D867 /* MetalPetal.swift in Sources */,
+				EF48B49D12CC39B7AF41339E95098CB0 /* MetalPetal-AppleSilicon-Core-Swift-dummy.m in Sources */,
+				E77576AD81874E86A656E86FD967B340 /* MTIAlphaPremultiplicationFilter.m in Sources */,
+				DF86564E7650642BF443131ADECDAF75 /* MTIAlphaType.m in Sources */,
+				74BAF6EF9624163EE4A98271F7C0EEB1 /* MTIAlphaType.swift in Sources */,
+				33FC44D39A3C252E6F288A00565CD40B /* MTIBlendFilter.m in Sources */,
+				D396CB4E5B46E5E9CFCD49F5A298B0E1 /* MTIBlendFormulaSupport.mm in Sources */,
+				7A9ED326BCD3C69A7340DD7B0C09659D /* MTIBlendModes.m in Sources */,
+				07FFCFA9266BB74C237466B1925FC75E /* MTIBlendWithMaskFilter.m in Sources */,
+				7E441ADED7E95D02EDA8EA388E670F30 /* MTIBuffer.m in Sources */,
+				94F9DD9B8CCA5B85811575294F49006E /* MTIBulgeDistortionFilter.m in Sources */,
+				248985CBCC0B8D3355F322DA7BCE0CC8 /* MTIChromaKeyBlendFilter.m in Sources */,
+				0799F95A8E0DC24A884B7F17FC0F7D7A /* MTICLAHEFilter.m in Sources */,
+				1155599DF3114E47D2BBC095AB696734 /* MTIColor.m in Sources */,
+				75190E6BFBBD5AC660495C55BE1D0955 /* MTIColor.swift in Sources */,
+				3DA7E2B42D15AE6AEB36650A28998F9B /* MTIColorHalftoneFilter.m in Sources */,
+				E62BC35964F3F3D7638D72D83E9B2629 /* MTIColorLookupFilter.m in Sources */,
+				5B502D0618E62E7E6CCE34C0C7E28FB1 /* MTIColorMatrix.m in Sources */,
+				B660BB0A0498CF4E4E959B5B39E48F24 /* MTIColorMatrix.swift in Sources */,
+				70B94BEC410FA3B380B2A9B3C3C5D06E /* MTIColorMatrixFilter.m in Sources */,
+				3409D5944C9090C49327DC5E305333A8 /* MTIComputePipeline.m in Sources */,
+				51489A5687C3E4C274AFDB54AA1FFEC4 /* MTIComputePipelineKernel.m in Sources */,
+				19DA514A66BA91BCD92E4D9DB9E5B6DC /* MTIComputePipelineKernel.swift in Sources */,
+				92B538EEE791DB9C482183532B202E88 /* MTIContext.m in Sources */,
+				688C8415ED4615227D153B4B74EB20E3 /* MTIContext.swift in Sources */,
+				CCFFD3D23EC65D2A56943A7375456744 /* MTIContext+Rendering.m in Sources */,
+				757F073390244D67918CC0B926AED7A0 /* MTICoreImageExtension.swift in Sources */,
+				B9406A933C26C92F26CB036623454A98 /* MTICoreImageRendering.m in Sources */,
+				AF9FC7C8FF3DB229FE3C5EC386BED6ED /* MTICorner.swift in Sources */,
+				C854054DC78A9366924A931B05FD6153 /* MTICropFilter.m in Sources */,
+				18A55001E60BF594529E4559C157510C /* MTICropRegion.swift in Sources */,
+				2F0E1BD8047D575AB2CC95C353519333 /* MTICVMetalIOSurfaceBridge.m in Sources */,
+				B12409791B21A12977B4B0FBC13836C4 /* MTICVMetalTextureCache.m in Sources */,
+				6F78718C399388204D04AC6CB72437B5 /* MTICVPixelBufferPool.m in Sources */,
+				1A53C6E28652DAA9775AFA37CA77EA19 /* MTICVPixelBufferPromise.m in Sources */,
+				03A604A78E19D95BBE58D3170A0DED4B /* MTICVPixelBufferRendering.m in Sources */,
+				98725DE008B41C7A6C43C45B85AAC8A5 /* MTIDataBuffer.swift in Sources */,
+				DBDC872FA48503C40079DB1093A690CA /* MTIDefer.m in Sources */,
+				F3F7ACD8D921CBDCBB78DA8C8D779C3C /* MTIDotScreenFilter.m in Sources */,
+				813934FAB4F64667726CB86F913C7247 /* MTIDrawableRendering.m in Sources */,
+				581DCB2E2074FE002B424192FDAFAED7 /* MTIError.m in Sources */,
+				E9B369D6DCA0DBACFA59AC5AAC26C740 /* MTIError.swift in Sources */,
+				0369DB0CC9DB687034464E21027D3177 /* MTIFilter.m in Sources */,
+				AB43E317B401DFE5E2CA07827AAB3392 /* MTIFunctionArgumentsEncoder.m in Sources */,
+				830AF6C404384EDA4FF7E960F92A18C3 /* MTIFunctionDescriptor.m in Sources */,
+				6BF28543F1876D2D41F919D29C773688 /* MTIFunctionDescriptor.swift in Sources */,
+				83F9346265E3E3BD0485DB561BBC9A67 /* MTIGeometry.m in Sources */,
+				9F418D003BE792959C13EA97BE705F78 /* MTIGeometryUtilities.m in Sources */,
+				AD01054ACCA7E09FB7D67AEDB3808C3B /* MTIHexagonalBokehBlurFilter.m in Sources */,
+				8A99B7EE7CFFA61D7926C139174A506D /* MTIHighPassSkinSmoothingFilter.m in Sources */,
+				25EF820E5001C851B0DEB57FD633146D /* MTIImage.m in Sources */,
+				FB27ECF71B3D205A42D6204FFEC9AEA8 /* MTIImage.swift in Sources */,
+				A904BF1FCD237F6CE7AE4CFCFB4FD639 /* MTIImage+Filters.m in Sources */,
+				2EDA4CC820A9D263897D3392C8BF2102 /* MTIImageOrientation.m in Sources */,
+				7F1C2AB7602B29FF760CAB9FED75BA08 /* MTIImagePromise.m in Sources */,
+				7F67178E16664724E0A894DCA9EADBA0 /* MTIImagePromiseDebug.m in Sources */,
+				2FEFAEC5862FCBDC6A750725F29C6ABC /* MTIImageProperties.m in Sources */,
+				358D2010899FF5897CF9DD198C85F333 /* MTIImageRenderingContext.mm in Sources */,
+				B4D5152126B2A5FEF2CDBE919B2C568C /* MTIImageView.m in Sources */,
+				76EFEB2CC24D0A47B4239C6CA3750093 /* MTIImageViewProtocol.swift in Sources */,
+				A184BA4046FFC3795AC5D0741DF0FC5A /* MTILayer.m in Sources */,
+				0DBDED79254435922C67C4469B392BF9 /* MTILibrarySource.m in Sources */,
+				F7916F982506937EE689F6E7CFDE482B /* MTILock.m in Sources */,
+				797D59A270BF1FFE7E5D5576F12CAE5A /* MTIMask.m in Sources */,
+				D273C015128948A1E9E4FADB973F44CA /* MTIMemoryWarningObserver.m in Sources */,
+				A67AC3B937DC92EF8F36CD4B671E1715 /* MTIMPSBoxBlurFilter.m in Sources */,
+				8752A26D6B9EB7597F1F063A1B617A48 /* MTIMPSConvolutionFilter.m in Sources */,
+				8EEF0D9CECD56BC2943AF1A27888006F /* MTIMPSDefinitionFilter.m in Sources */,
+				5F03F928D7BE8AAE74E2FD4377436F62 /* MTIMPSGaussianBlurFilter.m in Sources */,
+				E01AFF8F96ABB33BF1C03784C8E5392E /* MTIMPSHistogramFilter.m in Sources */,
+				DB4747C659396F209EE345147D66A583 /* MTIMPSKernel.m in Sources */,
+				8C30616E7DB0A2BDE4C22FD594203806 /* MTIMPSSobelFilter.m in Sources */,
+				28D2B926C78CD346BB36BC8F067C12E2 /* MTIMPSUnsharpMaskFilter.m in Sources */,
+				A8B45C69DC089756F2BA0D47AD6C164F /* MTIMultilayerCompositeKernel.m in Sources */,
+				CC5D98727EBD58E430DA4BBA626271A8 /* MTIMultilayerCompositingFilter.m in Sources */,
+				2BD8587D0E229DCA20ABAAAAF6C89B05 /* MTIPixelFormat.m in Sources */,
+				4CC65151132C527A579CF720C017E019 /* MTIPixelFormat.swift in Sources */,
+				C15239FEE52A06DAB841D1B6FB5F2699 /* MTIPixellateFilter.m in Sources */,
+				60EA8D06752315B341B7E6109E990384 /* MTIRenderCommand.m in Sources */,
+				44BF489DBB53FB3715ADCDD5315406D2 /* MTIRenderGraphOptimization.m in Sources */,
+				627B1254EF1529D4D8CE2F7ED06C092B /* MTIRenderPassOutputDescriptor.m in Sources */,
+				8D2D3D9805B50EC6006F8A0468A17DA5 /* MTIRenderPipeline.m in Sources */,
+				CE9764EC9F77D755ACF803A2A0448006 /* MTIRenderPipelineKernel.m in Sources */,
+				49DD1E9170216EF2325E2876DDC8B165 /* MTIRenderPipelineKernel.swift in Sources */,
+				2D52C61CC68D2FAC3042EEEFE03250AE /* MTIRenderTask.m in Sources */,
+				AB70A30F19371A7C855BEBFD65A3DB32 /* MTIRGBColorSpaceConversionFilter.m in Sources */,
+				961341E7B0469D189E70A94BF05D7DFE /* MTIRGBColorSpaceConversionFilter.swift in Sources */,
+				880F6B6175C316D98F7C78913AF2443A /* MTIRGBToneCurveFilter.m in Sources */,
+				5FD15C2A899F54C75DC834A2D18E0BEA /* MTIRoundCornerFilter.m in Sources */,
+				F14FC22EB6FBC6F545A2560F0028C233 /* MTISamplerDescriptor.m in Sources */,
+				E6893A929C47793B4689CEC1C0C29026 /* MTISCNSceneRenderer.m in Sources */,
+				48B007D0CC222F4AC2E7491785C3D423 /* MTISIMDArgumentEncoder.swift in Sources */,
+				E2FAEB3BFD292E35107F30974BC09A10 /* MTISKSceneRenderer.m in Sources */,
+				3D233807E70AF9AA754B87A6C6983987 /* MTITextureDescriptor.m in Sources */,
+				D690B6AF2234AB165E9B61409074609D /* MTITextureDimensions.swift in Sources */,
+				0E57568947636C90EC298AF9C10478EE /* MTITextureLoader.m in Sources */,
+				A1677E4B27AA7526B0EE37B5488C33F0 /* MTITexturePool.mm in Sources */,
+				DFDB1CD8611A0FA9DEEADBC8A3139447 /* MTIThreadSafeImageView.m in Sources */,
+				76D9A6AD40DF026E8C84C3F31C8A1E5C /* MTITransform.m in Sources */,
+				9A782A36FADEB8B028E406B97744971A /* MTITransformFilter.m in Sources */,
+				0C94FE1E604101D2B01164ECF6D48FFE /* MTIUnaryImageRenderingFilter.m in Sources */,
+				F80FCDA5123E688058527BCBD158D552 /* MTIVector.m in Sources */,
+				3109C58A14168F1B53391139C604A7E7 /* MTIVector.swift in Sources */,
+				1BC25998ECFDAC38CDC45F0E20996476 /* MTIVector+SIMD.m in Sources */,
+				9841CEB8EC0983B4A28C78FDD7B1595B /* MTIVertex.m in Sources */,
+				4B37F0AB9CD162948F37B119DA596712 /* MTIVertex.swift in Sources */,
+				7C5E3E340D624C34B37BF516D0F92A3A /* MTIVibranceFilter.m in Sources */,
+				7D029F7FF262C4E0F6315FFF5A01FE66 /* MTIVideoComposition.swift in Sources */,
+				C3E43706C02EAEA074A2196CFCA3A6E9 /* MTIWeakToStrongObjectsMapTable.m in Sources */,
+				9A19FDFF0109887E6EEA9B5BF0456FF0 /* MultilayerCompositeShaders.metal in Sources */,
+				019FEA72FDAEF4DA137CA0AB7F882E1F /* MultilayerCompositingFilter.swift in Sources */,
+				D7F1D5FD88D0822EF785D0024765C78E /* Shaders.metal in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		B0544A167C3FEB2E499B597FBB05575E /* PBXTargetDependency */ = {
+		08FFF79E72F8B8A6F9B88DB496D549E8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "MetalPetal-AppleSilicon-Core-Swift";
 			target = 45FF391DFF638DC1677EE9B92B249B48 /* MetalPetal-AppleSilicon-Core-Swift */;
-			targetProxy = 9E11E31C254E59A6DD2836BE6A8D04A4 /* PBXContainerItemProxy */;
+			targetProxy = 894DA3B8AD98236DDE10BD877F9FD624 /* PBXContainerItemProxy */;
 		};
-		B1706C1BF123C372EDBD4BEB8169D925 /* PBXTargetDependency */ = {
+		289206C6D9256266F7B72DE3700396F1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "MetalPetal-Core-Swift";
 			target = F6A6D917959D4C48ADF90BBFC7A7F507 /* MetalPetal-Core-Swift */;
-			targetProxy = A0B6CB4F8ECD4DACA8AF0459758741F1 /* PBXContainerItemProxy */;
+			targetProxy = 82A7FA5D3EEF740BCB761ED0CA704326 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1907,7 +1913,7 @@
 			};
 			name = Release;
 		};
-		5090978795722F5E2D87BFA6910DC16D /* Release */ = {
+		4C27A33394CE3778E2D8CDE4DE82352E /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E7DF12693A45897175F60127B439D16A /* MetalPetal-Core-Swift.release.xcconfig */;
 			buildSettings = {
@@ -1942,7 +1948,41 @@
 			};
 			name = Release;
 		};
-		7E7096C6B0A4F09258D97511460ACCC4 /* Release */ = {
+		7DA819368E585AD8ED30889BAD70A758 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2A705843283D25F9B8159D6E0E87B00E /* MetalPetal-Core-Swift.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "Target Support Files/MetalPetal-Core-Swift/MetalPetal-Core-Swift-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/MetalPetal-Core-Swift/MetalPetal-Core-Swift.modulemap";
+				PRODUCT_MODULE_NAME = MetalPetal;
+				PRODUCT_NAME = MetalPetal;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		895E9F05B4BF4C50D22B3ABA0BF2606F /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = FAF57654779509E76735FAB325EC058B /* MetalPetal-AppleSilicon-Core-Swift.release.xcconfig */;
 			buildSettings = {
@@ -1976,41 +2016,6 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
-		};
-		7FEF1355D5A3183C3BCFDA68931F89B4 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 32649AF567A0346EAB8CD35723F6C9F6 /* MetalPetal-AppleSilicon-Core-Swift.debug.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Target Support Files/MetalPetal-AppleSilicon-Core-Swift/MetalPetal-AppleSilicon-Core-Swift-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MODULEMAP_FILE = "Target Support Files/MetalPetal-AppleSilicon-Core-Swift/MetalPetal-AppleSilicon-Core-Swift.modulemap";
-				PRODUCT_MODULE_NAME = MetalPetal;
-				PRODUCT_NAME = MetalPetal;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
 		};
 		92236969D2CAE522F4C49923D0CA0A98 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -2180,6 +2185,41 @@
 			};
 			name = Release;
 		};
+		B61D30EE3169981F25C3CA8C9FA06CC4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 32649AF567A0346EAB8CD35723F6C9F6 /* MetalPetal-AppleSilicon-Core-Swift.debug.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "Target Support Files/MetalPetal-AppleSilicon-Core-Swift/MetalPetal-AppleSilicon-Core-Swift-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MODULEMAP_FILE = "Target Support Files/MetalPetal-AppleSilicon-Core-Swift/MetalPetal-AppleSilicon-Core-Swift.modulemap";
+				PRODUCT_MODULE_NAME = MetalPetal;
+				PRODUCT_NAME = MetalPetal;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
 		BE02FEFC230099892498736384AC5EF7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9BABAE36337C245863DB05281487FB97 /* Pods-MetalPetalExamples-MetalPetalExamples (iOS).debug.xcconfig */;
@@ -2211,40 +2251,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		F8B688FA3FA19B61A56410897A17E1D6 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2A705843283D25F9B8159D6E0E87B00E /* MetalPetal-Core-Swift.debug.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Target Support Files/MetalPetal-Core-Swift/MetalPetal-Core-Swift-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/MetalPetal-Core-Swift/MetalPetal-Core-Swift.modulemap";
-				PRODUCT_MODULE_NAME = MetalPetal;
-				PRODUCT_NAME = MetalPetal;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -2291,6 +2297,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		0E1AE4933E8EE6659B3B6035D6A763F6 /* Build configuration list for PBXNativeTarget "MetalPetal-Core-Swift" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7DA819368E585AD8ED30889BAD70A758 /* Debug */,
+				4C27A33394CE3778E2D8CDE4DE82352E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		459C9056D99075C253DAE7380C4AB581 /* Build configuration list for PBXNativeTarget "Pods-MetalPetalExamples-MetalPetalExamples (iOS)" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -2309,29 +2324,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		4C939637B6E242093DB07A03EEE9AC1E /* Build configuration list for PBXNativeTarget "MetalPetal-AppleSilicon-Core-Swift" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B61D30EE3169981F25C3CA8C9FA06CC4 /* Debug */,
+				895E9F05B4BF4C50D22B3ABA0BF2606F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		609AD00A3FED6B4DC4BEC0EF5C2893C6 /* Build configuration list for PBXNativeTarget "Pods-MetalPetalExamples-MetalPetalExamples (macOS)" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				F8F1D3DA1C8431FCAF7E16DE3AE8E208 /* Debug */,
 				1E2FFA9D5FBF2264412721CC5BDB7ECB /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		7B162AEC40B51F017FAB0CB6600BF2EF /* Build configuration list for PBXNativeTarget "MetalPetal-Core-Swift" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				F8B688FA3FA19B61A56410897A17E1D6 /* Debug */,
-				5090978795722F5E2D87BFA6910DC16D /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		C22633A65204489CF110D9FDB3FC7F3A /* Build configuration list for PBXNativeTarget "MetalPetal-AppleSilicon-Core-Swift" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				7FEF1355D5A3183C3BCFDA68931F89B4 /* Debug */,
-				7E7096C6B0A4F09258D97511460ACCC4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Sources/MetalPetal/MTIRenderPipelineKernel.swift
+++ b/Sources/MetalPetal/MTIRenderPipelineKernel.swift
@@ -1,0 +1,1 @@
+../../Frameworks/MetalPetal/Kernels/MTIRenderPipelineKernel.swift

--- a/Tests/MetalPetalTests/ImageLoadingTests.swift
+++ b/Tests/MetalPetalTests/ImageLoadingTests.swift
@@ -515,8 +515,9 @@ final class TextureLoaderImageLoadingTests: XCTestCase {
             let image = MTIImage(contentsOf: URL(fileURLWithPath: #file)
                                     .deletingLastPathComponent().deletingLastPathComponent()
                                     .appendingPathComponent("Fixture")
-                                    .appendingPathComponent("f\(orientation).png")
-                                 , options: [.SRGB: false], alphaType: .alphaIsOne)
+                                    .appendingPathComponent("f\(orientation).png"),
+                                 options: [.SRGB: false],
+                                 alphaType: .alphaIsOne)
             guard let inputImage = image else {
                 XCTFail()
                 return
@@ -537,8 +538,9 @@ final class TextureLoaderImageLoadingTests: XCTestCase {
             let image = MTIImage(contentsOf: URL(fileURLWithPath: #file)
                                     .deletingLastPathComponent().deletingLastPathComponent()
                                     .appendingPathComponent("Fixture")
-                                    .appendingPathComponent("fgray\(orientation).png")
-                                 , options: [.SRGB: false], alphaType: .alphaIsOne)
+                                    .appendingPathComponent("fgray\(orientation).png"),
+                                 options: [.SRGB: false],
+                                 alphaType: .alphaIsOne)
             guard let inputImage = image else {
                 XCTFail()
                 return
@@ -559,8 +561,9 @@ final class TextureLoaderImageLoadingTests: XCTestCase {
             let image = MTIImage(contentsOf: URL(fileURLWithPath: #file)
                                     .deletingLastPathComponent().deletingLastPathComponent()
                                     .appendingPathComponent("Fixture")
-                                    .appendingPathComponent("fgray\(orientation).png")
-                                 , options: [.SRGB: false, .origin: MTKTextureLoader.Origin.flippedVertically], alphaType: .alphaIsOne)
+                                    .appendingPathComponent("fgray\(orientation).png"),
+                                 options: [.SRGB: false, .origin: MTKTextureLoader.Origin.flippedVertically],
+                                 alphaType: .alphaIsOne)
             guard let inputImage = image else {
                 XCTFail()
                 return
@@ -581,8 +584,9 @@ final class TextureLoaderImageLoadingTests: XCTestCase {
             let image = MTIImage(contentsOf: URL(fileURLWithPath: #file)
                                     .deletingLastPathComponent().deletingLastPathComponent()
                                     .appendingPathComponent("Fixture")
-                                    .appendingPathComponent("fgray\(orientation).png")
-                                 , options: [.SRGB: false, .generateMipmaps: true], alphaType: .alphaIsOne)
+                                    .appendingPathComponent("fgray\(orientation).png"),
+                                 options: [.SRGB: false, .generateMipmaps: true],
+                                 alphaType: .alphaIsOne)
             guard let inputImage = image else {
                 XCTFail()
                 return

--- a/Tests/MetalPetalTests/RenderTests.swift
+++ b/Tests/MetalPetalTests/RenderTests.swift
@@ -1136,7 +1136,7 @@ final class RenderTests: XCTestCase {
         let libraryURL = MTILibrarySourceRegistration.shared.registerLibrary(source: librarySource, compileOptions: nil)
         let renderKernel = MTIRenderPipelineKernel(vertexFunctionDescriptor: .passthroughVertex, fragmentFunctionDescriptor: MTIFunctionDescriptor(name: "testRender", libraryURL: libraryURL))
         let image = MTIImage(color: MTIColor(red: 0, green: 1, blue: 0, alpha: 1), sRGB: false, size: CGSize(width: 1, height: 1))
-        let outputImage = renderKernel.apply(toInputImages: [image], parameters: ["color": MTIVector(value: SIMD4<Float>(1, 0, 0, 0))], outputTextureDimensions: image.dimensions, outputPixelFormat: .unspecified)
+        let outputImage = renderKernel.apply(to: [image], parameters: ["color": MTIVector(value: SIMD4<Float>(1, 0, 0, 0))], outputDimensions: image.dimensions, outputPixelFormat: .unspecified)
         let context = try makeContext()
         let output = try context.makeCGImage(from: outputImage)
         PixelEnumerator.enumeratePixels(in: output) { (pixel, _) in
@@ -1170,7 +1170,7 @@ final class RenderTests: XCTestCase {
         constantValues.setConstantValue(&color, type: .float4, withName: "constColor")
         let renderKernel = MTIRenderPipelineKernel(vertexFunctionDescriptor: .passthroughVertex, fragmentFunctionDescriptor: MTIFunctionDescriptor(name: "testRender", constantValues: constantValues, libraryURL: libraryURL))
         let image = MTIImage(color: MTIColor(red: 0, green: 1, blue: 0, alpha: 1), sRGB: false, size: CGSize(width: 1, height: 1))
-        let outputImage = renderKernel.apply(toInputImages: [image], parameters: [:], outputTextureDimensions: image.dimensions, outputPixelFormat: .unspecified)
+        let outputImage = renderKernel.apply(to: [image], parameters: [:], outputDimensions: image.dimensions, outputPixelFormat: .unspecified)
         let context = try makeContext()
         let output = try context.makeCGImage(from: outputImage)
         PixelEnumerator.enumeratePixels(in: output) { (pixel, _) in
@@ -1961,8 +1961,8 @@ final class RenderTests: XCTestCase {
     
     func testZeroSizeImage_filter_failure() throws {
         let image = MTIImage(color: .white, sRGB: false, size: CGSize(width: 1, height: 1))
-        let intermediate = MTIRenderPipelineKernel.passthrough.apply(toInputImages: [image], parameters: [:], outputTextureDimensions: MTITextureDimensions(width: 1, height: 0, depth: 1), outputPixelFormat: .unspecified)
-        let output = MTIRenderPipelineKernel.passthrough.apply(toInputImages: [intermediate], parameters: [:], outputTextureDimensions: MTITextureDimensions(width: 1, height: 1, depth: 1), outputPixelFormat: .unspecified)
+        let intermediate = MTIRenderPipelineKernel.passthrough.apply(to: [image], parameters: [:], outputDimensions: MTITextureDimensions(width: 1, height: 0, depth: 1), outputPixelFormat: .unspecified)
+        let output = MTIRenderPipelineKernel.passthrough.apply(to: [intermediate], parameters: [:], outputDimensions: MTITextureDimensions(width: 1, height: 1, depth: 1), outputPixelFormat: .unspecified)
         let context = try makeContext()
         do {
             try context.startTask(toRender: output, completion: nil)

--- a/Tests/MetalPetalTests/UtilitiesTests.swift
+++ b/Tests/MetalPetalTests/UtilitiesTests.swift
@@ -80,7 +80,7 @@ final class UtilitiesTests: XCTestCase {
         let libraryURL = MTILibrarySourceRegistration.shared.registerLibrary(source: librarySource, compileOptions: nil)
         let renderKernel = MTIRenderPipelineKernel(vertexFunctionDescriptor: .passthroughVertex, fragmentFunctionDescriptor: MTIFunctionDescriptor(name: "testRender", libraryURL: libraryURL))
         let image = MTIImage(color: MTIColor(red: 0, green: 1, blue: 0, alpha: 1), sRGB: false, size: CGSize(width: 1, height: 1))
-        let outputImage = renderKernel.apply(toInputImages: [image], parameters: ["color": SIMD4<Float>(1, 0, 0, 0)], outputTextureDimensions: image.dimensions, outputPixelFormat: .unspecified)
+        let outputImage = renderKernel.apply(to: [image], parameters: ["color": SIMD4<Float>(1, 0, 0, 0)], outputDimensions: image.dimensions, outputPixelFormat: .unspecified)
         let context = try makeContext()
         let output = try context.makeCGImage(from: outputImage)
         PixelEnumerator.enumeratePixels(in: output) { (pixel, _) in
@@ -110,7 +110,7 @@ final class UtilitiesTests: XCTestCase {
         let libraryURL = MTILibrarySourceRegistration.shared.registerLibrary(source: librarySource, compileOptions: nil)
         let renderKernel = MTIRenderPipelineKernel(vertexFunctionDescriptor: .passthroughVertex, fragmentFunctionDescriptor: MTIFunctionDescriptor(name: "testRender", libraryURL: libraryURL))
         let image = MTIImage(color: MTIColor(red: 0, green: 1, blue: 0, alpha: 1), sRGB: false, size: CGSize(width: 1, height: 1))
-        let outputImage = renderKernel.apply(toInputImages: [image], parameters: ["color": float2x2(rows: [SIMD2<Float>(1,0),SIMD2<Float>(1,0)])], outputTextureDimensions: image.dimensions, outputPixelFormat: .unspecified)
+        let outputImage = renderKernel.apply(to: [image], parameters: ["color": float2x2(rows: [SIMD2<Float>(1,0),SIMD2<Float>(1,0)])], outputDimensions: image.dimensions, outputPixelFormat: .unspecified)
         let context = try makeContext()
         let output = try context.makeCGImage(from: outputImage)
         PixelEnumerator.enumeratePixels(in: output) { (pixel, _) in
@@ -144,7 +144,7 @@ final class UtilitiesTests: XCTestCase {
         let libraryURL = MTILibrarySourceRegistration.shared.registerLibrary(source: librarySource, compileOptions: nil)
         let renderKernel = MTIRenderPipelineKernel(vertexFunctionDescriptor: .passthroughVertex, fragmentFunctionDescriptor: MTIFunctionDescriptor(name: "testRender", libraryURL: libraryURL))
         let image = MTIImage(color: MTIColor(red: 0, green: 1, blue: 0, alpha: 1), sRGB: false, size: CGSize(width: 1, height: 1))
-        let outputImage = renderKernel.apply(toInputImages: [image], parameters: ["color": SIMD4<UInt8>(128, 0, 0, 0)], outputTextureDimensions: image.dimensions, outputPixelFormat: .unspecified)
+        let outputImage = renderKernel.apply(to: [image], parameters: ["color": SIMD4<UInt8>(128, 0, 0, 0)], outputDimensions: image.dimensions, outputPixelFormat: .unspecified)
         let context = try makeContext()
         let output = try context.makeCGImage(from: outputImage)
         PixelEnumerator.enumeratePixels(in: output) { (pixel, _) in
@@ -251,7 +251,7 @@ final class UtilitiesTests: XCTestCase {
         let libraryURL = MTILibrarySourceRegistration.shared.registerLibrary(source: librarySource, compileOptions: nil)
         let renderKernel = MTIRenderPipelineKernel(vertexFunctionDescriptor: .passthroughVertex, fragmentFunctionDescriptor: MTIFunctionDescriptor(name: "testRender", libraryURL: libraryURL))
         let image = MTIImage(color: MTIColor(red: 0, green: 1, blue: 0, alpha: 1), sRGB: false, size: CGSize(width: 1, height: 1))
-        let outputImage = renderKernel.apply(toInputImages: [image], parameters: ["color": SIMD4<Int32>(128, 0, 0, 0)], outputTextureDimensions: image.dimensions, outputPixelFormat: .unspecified)
+        let outputImage = renderKernel.apply(to: [image], parameters: ["color": SIMD4<Int32>(128, 0, 0, 0)], outputDimensions: image.dimensions, outputPixelFormat: .unspecified)
         let context = try makeContext()
         let output = try context.makeCGImage(from: outputImage)
         PixelEnumerator.enumeratePixels(in: output) { (pixel, _) in


### PR DESCRIPTION
### Rename:

- Rename `MTIRenderPipelineKernel.apply(toInputImages:parameters:outputTextureDimensions:outputPixelFormat:)` to `MTIRenderPipelineKernel.apply(to:outputDimensions:outputPixelFormat:)`

- Rename `MTIRenderPipelineKernel.apply(toInputImages:parameters:outputDescriptors:)` to `MTIRenderPipelineKernel.apply(to:parameters:outputDescriptors:)`

### Convenience Methods

- Add `MTIRenderPipelineKernel.makeImage(...)`, `MTIRenderPipelineKernel.apply(to:...)`.

- Add `Array<MTIRenderCommand>.makeImage(...)` and `Array<MTIRenderCommand>.makeImages(...)`.